### PR TITLE
[codex] Clarify public entry points

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ url: "https://github.com/Snseam/awesome-agent-memory"
 abstract: >-
   A curated, decision-driven reading list and living survey of research on
   long-term memory for LLM agents. Indexes 989 unique papers from 9
-  cross-referenced sibling awesome-lists, with 529 locally archived PDFs and
+  cross-referenced sibling awesome-lists, with 534 locally archived PDFs and
   deep notes mapped to a generic agent-memory-kernel module taxonomy.
   Maintained as the public knowledge base for the Ymem agent memory kernel.
 keywords:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,37 +1,49 @@
 # Contributing
 
-Thanks for taking an interest in ZhiOne.
+Thanks for taking an interest in awesome-agent-memory.
 
-The project is early. The highest-value contributions are precise product and
-architecture improvements, small prototypes, and testable definitions of memory
-behavior.
+This repository is a decision-driven reading list, living survey, and research
+radar for long-term memory in LLM agents. The highest-value contributions make
+the evidence base clearer, more auditable, and easier to use for memory-kernel
+decisions.
 
 ## Before Opening A PR
 
-- Check the README and roadmap for current scope.
+- Check the README and `docs/README.md` for current scope.
 - Keep changes small and focused.
-- Prefer updating canonical docs over adding another long working note.
-- Do not add new dependencies without explaining why they are necessary.
+- Prefer updating canonical docs or existing notes over adding another long
+  working note.
+- Do not add new dependencies or automation without explaining why they are
+  necessary.
 - Do not commit private data, credentials, proprietary source, or unreviewed raw
   conversation logs.
+- Do not add PDFs unless the source permits redistribution; keep the canonical
+  URL in the corresponding note.
 
 ## Good First Contributions
 
-- Clarify MVP acceptance criteria.
-- Propose memory operation contracts.
-- Add evaluation fixtures for duplicate or stale context.
-- Improve documentation structure.
+- Upgrade an existing `papers/stubs/` entry into a `papers/` full note after
+  reading the source paper.
+- Add or refresh a product note in `products/` and, when appropriate, a
+  markdown snapshot in `products/archives/`.
+- Improve `docs/information-sources.md`, `docs/related-work.md`, or
+  `docs/products-landscape.md` with sourced entries.
+- Draft an `impact-reports/` entry for a full note that materially affects
+  memory-kernel architecture.
 - Identify privacy, provenance, or auditability risks.
 
-## Development Expectations
+## Note Expectations
 
-When implementation begins:
+Full paper and product notes should preserve the ResearchItem shape described in
+`docs/research-radar.md`:
 
