### PR TITLE
[codex] Clarify public README entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 # awesome-agent-memory
 
-**Long-term memory for LLM agents — a decision-driven reading list, 989-paper cross-list index, and living survey covering memory architectures, retrieval, consolidation, and forgetting.**
+**Long-term memory for LLM agents — a decision-driven reading list, 989-paper index, and living survey covering memory architectures, retrieval, consolidation, and forgetting.**
 
 [中文](README_cn.md) · **English**
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Papers](https://img.shields.io/badge/papers-989-brightgreen.svg)](papers/index.md)
 [![PDFs](https://img.shields.io/badge/local_PDFs-534-orange.svg)](papers/pdfs/)
-[![Products](https://img.shields.io/badge/products-10-purple.svg)](products/)
+[![Memory products](https://img.shields.io/badge/memory_products-10-purple.svg)](products/)
 [![Surveys](https://img.shields.io/badge/meta_surveys-6-yellow.svg)](docs/meta-surveys.md)
 [![Updated](https://img.shields.io/badge/updated-2026--05-lightgrey.svg)](docs/signals.md)
 
@@ -17,52 +17,40 @@
 
 ---
 
-This repo is intentionally **narrow**. It is not a general AI/ML reading list.
-Every entry should plausibly inform how an agent **remembers, forgets, retrieves,
-or consolidates** information.
-
-## What makes this different
-
-| | Most awesome-lists | **awesome-agent-memory** |
-|---|---|---|
-| Goal | Coverage | Decision-driven curation |
-| Per-paper note | Title + link | 7-section ResearchItem template |
-| PDF availability | URL only, breaks over time | Local archive (`papers/pdfs/`) |
-| Cross-list signal | None | Each stub records which of 9 sibling lists referenced it |
-| Module mapping | None | Every full note maps to common memory-kernel modules ([`docs/taxonomy.md`](docs/taxonomy.md)) |
-| Workflow | Read | Read → ImpactReport → Sandbox → ADR |
-
 ## Table of contents
 
 1. [At a glance](#at-a-glance)
-2. [Read first](#read-first)
-3. [Repository layout](#repository-layout)
-4. [How the loop works](#how-the-loop-works)
-5. [Note status](#note-status)
-6. [Adding an entry](#adding-an-entry)
-7. [License / archival policy](#license--archival-policy)
-8. [Origin / maintenance](#origin--maintenance)
+2. [Repository map](#repository-map)
+3. [Read first](#read-first)
+4. [Repository layout](#repository-layout)
+5. [License / archival policy](#license--archival-policy)
+6. [Origin / maintenance](#origin--maintenance)
 
 ## At a glance
 
-```text
-989 unique papers   ← scraped from 9 sibling awesome-lists, deduped
-988 paper stubs     ← auto-generated cross-list coverage under papers/stubs/
-534 local PDFs      ← open-redistribution sources, gated by signal / year / code link
- 10 product notes   ← Mem0, Letta, Zep, Graphiti, Cognee, LangMem, ...
-  9 archive pages   ← markdown snapshots for auditability
-  7 full paper notes + 2 seed paper notes
-  6 meta-surveys    ← 2025-12 ~ 2026-05 indexed in docs/meta-surveys.md
-  1 living survey   ← docs/agent-memory-survey.md
-```
+| Area | Count | Entry point | What it is for |
+|---|---:|---|---|
+| Paper index | 989 papers | [`papers/index.md`](papers/index.md) | Searchable entry point for agent-memory papers. |
+| Paper stubs | 988 stubs | [`papers/stubs/`](papers/stubs/) | Lightweight coverage records for papers not yet fully read. |
+| Local PDFs | 534 files | [`papers/pdfs/`](papers/pdfs/) | Archived PDFs for stable reading and audit. |
+| Full / seed notes | 7 full + 2 seed | [`papers/`](papers/) | Human-read paper notes and notes in progress. |
+| Memory product notes | 10 notes | [`products/`](products/) | Notes on existing memory infrastructure and agent-memory products. |
+| Page archives | 9 snapshots | [`products/archives/`](products/archives/) | Markdown snapshots for memory-product page auditability. |
+| Survey docs | 1 living survey + 6 meta-survey records | [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) · [`docs/meta-surveys.md`](docs/meta-surveys.md) | Maintainer synthesis and survey tracking. |
 
-**Top-6 cross-list papers** (referenced by 6 / 9 sibling awesome-lists):
-[MAGMA](papers/stubs/magma-a-multi-graph-based-agentic-memory-architecture-for.md) ·
-[Mem0](papers/mem0-paper.md) ·
-[MemGen](papers/stubs/memgen-weaving-generative-latent-memory-for-self-evolving.md) ·
-[Memory-R1](papers/stubs/memory-r1-enhancing-large-language-model-agents-to-manage.md) ·
-[MIRIX](papers/stubs/mirix-multi-agent-memory-system-for-llm-based-agents.md) ·
-[O-Mem](papers/stubs/o-mem-omni-memory-system-for-personalized-long-horizon-self.md)
+## Repository map
+
+```mermaid
+flowchart LR
+  R["README"] --> D["Docs map<br/>survey + taxonomy"]
+  R --> P["Papers<br/>index + stubs + PDFs"]
+  R --> PL["Memory products<br/>notes + page archives"]
+  D --> IR["Impact reports<br/>evaluation template"]
+  P --> IR
+  PL --> IR
+  IR --> KD["Kernel decisions<br/>sandbox + ADR"]
+  D -. "optional" .-> YB["Ymem binding"]
+```
 
 ## Read first
 
@@ -71,8 +59,8 @@ If this is your first visit, use these entry points in order:
 1. [`docs/README.md`](docs/README.md) — map of the documentation set.
 2. [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) — the living survey and current maintainer synthesis.
 3. [`docs/taxonomy.md`](docs/taxonomy.md) — the shared vocabulary for forms, functions, dynamics, persistence, and curation.
-4. [`papers/index.md`](papers/index.md) — the 989-paper cross-list index, sorted by maturity signals.
-5. [`docs/products-landscape.md`](docs/products-landscape.md) — product notes grouped by domain and audience.
+4. [`papers/index.md`](papers/index.md) — the 989-paper index, organized for discovery and follow-up reading.
+5. [`docs/products-landscape.md`](docs/products-landscape.md) — memory product notes grouped by domain and audience.
 
 ## Repository layout
 
@@ -87,95 +75,23 @@ All concept docs now live under [`docs/`](docs/). Start with
 | [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) | A living literature review by the maintainer. |
 | [`docs/meta-surveys.md`](docs/meta-surveys.md) | Index of **external** meta-surveys (2025-12 ~ 2026-05). |
 | [`docs/taxonomy.md`](docs/taxonomy.md) | Generic agent-memory taxonomy: cross-walk of 3 external frameworks. |
-| [`docs/research-radar.md`](docs/research-radar.md) | Generic Radar workflow: Paper → ResearchItem → ImpactReport → sandbox → ADR. |
+| [`docs/research-radar.md`](docs/research-radar.md) | Generic Radar schema for ResearchItem and ImpactReport notes. |
 | [`docs/information-sources.md`](docs/information-sources.md) | 10-category source catalog with a dedicated zh-CN section. |
-| [`docs/related-work.md`](docs/related-work.md) | 9 sibling awesome-list repos with positioning vs each. |
-| [`docs/products-landscape.md`](docs/products-landscape.md) | Agent-memory products by **domain × audience**. |
-| [`docs/signals.md`](docs/signals.md) | Reverse-chrono 2026 H1 release / comparison / blog log. |
+| [`docs/related-work.md`](docs/related-work.md) | Discovery-input attribution and scrape provenance. |
+| [`docs/products-landscape.md`](docs/products-landscape.md) | Memory products by **domain × audience**. |
+| [`docs/signals.md`](docs/signals.md) | Reverse-chrono 2026 H1 release / memory product / blog log. |
 
 ### Per-item notes
 
 | Path | Contents |
 |---|---|
 | [`papers/`](papers/) | 7 full paper notes, 2 seed notes, and master [`index.md`](papers/index.md). |
-| [`papers/stubs/`](papers/stubs/) | 988 auto-generated stubs (cross-list scrape output). |
+| [`papers/stubs/`](papers/stubs/) | 988 auto-generated stubs for papers not yet fully read. |
 | [`papers/pdfs/`](papers/pdfs/) | 534 archived PDFs (~1.8 GB). See archival policy. |
 | [`papers/_scrape/`](papers/_scrape/) | Reproducibility artifacts: scrape script + dedup JSON. |
-| [`products/`](products/) | 10 product notes (Mem0, Letta, Zep, Graphiti, …). |
-| [`products/archives/`](products/archives/) | Markdown snapshots of canonical product pages. |
+| [`products/`](products/) | 10 memory product notes (Mem0, Letta, Zep, Graphiti, …). |
+| [`products/archives/`](products/archives/) | Markdown snapshots of canonical memory product pages. |
 | [`docs/ymem-binding/`](docs/ymem-binding/) | Project-specific bindings from the maintainer's [Ymem](https://github.com/Snseam/Ymem) kernel; safe to ignore if you don't use Ymem. |
-
-## How the loop works
-
-```text
-paper or product
-    ↓
-ResearchItem note (papers/ or products/)
-    ↓
-classification against docs/taxonomy.md
-    ↓
-ArchitectureImpactReport (impact-reports/)
-    ↓
-sandbox experiment (in your kernel repo)
-    ↓
-ADR (in your kernel repo)
-    ↓
-graduated to main, or rejected
-```
-
-The external survey index and our living survey reflect the current
-understanding; the per-item notes are the raw material; the impact reports
-are how candidates are evaluated; the ADR (in your kernel repo) is where
-decisions are recorded.
-
-## Note status
-
-Most paper notes are **stubs**: just enough frontmatter (title, arXiv ID,
-year, source list, optional local PDF link, `status: stub`) plus a one-line
-context snippet, generated from the cross-list scrape. They exist so that:
-
-1. The Radar has 100% coverage of what the 9 sibling lists track.
-2. Cross-list reference count gives a *maturity* signal for which stubs to
-   upgrade first.
-
-Status labels:
-
-| Status | Meaning |
-|---|---|
-| `stub` | Auto-generated or lightly generated coverage entry. Useful for discovery, not for architectural claims. |
-| `seed` | Human-started note with enough structure to track, but still missing a full read or complete evidence pass. |
-| `full` | Human-read ResearchItem with the seven-section template and memory-module mapping. |
-| `working-notes` | Exploratory product or essay notes that are intentionally not yet normalized as a full ResearchItem. |
-
-A stub becomes a **full** note when a human reads the paper and fills the
-seven-section template:
-
-```text
-1. 问题陈述           Problem
-2. 核心 claim         Central thesis
-3. 方法 / 框架        Method
-4. 评估 / benchmark   Evaluation
-5. 决策相关性          ★ Decision relevance (memory-module mapping)
-6. 优劣 / 注意事项    Pros / cons
-7. 待跟进             Follow-ups
-```
-
-**Only full notes should be cited as evidence in an ArchitectureImpactReport.**
-
-## Adding an entry
-
-Per-item full notes must include, at minimum:
-
-- title · source (arXiv ID / conference / blog URL) · date
-- domain — one of `memory | retrieval | graph | agent | eval | compression | UI | security`
-- core claim · method summary · required assumptions · benchmarks used
-- evidence level (`weak | medium | strong`)
-- code available (yes/no + link) · license · cost/complexity estimate
-- **decision relevance** — which memory-kernel modules this would affect
-  (see [`docs/taxonomy.md`](docs/taxonomy.md))
-
-See [`docs/research-radar.md`](docs/research-radar.md) for the full schema
-and naming conventions.
 
 ## License / archival policy
 
@@ -191,7 +107,7 @@ source restricts redistribution, please open an issue; we will remove it.
 The canonical URL in the corresponding note's `urls` field remains the
 authoritative source.
 
-**Product page snapshots** (`products/archives/`) are research backups,
+**Memory product page snapshots** (`products/archives/`) are research backups,
 captured so that this repo's reasoning stays auditable when source pages
 change or disappear. They are **not** re-published material; commercial
 citation should always use the original URL in the snapshot's `source_url`
@@ -204,20 +120,26 @@ This repo was started by the
 documentation is intended to stay useful for any agent-memory kernel. Ymem
 specific bindings — module names, maintainer stance, and internal benchmark
 choices — live in [`docs/ymem-binding/`](docs/ymem-binding/) so the public
-entry points remain product-neutral.
+entry points remain project-neutral.
+
+The paper index also uses a small set of public awesome-list repositories as
+discovery inputs. Source attribution and scrape artifacts live in
+[`docs/related-work.md`](docs/related-work.md) and
+[`papers/_scrape/`](papers/_scrape/). These inputs are used for discovery only;
+notes, survey synthesis, and maintainer judgments are maintained here.
 
 ---
 
 > *Notes are authored by the maintainer. Some stubs and first drafts were
 > accelerated with LLM tooling; every full note is grounded in the actual
-> PDF or product page that was read, not in unverified secondary summaries.*
+> PDF or memory product page that was read, not in unverified secondary summaries.*
 
 <div align="center">
 
 **[Survey](docs/agent-memory-survey.md)** ·
 **[Docs map](docs/README.md)** ·
 **[Papers index](papers/index.md)** ·
-**[Products landscape](docs/products-landscape.md)** ·
+**[Memory products landscape](docs/products-landscape.md)** ·
 **[Signals](docs/signals.md)** ·
 **[中文版](README_cn.md)**
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -2,14 +2,14 @@
 
 # awesome-agent-memory
 
-**面向 LLM agent 长程记忆的研究入口 —— 决策驱动的阅读清单、989 篇跨仓索引、活综述,涵盖记忆架构、检索、整合与遗忘。**
+**面向 LLM agent 长程记忆的研究入口 —— 决策驱动的阅读清单、989 篇论文索引、活综述,涵盖记忆架构、检索、整合与遗忘。**
 
 **中文** · [English](README.md)
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Papers](https://img.shields.io/badge/papers-989-brightgreen.svg)](papers/index.md)
 [![PDFs](https://img.shields.io/badge/local_PDFs-534-orange.svg)](papers/pdfs/)
-[![Products](https://img.shields.io/badge/products-10-purple.svg)](products/)
+[![记忆产品](https://img.shields.io/badge/memory_products-10-purple.svg)](products/)
 [![Surveys](https://img.shields.io/badge/meta_surveys-6-yellow.svg)](docs/meta-surveys.md)
 [![Updated](https://img.shields.io/badge/updated-2026--05-lightgrey.svg)](docs/signals.md)
 
@@ -17,52 +17,41 @@
 
 ---
 
-本仓库**有意保持窄域**:不是通用 AI/ML 阅读清单。每一条目都应当能合理说明
-agent 如何**记忆、遗忘、检索、整合**信息。
-
-## 与同类 awesome-list 的不同
-
-| | 一般 awesome-list | **awesome-agent-memory** |
-|---|---|---|
-| 目标 | 求覆盖 | 决策驱动的精选 |
-| 单篇笔记 | 标题 + 链接 | 七节 ResearchItem 模板 |
-| PDF | 只留链接,链接坏掉就丢 | 本地存档(`papers/pdfs/`)|
-| 跨仓信号 | 无 | 每个 stub 记录 9 个同生态 list 中哪些引用了它 |
-| 模块映射 | 无 | 每个 full 笔记必须映射到通用 memory kernel 模块([`docs/taxonomy.md`](docs/taxonomy.md))|
-| 工作流 | 读 | 读 → ImpactReport → 沙盒实验 → ADR |
-
 ## 目录
 
 1. [一眼总览](#一眼总览)
-2. [先读这里](#先读这里)
-3. [仓库结构](#仓库结构)
-4. [工作流](#工作流)
-5. [笔记状态](#笔记状态)
-6. [新增 full 笔记的字段要求](#新增-full-笔记的字段要求)
-7. [License 与存档策略](#license-与存档策略)
-8. [发起方与维护](#发起方与维护)
-9. [贡献](#贡献)
+2. [仓库地图](#仓库地图)
+3. [先读这里](#先读这里)
+4. [仓库结构](#仓库结构)
+5. [License 与存档策略](#license-与存档策略)
+6. [发起方与维护](#发起方与维护)
+7. [贡献](#贡献)
 
 ## 一眼总览
 
-```text
-989 篇唯一论文     ← 9 个同生态 awesome-list 抓取去重
-988 个论文 stub    ← papers/stubs/ 下的自动生成跨仓覆盖
-534 个本地 PDF     ← 开放再分发来源;按信号 / 年份 / 代码链接筛选入库
- 10 个产品笔记     ← Mem0、Letta、Zep、Graphiti、Cognee、LangMem、…
-  9 个页面快照     ← markdown 形式,便于审计
-  7 个 full 论文笔记 + 2 个 seed 论文笔记
-  6 个 meta-survey ← 2025-12 ~ 2026-05,见 docs/meta-surveys.md
-  1 份活综述       ← docs/agent-memory-survey.md
-```
+| 板块 | 数量 | 入口 | 用途 |
+|---|---:|---|---|
+| 论文索引 | 989 篇论文 | [`papers/index.md`](papers/index.md) | 检索 agent memory 论文的主入口。 |
+| 论文 stub | 988 个 stub | [`papers/stubs/`](papers/stubs/) | 尚未 full 阅读论文的轻量覆盖记录。 |
+| 本地 PDF | 534 个文件 | [`papers/pdfs/`](papers/pdfs/) | 稳定阅读和审计用的 PDF 存档。 |
+| full / seed 笔记 | 7 个 full + 2 个 seed | [`papers/`](papers/) | 已人工阅读或正在推进的论文笔记。 |
+| 记忆产品笔记 | 10 个笔记 | [`products/`](products/) | 市面上已有的记忆基础设施和 agent-memory 产品记录。 |
+| 页面快照 | 9 个快照 | [`products/archives/`](products/archives/) | 用于审计的记忆产品页面 markdown 快照。 |
+| 综述文档 | 1 份活综述 + 6 条 meta-survey 记录 | [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) · [`docs/meta-surveys.md`](docs/meta-surveys.md) | 维护者综合判断与综述追踪。 |
 
-**跨 9 仓引用 top-6**(每篇均被 6 / 9 个同生态 list 引用):
-[MAGMA](papers/stubs/magma-a-multi-graph-based-agentic-memory-architecture-for.md) ·
-[Mem0](papers/mem0-paper.md) ·
-[MemGen](papers/stubs/memgen-weaving-generative-latent-memory-for-self-evolving.md) ·
-[Memory-R1](papers/stubs/memory-r1-enhancing-large-language-model-agents-to-manage.md) ·
-[MIRIX](papers/stubs/mirix-multi-agent-memory-system-for-llm-based-agents.md) ·
-[O-Mem](papers/stubs/o-mem-omni-memory-system-for-personalized-long-horizon-self.md)
+## 仓库地图
+
+```mermaid
+flowchart LR
+  R["README"] --> D["文档地图<br/>综述 + taxonomy"]
+  R --> P["论文<br/>索引 + stubs + PDFs"]
+  R --> PL["记忆产品<br/>笔记 + 页面快照"]
+  D --> IR["Impact reports<br/>评估模板"]
+  P --> IR
+  PL --> IR
+  IR --> KD["Kernel 决策<br/>沙盒 + ADR"]
+  D -. "可选" .-> YB["Ymem binding"]
+```
 
 ## 先读这里
 
@@ -71,8 +60,8 @@ agent 如何**记忆、遗忘、检索、整合**信息。
 1. [`docs/README.md`](docs/README.md) —— 文档地图,快速判断每份文档负责什么。
 2. [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) —— 活综述与当前维护者综合判断。
 3. [`docs/taxonomy.md`](docs/taxonomy.md) —— forms / functions / dynamics / persistence / curation 的共享词表。
-4. [`papers/index.md`](papers/index.md) —— 989 篇跨仓论文索引,按成熟度信号排序。
-5. [`docs/products-landscape.md`](docs/products-landscape.md) —— 按领域和服务对象整理的产品全景。
+4. [`papers/index.md`](papers/index.md) —— 989 篇论文索引,用于发现线索和后续阅读。
+5. [`docs/products-landscape.md`](docs/products-landscape.md) —— 按领域和服务对象整理的记忆产品全景。
 
 ## 仓库结构
 
@@ -87,87 +76,23 @@ agent 如何**记忆、遗忘、检索、整合**信息。
 | [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) | 维护者的活综述。 |
 | [`docs/meta-surveys.md`](docs/meta-surveys.md) | **外部** meta-survey 索引(2025-12 ~ 2026-05)。 |
 | [`docs/taxonomy.md`](docs/taxonomy.md) | 通用 agent memory taxonomy:三套外部分类轴对照。 |
-| [`docs/research-radar.md`](docs/research-radar.md) | 通用 Radar workflow:论文 → ResearchItem → ImpactReport → 沙盒 → ADR。 |
+| [`docs/research-radar.md`](docs/research-radar.md) | ResearchItem 与 ImpactReport 笔记的通用 Radar schema。 |
 | [`docs/information-sources.md`](docs/information-sources.md) | 10 类信息源 catalog,含 zh-CN 独立节。 |
-| [`docs/related-work.md`](docs/related-work.md) | 9 个同生态 awesome-list 与我们的差异。 |
-| [`docs/products-landscape.md`](docs/products-landscape.md) | agent memory 产品按**领域 × 服务对象**全景。 |
-| [`docs/signals.md`](docs/signals.md) | 2026 H1 反时序日志(release / comparison / blog)。 |
+| [`docs/related-work.md`](docs/related-work.md) | 发现线索归因与抓取来源记录。 |
+| [`docs/products-landscape.md`](docs/products-landscape.md) | 记忆产品按**领域 × 服务对象**全景。 |
+| [`docs/signals.md`](docs/signals.md) | 2026 H1 反时序日志(release / memory product / blog)。 |
 
 ### 逐条笔记
 
 | 路径 | 内容 |
 |---|---|
 | [`papers/`](papers/) | 7 个 full 论文笔记、2 个 seed 笔记 + 主索引 [`index.md`](papers/index.md)。 |
-| [`papers/stubs/`](papers/stubs/) | 988 个自动生成的 stub(跨仓抓取产物)。 |
+| [`papers/stubs/`](papers/stubs/) | 988 个尚未 full 阅读论文的自动生成 stub。 |
 | [`papers/pdfs/`](papers/pdfs/) | 534 个本地 PDF(~1.8 GB)。详见存档策略。 |
 | [`papers/_scrape/`](papers/_scrape/) | 可复现产物:抓取脚本 + dedup JSON。 |
-| [`products/`](products/) | 10 个产品笔记。 |
-| [`products/archives/`](products/archives/) | 产品页面的 markdown 快照。 |
+| [`products/`](products/) | 10 个记忆产品笔记。 |
+| [`products/archives/`](products/archives/) | 记忆产品页面的 markdown 快照。 |
 | [`docs/ymem-binding/`](docs/ymem-binding/) | 维护者所在的 [Ymem](https://github.com/Snseam/Ymem) 项目特定绑定;如果你不维护 Ymem,可以跳过。 |
-
-## 工作流
-
-```text
-论文 或 产品
-    ↓
-ResearchItem 笔记(papers/ 或 products/)
-    ↓
-对照 docs/taxonomy.md 归类
-    ↓
-ArchitectureImpactReport (impact-reports/)
-    ↓
-沙盒实验(在你自己的 kernel 仓内)
-    ↓
-ADR(在你自己的 kernel 仓内)
-    ↓
-进入主线 或 归档
-```
-
-外部 survey 索引和活综述反映当前理解面;逐条笔记是原材料;ImpactReport
-是评估通道;最终 ADR(在你的 kernel 仓)记录决策。
-
-## 笔记状态
-
-大多数论文笔记是 **stub**:只有 frontmatter(标题、arXiv ID、年份、source 仓
-列表、可选本地 PDF 链接、`status: stub`)加一行上下文,由跨仓抓取自动产出。
-它们的存在意义是:
-
-1. 让 Radar 对 9 个同生态 list 追踪的内容做到 100% 覆盖;
-2. 跨仓引用次数提供"成熟度"信号,告诉我们 stub 升级的优先级。
-
-状态含义:
-
-| Status | 含义 |
-|---|---|
-| `stub` | 自动生成或轻量生成的覆盖条目。适合发现线索,不适合直接作为架构判断依据。 |
-| `seed` | 人工开始整理的笔记,结构已经建立,但还没有完成全文精读或证据补齐。 |
-| `full` | 已完成七节 ResearchItem 模板和 memory-module 映射的人工深读笔记。 |
-| `working-notes` | 产品或文章的探索性记录,暂时不强行规范成 full ResearchItem。 |
-
-stub 在有人通读论文后填完七节模板,升级为 **full** 笔记:
-
-```text
-1. 问题陈述
-2. 核心 claim
-3. 方法 / 框架
-4. 评估 / benchmark
-5. 决策相关性           ★ 通用 memory kernel 模块映射
-6. 优劣 / 注意事项
-7. 待跟进
-```
-
-**只有 full 笔记应该作为证据写进 ArchitectureImpactReport。**
-
-## 新增 full 笔记的字段要求
-
-- title · source(arXiv ID / 会议 / 博文 URL)· date
-- domain —— `memory | retrieval | graph | agent | eval | compression | UI | security` 之一
-- core claim · method summary · required assumptions · benchmarks used
-- evidence level(`weak | medium | strong`)
-- code available(yes/no + 链接)· license · cost/complexity 估算
-- **decision relevance** —— 影响的 memory kernel 模块(见 [`docs/taxonomy.md`](docs/taxonomy.md))
-
-完整 schema 与命名约定见 [`docs/research-radar.md`](docs/research-radar.md)。
 
 ## License 与存档策略
 
@@ -180,7 +105,7 @@ arXiv perpetual non-exclusive license、ACL Anthology 的 CC-BY、OpenReview
 开放投稿等。若发现本仓某 PDF 的源协议禁止 redistribute,请开 issue,
 我们会撤下;对应笔记 `urls` 字段中的 canonical URL 仍是权威来源。
 
-**产品页面快照**(`products/archives/`)是研究备份,用以让本仓的推理在源
+**记忆产品页面快照**(`products/archives/`)是研究备份,用以让本仓的推理在源
 页面变更或消失后仍可审计。它们**不是**重新发布材料;商用引用请以快照 header
 中的 `source_url` 为准。
 
@@ -189,17 +114,12 @@ arXiv perpetual non-exclusive license、ACL Anthology 的 CC-BY、OpenReview
 本仓由 [**Ymem**](https://github.com/Snseam/Ymem)(一个 agent memory
 kernel)项目发起,但顶层文档应当对任何 agent-memory kernel 都有用。
 **Ymem 特定绑定** —— 模块名、维护者立场、内部 benchmark 选择 —— 收纳到
-[`docs/ymem-binding/`](docs/ymem-binding/) 子目录,以确保公开入口保持产品中性。
+[`docs/ymem-binding/`](docs/ymem-binding/) 子目录,以确保公开入口保持项目中性。
 
-## 与中文同行的关系
-
-- [IAAR-Shanghai/Awesome-AI-Memory](https://github.com/IAAR-Shanghai/Awesome-AI-Memory)
-  是中文社区目前 agent memory 覆盖最全的双语 awesome-list。我们引用它的条目
-  作为 cross-list 信号源(详见 [`docs/related-work.md`](docs/related-work.md))。
-  **差异**:我们的每条 ResearchItem 都标注 memory kernel 模块映射,并且围绕
-  "决策驱动"组织,不追求百科式覆盖。
-- 完整中文社区信息源(知乎 / B 站 / 公众号 / 小红书 / 中文 awesome 仓)单独
-  成节,见 [`docs/information-sources.md`](docs/information-sources.md) §6。
+论文索引整理时也参考了若干公开 awesome-list 仓库作为发现线索;具体来源、
+抓取记录与归因见 [`docs/related-work.md`](docs/related-work.md) 和
+[`papers/_scrape/`](papers/_scrape/)。这些来源仅作为发现入口;条目说明、
+综述判断和维护口径由本仓独立整理。
 
 ## 贡献
 
@@ -207,11 +127,11 @@ kernel)项目发起,但顶层文档应当对任何 agent-memory kernel 都有用
 
 - **新论文** → 先在 `papers/` 加 stub(或升级已有 stub 到 full),然后看是否
   值得写 ImpactReport。
-- **新产品** → 在 `products/` 加笔记并存档页面到 `products/archives/`,再
+- **新记忆产品** → 在 `products/` 加笔记并存档页面到 `products/archives/`,再
   决定是否需要进入 [`docs/products-landscape.md`](docs/products-landscape.md)。
 - **新信息源** → 加进 [`docs/information-sources.md`](docs/information-sources.md)
   对应的类目。
-- **新 awesome-list** → 加进 [`docs/related-work.md`](docs/related-work.md) 并讨论差异。
+- **新发现来源** → 加进 [`docs/related-work.md`](docs/related-work.md) 并记录来源范围。
 
 ---
 
@@ -220,11 +140,11 @@ kernel)项目发起,但顶层文档应当对任何 agent-memory kernel 都有用
 **[活综述](docs/agent-memory-survey.md)** ·
 **[文档地图](docs/README.md)** ·
 **[Papers 索引](papers/index.md)** ·
-**[产品全景](docs/products-landscape.md)** ·
+**[记忆产品全景](docs/products-landscape.md)** ·
 **[信号日志](docs/signals.md)** ·
 **[English](README.md)**
 
 </div>
 
 > *本仓内容由仓库维护者人工撰写,部分 stub 与初稿借助 LLM 工具加速生成;每条
-> full 笔记都基于实际的 PDF / 产品页面 grounded,不引用未经验证的二手摘要。*
+> full 笔记都基于实际的 PDF / 记忆产品页面 grounded,不引用未经验证的二手摘要。*


### PR DESCRIPTION
## Summary
- Simplifies the English and Chinese README public entry.
- Replaces comparison-oriented copy with a concise internal asset overview and compact Mermaid repository map.
- Clarifies products as memory products, moves discovery-source attribution to maintenance notes, and removes workflow/status/full-note field sections from the README.

## Review notes
- Reviewed the README diff for stale comparison language, workflow/status section remnants, and memory-product wording consistency.
- Tightened the at-a-glance product/archive descriptions in both languages before publishing.

## Validation
- `git diff --check HEAD~1..HEAD`
- `rg` checks for removed workflow, note-status, full-note field, comparison, and narrow-scope wording
- Checked key README local links exist

## Not tested
- Mermaid rendered preview; `mmdc` is not installed in this workspace.