### PR TITLE
[codex] Fix memory products badge rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Papers](https://img.shields.io/badge/papers-989-brightgreen.svg)](papers/index.md)
 [![PDFs](https://img.shields.io/badge/local_PDFs-534-orange.svg)](papers/pdfs/)
-[![Memory products](https://img.shields.io/badge/memory_products-10-purple.svg)](products/)
+[![Memory products](https://img.shields.io/badge/memory%20products-10-purple.svg)](products/)
 [![Surveys](https://img.shields.io/badge/meta_surveys-6-yellow.svg)](docs/meta-surveys.md)
 [![Updated](https://img.shields.io/badge/updated-2026--05-lightgrey.svg)](docs/signals.md)
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -9,7 +9,7 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Papers](https://img.shields.io/badge/papers-989-brightgreen.svg)](papers/index.md)
 [![PDFs](https://img.shields.io/badge/local_PDFs-534-orange.svg)](papers/pdfs/)
-[![记忆产品](https://img.shields.io/badge/memory_products-10-purple.svg)](products/)
+[![记忆产品](https://img.shields.io/badge/memory%20products-10-purple.svg)](products/)
 [![Surveys](https://img.shields.io/badge/meta_surveys-6-yellow.svg)](docs/meta-surveys.md)
 [![Updated](https://img.shields.io/badge/updated-2026--05-lightgrey.svg)](docs/signals.md)
 


### PR DESCRIPTION
## Summary
- Fixes the broken `Memory products` / `记忆产品` badge image in the README header.
- Uses URL-encoded space in the shields.io badge path so GitHub renders the SVG instead of showing alt text.

## Validation
- `git diff --check`
- `curl -I` returned `200` and `image/svg+xml` for the encoded shields.io URL.

## Not tested
- Browser render after merge; GitHub image cache may need a refresh.