-- add focused tests with behavior changes;
-- keep public APIs explicit;
-- include SPDX license identifiers in source files where practical;
-- document storage formats and migration risks;
-- make local-first behavior the default.
+- include title, source, date, domain, core claim, method summary, assumptions,
+  benchmarks, evidence level, code/license status, and cost/complexity;
+- map the note to one or more memory modules from `docs/taxonomy.md` or, for
+  Ymem-specific metadata, `docs/ymem-binding/taxonomy-modules.md`;
+- separate direct evidence from maintainer inference;
+- keep unverified claims marked as `check`, `seed`, or follow-up work instead of
+  presenting them as settled.
 
 ## Commit Messages
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Papers](https://img.shields.io/badge/papers-989-brightgreen.svg)](papers/index.md)
-[![PDFs](https://img.shields.io/badge/local_PDFs-529-orange.svg)](papers/pdfs/)
+[![PDFs](https://img.shields.io/badge/local_PDFs-534-orange.svg)](papers/pdfs/)
 [![Products](https://img.shields.io/badge/products-10-purple.svg)](products/)
 [![Surveys](https://img.shields.io/badge/meta_surveys-6-yellow.svg)](docs/meta-surveys.md)
 [![Updated](https://img.shields.io/badge/updated-2026--05-lightgrey.svg)](docs/signals.md)
@@ -35,21 +35,23 @@ or consolidates** information.
 ## Table of contents
 
 1. [At a glance](#at-a-glance)
-2. [Repository layout](#repository-layout)
-3. [How the loop works](#how-the-loop-works)
-4. [Stub vs full notes](#stub-vs-full-notes)
-5. [Adding an entry](#adding-an-entry)
-6. [License / archival policy](#license--archival-policy)
-7. [Origin / maintenance](#origin--maintenance)
+2. [Read first](#read-first)
+3. [Repository layout](#repository-layout)
+4. [How the loop works](#how-the-loop-works)
+5. [Note status](#note-status)
+6. [Adding an entry](#adding-an-entry)
+7. [License / archival policy](#license--archival-policy)
+8. [Origin / maintenance](#origin--maintenance)
 
 ## At a glance
 
 ```text
 989 unique papers   ← scraped from 9 sibling awesome-lists, deduped
-529 local PDFs      ← arXiv open-license, gated by (>=2 cross-list refs) OR (year=2026) OR (has GitHub link)
+988 paper stubs     ← auto-generated cross-list coverage under papers/stubs/
+534 local PDFs      ← open-redistribution sources, gated by signal / year / code link
  10 product notes   ← Mem0, Letta, Zep, Graphiti, Cognee, LangMem, ...
   9 archive pages   ← markdown snapshots for auditability
-  7 deep notes      ← full ResearchItem template, grounded in PDFs read
+  7 full paper notes + 2 seed paper notes
   6 meta-surveys    ← 2025-12 ~ 2026-05 indexed in docs/meta-surveys.md
   1 living survey   ← docs/agent-memory-survey.md
 ```
@@ -62,15 +64,27 @@ or consolidates** information.
 [MIRIX](papers/stubs/mirix-multi-agent-memory-system-for-llm-based-agents.md) ·
 [O-Mem](papers/stubs/o-mem-omni-memory-system-for-personalized-long-horizon-self.md)
 
+## Read first
+
+If this is your first visit, use these entry points in order:
+
+1. [`docs/README.md`](docs/README.md) — map of the documentation set.
+2. [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) — the living survey and current maintainer synthesis.
+3. [`docs/taxonomy.md`](docs/taxonomy.md) — the shared vocabulary for forms, functions, dynamics, persistence, and curation.
+4. [`papers/index.md`](papers/index.md) — the 989-paper cross-list index, sorted by maturity signals.
+5. [`docs/products-landscape.md`](docs/products-landscape.md) — product notes grouped by domain and audience.
+
 ## Repository layout
 
 ### Concept files (top level)
 
-All concept docs now live under [`docs/`](docs/).
+All concept docs now live under [`docs/`](docs/). Start with
+[`docs/README.md`](docs/README.md) if you want the shortest map.
 
 | File | Purpose |
 |---|---|
-| [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) | A living literature review by the maintainer. Read first. |
+| [`docs/README.md`](docs/README.md) | Documentation map: what to read first and where each concept lives. |
+| [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) | A living literature review by the maintainer. |
 | [`docs/meta-surveys.md`](docs/meta-surveys.md) | Index of **external** meta-surveys (2025-12 ~ 2026-05). |
 | [`docs/taxonomy.md`](docs/taxonomy.md) | Generic agent-memory taxonomy: cross-walk of 3 external frameworks. |
 | [`docs/research-radar.md`](docs/research-radar.md) | Generic Radar workflow: Paper → ResearchItem → ImpactReport → sandbox → ADR. |
@@ -83,9 +97,9 @@ All concept docs now live under [`docs/`](docs/).
 
 | Path | Contents |
 |---|---|
-| [`papers/`](papers/) | 9 deep notes + master [`index.md`](papers/index.md). |
-| [`papers/stubs/`](papers/stubs/) | ~988 auto-generated stubs (cross-list scrape output). |
-| [`papers/pdfs/`](papers/pdfs/) | 529 archived PDFs (~1.8 GB). See archival policy. |
+| [`papers/`](papers/) | 7 full paper notes, 2 seed notes, and master [`index.md`](papers/index.md). |
+| [`papers/stubs/`](papers/stubs/) | 988 auto-generated stubs (cross-list scrape output). |
+| [`papers/pdfs/`](papers/pdfs/) | 534 archived PDFs (~1.8 GB). See archival policy. |
 | [`papers/_scrape/`](papers/_scrape/) | Reproducibility artifacts: scrape script + dedup JSON. |
 | [`products/`](products/) | 10 product notes (Mem0, Letta, Zep, Graphiti, …). |
 | [`products/archives/`](products/archives/) | Markdown snapshots of canonical product pages. |
@@ -100,7 +114,7 @@ ResearchItem note (papers/ or products/)
     ↓
 classification against docs/taxonomy.md
     ↓
-ArchitectureImpactReport
+ArchitectureImpactReport (impact-reports/)
     ↓
 sandbox experiment (in your kernel repo)
     ↓
@@ -114,7 +128,7 @@ understanding; the per-item notes are the raw material; the impact reports
 are how candidates are evaluated; the ADR (in your kernel repo) is where
 decisions are recorded.
 
-## Stub vs full notes
+## Note status
 
 Most paper notes are **stubs**: just enough frontmatter (title, arXiv ID,
 year, source list, optional local PDF link, `status: stub`) plus a one-line
@@ -123,6 +137,15 @@ context snippet, generated from the cross-list scrape. They exist so that:
 1. The Radar has 100% coverage of what the 9 sibling lists track.
 2. Cross-list reference count gives a *maturity* signal for which stubs to
    upgrade first.
+
+Status labels:
+
+| Status | Meaning |
+|---|---|
+| `stub` | Auto-generated or lightly generated coverage entry. Useful for discovery, not for architectural claims. |
+| `seed` | Human-started note with enough structure to track, but still missing a full read or complete evidence pass. |
+| `full` | Human-read ResearchItem with the seven-section template and memory-module mapping. |
+| `working-notes` | Exploratory product or essay notes that are intentionally not yet normalized as a full ResearchItem. |
 
 A stub becomes a **full** note when a human reads the paper and fills the
 seven-section template:
@@ -137,7 +160,7 @@ seven-section template:
 7. 待跟进             Follow-ups
 ```
 
-**Only full notes can be cited in an ArchitectureImpactReport.**
+**Only full notes should be cited as evidence in an ArchitectureImpactReport.**
 
 ## Adding an entry
 
@@ -176,13 +199,12 @@ header.
 
 ## Origin / maintenance
 
-This repo was started and is maintained by the
-[**Ymem**](https://github.com/Snseam/Ymem) project (an agent memory
-kernel). Project-specific bindings — module names referenced in note
-frontmatter, the maintainer's stance on individual papers, internal
-benchmark choices — live in [`docs/ymem-binding/`](docs/ymem-binding/) so
-that the top-level files stay product-neutral. If you don't use Ymem you
-can simply ignore that subdirectory.
+This repo was started by the
+[**Ymem**](https://github.com/Snseam/Ymem) project, but the top-level
+documentation is intended to stay useful for any agent-memory kernel. Ymem
+specific bindings — module names, maintainer stance, and internal benchmark
+choices — live in [`docs/ymem-binding/`](docs/ymem-binding/) so the public
+entry points remain product-neutral.
 
 ---
 
@@ -193,6 +215,7 @@ can simply ignore that subdirectory.
 <div align="center">
 
 **[Survey](docs/agent-memory-survey.md)** ·
+**[Docs map](docs/README.md)** ·
 **[Papers index](papers/index.md)** ·
 **[Products landscape](docs/products-landscape.md)** ·
 **[Signals](docs/signals.md)** ·

--- a/README_cn.md
+++ b/README_cn.md
@@ -8,7 +8,7 @@
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Papers](https://img.shields.io/badge/papers-989-brightgreen.svg)](papers/index.md)
-[![PDFs](https://img.shields.io/badge/local_PDFs-529-orange.svg)](papers/pdfs/)
+[![PDFs](https://img.shields.io/badge/local_PDFs-534-orange.svg)](papers/pdfs/)
 [![Products](https://img.shields.io/badge/products-10-purple.svg)](products/)
 [![Surveys](https://img.shields.io/badge/meta_surveys-6-yellow.svg)](docs/meta-surveys.md)
 [![Updated](https://img.shields.io/badge/updated-2026--05-lightgrey.svg)](docs/signals.md)
@@ -34,22 +34,24 @@ agent 如何**记忆、遗忘、检索、整合**信息。
 ## 目录
 
 1. [一眼总览](#一眼总览)
-2. [仓库结构](#仓库结构)
-3. [工作流](#工作流)
-4. [Stub 与 Full 笔记](#stub-与-full-笔记)
-5. [新增 full 笔记的字段要求](#新增-full-笔记的字段要求)
-6. [License 与存档策略](#license-与存档策略)
-7. [发起方与维护](#发起方与维护)
-8. [贡献](#贡献)
+2. [先读这里](#先读这里)
+3. [仓库结构](#仓库结构)
+4. [工作流](#工作流)
+5. [笔记状态](#笔记状态)
+6. [新增 full 笔记的字段要求](#新增-full-笔记的字段要求)
+7. [License 与存档策略](#license-与存档策略)
+8. [发起方与维护](#发起方与维护)
+9. [贡献](#贡献)
 
 ## 一眼总览
 
 ```text
 989 篇唯一论文     ← 9 个同生态 awesome-list 抓取去重
-529 个本地 PDF     ← arXiv 开放协议;跨仓引用 ≥2 或 2026 新作 或 有 GitHub 链接 才入库
+988 个论文 stub    ← papers/stubs/ 下的自动生成跨仓覆盖
+534 个本地 PDF     ← 开放再分发来源;按信号 / 年份 / 代码链接筛选入库
  10 个产品笔记     ← Mem0、Letta、Zep、Graphiti、Cognee、LangMem、…
   9 个页面快照     ← markdown 形式,便于审计
-  7 个深读笔记     ← 七节模板,基于实际读过的 PDF
+  7 个 full 论文笔记 + 2 个 seed 论文笔记
   6 个 meta-survey ← 2025-12 ~ 2026-05,见 docs/meta-surveys.md
   1 份活综述       ← docs/agent-memory-survey.md
 ```
@@ -62,15 +64,27 @@ agent 如何**记忆、遗忘、检索、整合**信息。
 [MIRIX](papers/stubs/mirix-multi-agent-memory-system-for-llm-based-agents.md) ·
 [O-Mem](papers/stubs/o-mem-omni-memory-system-for-personalized-long-horizon-self.md)
 
+## 先读这里
+
+第一次打开本仓,建议按这个顺序读:
+
+1. [`docs/README.md`](docs/README.md) —— 文档地图,快速判断每份文档负责什么。
+2. [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) —— 活综述与当前维护者综合判断。
+3. [`docs/taxonomy.md`](docs/taxonomy.md) —— forms / functions / dynamics / persistence / curation 的共享词表。
+4. [`papers/index.md`](papers/index.md) —— 989 篇跨仓论文索引,按成熟度信号排序。
+5. [`docs/products-landscape.md`](docs/products-landscape.md) —— 按领域和服务对象整理的产品全景。
+
 ## 仓库结构
 
 ### 顶层概念文档
 
-所有概念文档现已收纳到 [`docs/`](docs/) 子目录。
+所有概念文档现已收纳到 [`docs/`](docs/) 子目录。如果只想先看地图,从
+[`docs/README.md`](docs/README.md) 开始。
 
 | 文件 | 用途 |
 |---|---|
-| [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) | 维护者的活综述。首选入口。 |
+| [`docs/README.md`](docs/README.md) | 文档地图:先读什么、每份概念文档放在哪里。 |
+| [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) | 维护者的活综述。 |
 | [`docs/meta-surveys.md`](docs/meta-surveys.md) | **外部** meta-survey 索引(2025-12 ~ 2026-05)。 |
 | [`docs/taxonomy.md`](docs/taxonomy.md) | 通用 agent memory taxonomy:三套外部分类轴对照。 |
 | [`docs/research-radar.md`](docs/research-radar.md) | 通用 Radar workflow:论文 → ResearchItem → ImpactReport → 沙盒 → ADR。 |
@@ -83,9 +97,9 @@ agent 如何**记忆、遗忘、检索、整合**信息。
 
 | 路径 | 内容 |
 |---|---|
-| [`papers/`](papers/) | 9 篇深读笔记 + 主索引 [`index.md`](papers/index.md)。 |
-| [`papers/stubs/`](papers/stubs/) | ~988 个自动生成的 stub(跨仓抓取产物)。 |
-| [`papers/pdfs/`](papers/pdfs/) | 529 个本地 PDF(~1.8 GB)。详见存档策略。 |
+| [`papers/`](papers/) | 7 个 full 论文笔记、2 个 seed 笔记 + 主索引 [`index.md`](papers/index.md)。 |
+| [`papers/stubs/`](papers/stubs/) | 988 个自动生成的 stub(跨仓抓取产物)。 |
+| [`papers/pdfs/`](papers/pdfs/) | 534 个本地 PDF(~1.8 GB)。详见存档策略。 |
 | [`papers/_scrape/`](papers/_scrape/) | 可复现产物:抓取脚本 + dedup JSON。 |
 | [`products/`](products/) | 10 个产品笔记。 |
 | [`products/archives/`](products/archives/) | 产品页面的 markdown 快照。 |
@@ -100,7 +114,7 @@ ResearchItem 笔记(papers/ 或 products/)
     ↓
 对照 docs/taxonomy.md 归类
     ↓
-ArchitectureImpactReport
+ArchitectureImpactReport (impact-reports/)
     ↓
 沙盒实验(在你自己的 kernel 仓内)
     ↓
@@ -112,7 +126,7 @@ ADR(在你自己的 kernel 仓内)
 外部 survey 索引和活综述反映当前理解面;逐条笔记是原材料;ImpactReport
 是评估通道;最终 ADR(在你的 kernel 仓)记录决策。
 
-## Stub 与 Full 笔记
+## 笔记状态
 
 大多数论文笔记是 **stub**:只有 frontmatter(标题、arXiv ID、年份、source 仓
 列表、可选本地 PDF 链接、`status: stub`)加一行上下文,由跨仓抓取自动产出。
@@ -120,6 +134,15 @@ ADR(在你自己的 kernel 仓内)
 
 1. 让 Radar 对 9 个同生态 list 追踪的内容做到 100% 覆盖;
 2. 跨仓引用次数提供"成熟度"信号,告诉我们 stub 升级的优先级。
+
+状态含义:
+
+| Status | 含义 |
+|---|---|
+| `stub` | 自动生成或轻量生成的覆盖条目。适合发现线索,不适合直接作为架构判断依据。 |
+| `seed` | 人工开始整理的笔记,结构已经建立,但还没有完成全文精读或证据补齐。 |
+| `full` | 已完成七节 ResearchItem 模板和 memory-module 映射的人工深读笔记。 |
+| `working-notes` | 产品或文章的探索性记录,暂时不强行规范成 full ResearchItem。 |
 
 stub 在有人通读论文后填完七节模板,升级为 **full** 笔记:
 
@@ -133,7 +156,7 @@ stub 在有人通读论文后填完七节模板,升级为 **full** 笔记:
 7. 待跟进
 ```
 
-**只有 full 笔记可以在 ArchitectureImpactReport 中被引用。**
+**只有 full 笔记应该作为证据写进 ArchitectureImpactReport。**
 
 ## 新增 full 笔记的字段要求
 
@@ -164,10 +187,9 @@ arXiv perpetual non-exclusive license、ACL Anthology 的 CC-BY、OpenReview
 ## 发起方与维护
 
 本仓由 [**Ymem**](https://github.com/Snseam/Ymem)(一个 agent memory
-kernel)项目发起和维护。**项目特定绑定** —— 笔记 frontmatter 引用的模块
-名、维护者对单篇论文的具体立场、内部 benchmark 选择 —— 都收纳到
-[`docs/ymem-binding/`](docs/ymem-binding/) 子目录,以确保顶层文档对外完全
-中性。如果你不维护 Ymem 可以忽略该子目录。
+kernel)项目发起,但顶层文档应当对任何 agent-memory kernel 都有用。
+**Ymem 特定绑定** —— 模块名、维护者立场、内部 benchmark 选择 —— 收纳到
+[`docs/ymem-binding/`](docs/ymem-binding/) 子目录,以确保公开入口保持产品中性。
 
 ## 与中文同行的关系
 
@@ -196,6 +218,7 @@ kernel)项目发起和维护。**项目特定绑定** —— 笔记 frontmatter 
 <div align="center">
 
 **[活综述](docs/agent-memory-survey.md)** ·
+**[文档地图](docs/README.md)** ·
 **[Papers 索引](papers/index.md)** ·
 **[产品全景](docs/products-landscape.md)** ·
 **[信号日志](docs/signals.md)** ·

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,44 @@
+# Documentation map
+
+This directory contains the concept layer for awesome-agent-memory. Use it to
+decide what to read before opening the 989-paper index or the product notes.
+
+## Read first
+
+1. [`agent-memory-survey.md`](agent-memory-survey.md) — living maintainer survey
+   and the current synthesis of the field.
+2. [`taxonomy.md`](taxonomy.md) — shared vocabulary for classifying agent memory
+   systems and papers.
+3. [`research-radar.md`](research-radar.md) — workflow for turning papers and
+   products into ResearchItems, ImpactReports, experiments, and ADRs.
+4. [`products-landscape.md`](products-landscape.md) — product map by domain and
+   audience.
+
+## Concept docs
+
+| File | Purpose |
+|---|---|
+| [`agent-memory-survey.md`](agent-memory-survey.md) | Living survey for memory architectures, retrieval, consolidation, forgetting, and evaluation. |
+| [`taxonomy.md`](taxonomy.md) | Cross-walk of external taxonomies and common memory-kernel responsibilities. |
+| [`meta-surveys.md`](meta-surveys.md) | External survey index from late 2025 through 2026 H1. |
+| [`signals.md`](signals.md) | Reverse-chronological release, comparison, and blog signal log. |
+
+## Research workflow
+
+| File | Purpose |
+|---|---|
+| [`research-radar.md`](research-radar.md) | Generic Radar loop: paper/product -> ResearchItem -> ImpactReport -> sandbox -> ADR. |
+| [`information-sources.md`](information-sources.md) | Source catalog for papers, products, communities, and zh-CN information channels. |
+| [`related-work.md`](related-work.md) | Positioning against sibling agent-memory awesome-lists. |
+
+## Product and project bindings
+
+| File | Purpose |
+|---|---|
+| [`products-landscape.md`](products-landscape.md) | Agent-memory products grouped by domain and buyer/audience. |
+| [`ymem-binding/README.md`](ymem-binding/README.md) | Ymem-specific module names, stance, and radar bindings. Safe to skip if you only need the generic reading list. |
+
+The detailed paper index lives outside this directory at
+[`../papers/index.md`](../papers/index.md). Product notes live under
+[`../products/`](../products/), with archived source-page snapshots in
+[`../products/archives/`](../products/archives/).

--- a/docs/agent-memory-survey.md
+++ b/docs/agent-memory-survey.md
@@ -145,7 +145,8 @@ verbs。
 每次更新本综述时:
 
 1. 在 `papers/` 或 `products/` 新增/更新对应笔记;
-2. 如果对你 kernel 有结构性影响,起一份 `impact-reports/<slug>.md`;
+2. 如果对你 kernel 有结构性影响,在 [`../impact-reports/`](../impact-reports/)
+   起一份 ImpactReport;
 3. 回到本文档,更新相关章节,标记新的 last_revised 日期。
 
 ---

--- a/docs/research-radar.md
+++ b/docs/research-radar.md
@@ -77,7 +77,7 @@ ResearchItem
 ## 5. ArchitectureImpactReport
 
 候选改进进入沙盒实验前,需要写一份 impact report,放在
-`impact-reports/<short-slug>.md`:
+[`../impact-reports/`](../impact-reports/) 目录下:
 
 ```text
 ImpactReport

--- a/docs/ymem-binding/README.md
+++ b/docs/ymem-binding/README.md
@@ -66,6 +66,6 @@ ymem-binding/
 | Repo | 角色 | 与本目录的接口 |
 |---|---|---|
 | [Ymem](https://github.com/Snseam/Ymem) | agent 记忆 kernel | 消费本仓 deep notes 的"决策相关性"小节;`taxonomy-modules.md` 在 Ymem 主仓 ADR 里被反向 cite |
-| [ZhiOne](https://github.com/Snseam/zhione) | 首个基于 Ymem 的 host app | 只关心 Ymem 的 API,不直接消费本仓 |
+| Ymem host apps | 基于 Ymem 的产品层 | 只关心 Ymem 的 API,不直接消费本仓 |
 
-ZhiOne 不直接读 awesome-agent-memory;它通过 Ymem 间接受益于这里整理的研究。
+Host apps 不直接读 awesome-agent-memory;它们通过 Ymem 间接受益于这里整理的研究。

--- a/docs/ymem-binding/relevance-index.md
+++ b/docs/ymem-binding/relevance-index.md
@@ -79,7 +79,7 @@ memory_modules:
 
 (从根 [`../products-landscape.md`](../products-landscape.md) v0.2 §C 抽出。)
 
-Ymem **不是产品**,是给 host-app(如 ZhiOne)用的 memory kernel。它最直接
+Ymem **不是产品**,是给 host-app 用的 memory kernel。它最直接
 对照根 landscape A1 中的 **Mem0 OSS / Letta / Graphiti** —— 这三者都把自己
 定位为"被 host 嵌入"。
 

--- a/docs/ymem-binding/research-radar.md
+++ b/docs/ymem-binding/research-radar.md
@@ -5,11 +5,11 @@ revised: 2026-05-19
 status: working-spec
 language: zh-CN
 origin: |
-  Originally drafted as §12 of zhione/docs/design/context-evolution-2026-05-08.md
-  when the Radar was scoped as a ZhiOne v1+ feature. On 2026-05-18 the Radar
-  was promoted to an independent repository, awesome-agent-memory, so that
-  algorithm iteration (in Ymem) and product iteration (in zhione) can both
-  consume from a shared, public knowledge base.
+  Originally drafted as part of an internal host-app design note when the Radar
+  was scoped as a host-app v1+ feature. On 2026-05-18 the Radar was promoted to
+  an independent repository, awesome-agent-memory, so that algorithm iteration
+  in Ymem and product iteration in host apps can both consume from a shared,
+  public knowledge base.
   On 2026-05-19 the generic Radar workflow moved to the root-level
   `research-radar.md`; this file is the Ymem-specific binding.
 ---
@@ -26,7 +26,7 @@ ResearchItem、ImpactReport 和实验提案。
 
 具体输出路径:
 - ResearchItem → `papers/<slug>.md` 或 `products/<slug>.md`(本仓)
-- ImpactReport → `impact-reports/<slug>.md`(本仓)
+- ImpactReport → [`../../impact-reports/`](../../impact-reports/)(本仓)
 - 沙盒实验 → 在 [Ymem](https://github.com/Snseam/Ymem) 仓内,见其
   `experiments/`(暂未公开)
 - ADR → 在 Ymem 仓内,见其 `docs/adr/`(暂未公开)
@@ -133,10 +133,10 @@ v2:
 > Ymem 不只管理记忆,也管理记忆系统自己的进化 —— 而 awesome-agent-memory
 > 是这套进化机制的输入面。
 
-## 7. 与 ZhiOne(host app)的契约
+## 7. 与 host app 的契约
 
 - host-side 模块(`context-packer`、`publisher`、`interface`、`audit-ui` ——
-  见 [`taxonomy-modules.md`](taxonomy-modules.md))由 ZhiOne 负责实现;
+  见 [`taxonomy-modules.md`](taxonomy-modules.md))由 host app 负责实现;
   Radar 仍追踪这些模块的研究,但 ImpactReport 应标注 `affected_modules` 是
   kernel-side 还是 host-side,避免把 host 侧改造硬推进 Ymem。
-- ZhiOne 不直接消费本仓;它通过 Ymem 的 API 间接获益。
+- Host app 不直接消费本仓;它通过 Ymem 的 API 间接获益。

--- a/docs/ymem-binding/survey-stance.md
+++ b/docs/ymem-binding/survey-stance.md
@@ -76,8 +76,7 @@ David Soria Parra 的 MCP 分享对 Ymem API 的启示:不要暴露
   lifecycle。
 - **不是 long-context inference 加速**:Ymem 假设 LLM 上下文有限;长上下文
   是另一条产品线。
-- **不是 agent runtime**:Ymem 只管记忆,不管 agent loop。host app
-  (ZhiOne)负责。
+- **不是 agent runtime**:Ymem 只管记忆,不管 agent loop。host app 负责。
 - **不是 vector DB**:vector store 是 substrate;Ymem 复用它们而不取代。
 - **不是 persona / 个性化 prompt 框架**:persona ≠ memory。
 

--- a/docs/ymem-binding/taxonomy-modules.md
+++ b/docs/ymem-binding/taxonomy-modules.md
@@ -59,7 +59,7 @@ ImpactReport 必须使用本文档列出的模块名;若发现新模块概念,�
 ## host-side vs kernel-side
 
 并非所有模块都属于 Ymem kernel。`context-packer` / `publisher` / `interface` /
-`audit-ui` 都是 host-app(目前是 ZhiOne)的责任。但 radar 仍然追踪这些模块的
+`audit-ui` 都是 host-app 的责任。但 radar 仍然追踪这些模块的
 研究,因为:
 
 1. host 侧的需求会反推 Ymem 输出的形状(例如 `MemoryResult` 需要带 omitted /

--- a/impact-reports/README.md
+++ b/impact-reports/README.md
@@ -23,7 +23,9 @@ source note to `full` first.
 ## Affected modules
 - ingest-adapter | parser-chunker | semantic-dedup | retriever-reranker |
   context-packer | dream-consolidator | memorydiff-generator |
-  evaluator-benchmark | security-privacy
+  evaluator-benchmark | publisher | interface | audit-ui | security-privacy
+- If this list drifts, use ../docs/ymem-binding/taxonomy-modules.md as the
+  source of truth.
 
 ## Evidence
 - Benchmark, product behavior, implementation detail, or source-page evidence.

--- a/impact-reports/README.md
+++ b/impact-reports/README.md
@@ -1,0 +1,39 @@
+# Impact reports
+
+Impact reports are the bridge between a full ResearchItem and a concrete
+memory-kernel decision. They should be written only when a paper or product note
+is strong enough to affect architecture, experiments, or an ADR.
+
+This directory is intentionally empty except for this guide until the first
+candidate needs review. Do not cite `stub` notes as evidence here; upgrade the
+source note to `full` first.
+
+## Minimal template
+
+```markdown
+# <short title>
+
+## Source
+- ResearchItem: ../papers/<slug>.md or ../products/<slug>.md
+- Status: full
+
+## Problem
+- What memory-kernel problem this candidate addresses.
+
+## Affected modules
+- ingest-adapter | parser-chunker | semantic-dedup | retriever-reranker |
+  context-packer | dream-consolidator | memorydiff-generator |
+  evaluator-benchmark | security-privacy
+
+## Evidence
+- Benchmark, product behavior, implementation detail, or source-page evidence.
+
+## Costs and risks
+- Implementation cost:
+- Runtime cost:
+- Privacy/provenance risk:
+- Maintenance risk:
+
+## Recommendation
+- ignore | monitor | prototype | adopt_as_plugin | consider_core_change
+```


### PR DESCRIPTION
## Summary
- Clarifies the bilingual public entry points with corrected repository counts and a first-read path.
- Adds `docs/README.md` as a documentation map and `impact-reports/README.md` as the ImpactReport placeholder/template.
- Updates contributor guidance, citation metadata, and Ymem-binding language so public docs stay product-neutral.

## Validation
- `git diff --check HEAD~1..HEAD`
- `rg -n "ZhiOne|529|9 deep notes|7 deep notes|impact-reports/<" README.md README_cn.md CONTRIBUTING.md docs CITATION.cff` returned no matches.
- Confirmed PDF count: `534`.
- Confirmed stub count: `988`.
- Confirmed core link targets exist: `docs/README.md`, `docs/agent-memory-survey.md`, `papers/index.md`, `docs/products-landscape.md`, `docs/ymem-binding/README.md`, `impact-reports/README.md`.

## Notes
- No paper, PDF, product archive, or scrape output was moved or regenerated.
- Not tested with a full markdown link crawler or rendered GitHub preview.
