### PR TITLE
[codex] Expand memory evidence surfaces

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,8 @@ decisions.
   reading the source paper.
 - Add or refresh a product note in `products/` and, when appropriate, a
   markdown snapshot in `products/archives/`.
+- Add or refresh a benchmark note in `benchmarks/` and record observed usage in
+  `benchmarks/claims/claims.yaml`.
 - Improve `docs/information-sources.md`, `docs/related-work.md`, or
   `docs/products-landscape.md` with sourced entries.
 - Draft an `impact-reports/` entry for a full note that materially affects
@@ -44,6 +46,12 @@ Full paper and product notes should preserve the ResearchItem shape described in
 - separate direct evidence from maintainer inference;
 - keep unverified claims marked as `check`, `seed`, or follow-up work instead of
   presenting them as settled.
+
+Benchmark notes should preserve the BenchmarkItem shape in
+`docs/research-radar.md`, and every score, product comparison, critique, or
+reproduction claim should have a ledger event in
+`benchmarks/claims/claims.yaml`. Do not reclassify a vendor blog, product page,
+or affiliated paper result as independent reproduction.
 
 ## Commit Messages
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Papers](https://img.shields.io/badge/papers-989-brightgreen.svg)](papers/index.md)
 [![PDFs](https://img.shields.io/badge/local_PDFs-534-orange.svg)](papers/pdfs/)
-[![Memory products](https://img.shields.io/badge/memory%20products-10-purple.svg)](products/)
+[![Memory products](https://img.shields.io/badge/memory%20products-34-purple.svg)](products/)
+[![Benchmarks](https://img.shields.io/badge/benchmarks-12-blueviolet.svg)](benchmarks/)
 [![Surveys](https://img.shields.io/badge/meta_surveys-6-yellow.svg)](docs/meta-surveys.md)
-[![Updated](https://img.shields.io/badge/updated-2026--05-lightgrey.svg)](docs/signals.md)
+[![Updated](https://img.shields.io/badge/updated-2026--06-lightgrey.svg)](docs/signals.md)
 
 </div>
+
 
 ---
 
@@ -34,8 +36,9 @@
 | Paper stubs | 988 stubs | [`papers/stubs/`](papers/stubs/) | Lightweight coverage records for papers not yet fully read. |
 | Local PDFs | 534 files | [`papers/pdfs/`](papers/pdfs/) | Archived PDFs for stable reading and audit. |
 | Full / seed notes | 7 full + 2 seed | [`papers/`](papers/) | Human-read paper notes and notes in progress. |
-| Memory product notes | 10 notes | [`products/`](products/) | Notes on existing memory infrastructure and agent-memory products. |
-| Page archives | 9 snapshots | [`products/archives/`](products/archives/) | Markdown snapshots for memory-product page auditability. |
+| Memory product notes | 34 notes | [`products/`](products/) | Notes on existing memory infrastructure and agent-memory products. |
+| Page archives | 33 snapshots | [`products/archives/`](products/archives/) | Markdown snapshots for memory-product page auditability. |
+| Benchmark catalog | 12 seed entries | [`benchmarks/index.md`](benchmarks/index.md) | First-class benchmark records and usage-claim ledger. |
 | Survey docs | 1 living survey + 6 meta-survey records | [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) · [`docs/meta-surveys.md`](docs/meta-surveys.md) | Maintainer synthesis and survey tracking. |
 
 ## Repository map
@@ -45,9 +48,11 @@ flowchart LR
   R["README"] --> D["Docs map<br/>survey + taxonomy"]
   R --> P["Papers<br/>index + stubs + PDFs"]
   R --> PL["Memory products<br/>notes + page archives"]
+  R --> B["Benchmarks<br/>protocols + claims ledger"]
   D --> IR["Impact reports<br/>evaluation template"]
   P --> IR
   PL --> IR
+  B --> IR
   IR --> KD["Kernel decisions<br/>sandbox + ADR"]
   D -. "optional" .-> YB["Ymem binding"]
 ```
@@ -60,7 +65,9 @@ If this is your first visit, use these entry points in order:
 2. [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) — the living survey and current maintainer synthesis.
 3. [`docs/taxonomy.md`](docs/taxonomy.md) — the shared vocabulary for forms, functions, dynamics, persistence, and curation.
 4. [`papers/index.md`](papers/index.md) — the 989-paper index, organized for discovery and follow-up reading.
-5. [`docs/products-landscape.md`](docs/products-landscape.md) — memory product notes grouped by domain and audience.
+5. [`docs/benchmarks-landscape.md`](docs/benchmarks-landscape.md) — benchmark usage, evidence class, and cross-source statistics.
+6. [`docs/products-landscape.md`](docs/products-landscape.md) — memory product notes grouped by domain and audience.
+7. [`docs/product-memory-architectures.md`](docs/product-memory-architectures.md) — cross-product architecture patterns and diagrams.
 
 ## Repository layout
 
@@ -79,6 +86,10 @@ All concept docs now live under [`docs/`](docs/). Start with
 | [`docs/information-sources.md`](docs/information-sources.md) | 10-category source catalog with a dedicated zh-CN section. |
 | [`docs/related-work.md`](docs/related-work.md) | Discovery-input attribution and scrape provenance. |
 | [`docs/products-landscape.md`](docs/products-landscape.md) | Memory products by **domain × audience**. |
+| [`docs/product-discovery-log.md`](docs/product-discovery-log.md) | Multi-agent product discovery log with Tier A / Tier B / reject decisions. |
+| [`docs/product-memory-architectures.md`](docs/product-memory-architectures.md) | Cross-product memory architecture patterns and comparison diagrams. |
+| [`docs/product-architecture-diagrams.md`](docs/product-architecture-diagrams.md) | Per-product Mermaid architecture diagrams for public product patterns. |
+| [`docs/benchmarks-landscape.md`](docs/benchmarks-landscape.md) | Benchmark landscape by capability, usage type, and evidence independence. |
 | [`docs/signals.md`](docs/signals.md) | Reverse-chrono 2026 H1 release / memory product / blog log. |
 
 ### Per-item notes
@@ -89,8 +100,11 @@ All concept docs now live under [`docs/`](docs/). Start with
 | [`papers/stubs/`](papers/stubs/) | 988 auto-generated stubs for papers not yet fully read. |
 | [`papers/pdfs/`](papers/pdfs/) | 534 archived PDFs (~1.8 GB). See archival policy. |
 | [`papers/_scrape/`](papers/_scrape/) | Reproducibility artifacts: scrape script + dedup JSON. |
-| [`products/`](products/) | 10 memory product notes (Mem0, Letta, Zep, Graphiti, …). |
-| [`products/archives/`](products/archives/) | Markdown snapshots of canonical memory product pages. |
+| [`products/`](products/) | 34 memory product notes (Mem0, Letta, Zep, Graphiti, EverOS, Redis Agent Memory Server, …). |
+| [`products/archives/`](products/archives/) | 33 Markdown snapshots of canonical memory product pages. |
+| [`benchmarks/`](benchmarks/) | 12 benchmark seed entries and first-class protocol notes. |
+| [`benchmarks/claims/`](benchmarks/claims/) | Event ledger for benchmark usage, vendor claims, critiques, and reproductions. |
+| [`benchmarks/archives/`](benchmarks/archives/) | Optional source-page snapshots for benchmark pages, repos, or dataset cards. |
 | [`docs/ymem-binding/`](docs/ymem-binding/) | Project-specific bindings from the maintainer's [Ymem](https://github.com/Snseam/Ymem) kernel; safe to ignore if you don't use Ymem. |
 
 ## License / archival policy
@@ -139,7 +153,9 @@ notes, survey synthesis, and maintainer judgments are maintained here.
 **[Survey](docs/agent-memory-survey.md)** ·
 **[Docs map](docs/README.md)** ·
 **[Papers index](papers/index.md)** ·
+**[Benchmarks](benchmarks/index.md)** ·
 **[Memory products landscape](docs/products-landscape.md)** ·
+**[Product architectures](docs/product-memory-architectures.md)** ·
 **[Signals](docs/signals.md)** ·
 **[中文版](README_cn.md)**
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Papers](https://img.shields.io/badge/papers-989-brightgreen.svg)](papers/index.md)
 [![PDFs](https://img.shields.io/badge/local_PDFs-534-orange.svg)](papers/pdfs/)
-[![Memory products](https://img.shields.io/badge/memory_products-10-purple.svg)](products/)
+[![Memory products](https://img.shields.io/badge/memory%20products-10-purple.svg)](products/)
 [![Surveys](https://img.shields.io/badge/meta_surveys-6-yellow.svg)](docs/meta-surveys.md)
 [![Updated](https://img.shields.io/badge/updated-2026--05-lightgrey.svg)](docs/signals.md)
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -9,9 +9,10 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Papers](https://img.shields.io/badge/papers-989-brightgreen.svg)](papers/index.md)
 [![PDFs](https://img.shields.io/badge/local_PDFs-534-orange.svg)](papers/pdfs/)
-[![记忆产品](https://img.shields.io/badge/memory%20products-10-purple.svg)](products/)
+[![记忆产品](https://img.shields.io/badge/memory%20products-34-purple.svg)](products/)
+[![Benchmarks](https://img.shields.io/badge/benchmarks-12-blueviolet.svg)](benchmarks/)
 [![Surveys](https://img.shields.io/badge/meta_surveys-6-yellow.svg)](docs/meta-surveys.md)
-[![Updated](https://img.shields.io/badge/updated-2026--05-lightgrey.svg)](docs/signals.md)
+[![Updated](https://img.shields.io/badge/updated-2026--06-lightgrey.svg)](docs/signals.md)
 
 </div>
 
@@ -35,8 +36,9 @@
 | 论文 stub | 988 个 stub | [`papers/stubs/`](papers/stubs/) | 尚未 full 阅读论文的轻量覆盖记录。 |
 | 本地 PDF | 534 个文件 | [`papers/pdfs/`](papers/pdfs/) | 稳定阅读和审计用的 PDF 存档。 |
 | full / seed 笔记 | 7 个 full + 2 个 seed | [`papers/`](papers/) | 已人工阅读或正在推进的论文笔记。 |
-| 记忆产品笔记 | 10 个笔记 | [`products/`](products/) | 市面上已有的记忆基础设施和 agent-memory 产品记录。 |
-| 页面快照 | 9 个快照 | [`products/archives/`](products/archives/) | 用于审计的记忆产品页面 markdown 快照。 |
+| 记忆产品笔记 | 34 个笔记 | [`products/`](products/) | 市面上已有的记忆基础设施和 agent-memory 产品记录。 |
+| 页面快照 | 33 个快照 | [`products/archives/`](products/archives/) | 用于审计的记忆产品页面 markdown 快照。 |
+| Benchmark 目录 | 12 个 seed 条目 | [`benchmarks/index.md`](benchmarks/index.md) | 与论文、产品并列的评测协议和使用 claims ledger。 |
 | 综述文档 | 1 份活综述 + 6 条 meta-survey 记录 | [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) · [`docs/meta-surveys.md`](docs/meta-surveys.md) | 维护者综合判断与综述追踪。 |
 
 ## 仓库地图
@@ -46,9 +48,11 @@ flowchart LR
   R["README"] --> D["文档地图<br/>综述 + taxonomy"]
   R --> P["论文<br/>索引 + stubs + PDFs"]
   R --> PL["记忆产品<br/>笔记 + 页面快照"]
+  R --> B["Benchmark<br/>协议 + claims ledger"]
   D --> IR["Impact reports<br/>评估模板"]
   P --> IR
   PL --> IR
+  B --> IR
   IR --> KD["Kernel 决策<br/>沙盒 + ADR"]
   D -. "可选" .-> YB["Ymem binding"]
 ```
@@ -61,7 +65,9 @@ flowchart LR
 2. [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) —— 活综述与当前维护者综合判断。
 3. [`docs/taxonomy.md`](docs/taxonomy.md) —— forms / functions / dynamics / persistence / curation 的共享词表。
 4. [`papers/index.md`](papers/index.md) —— 989 篇论文索引,用于发现线索和后续阅读。
-5. [`docs/products-landscape.md`](docs/products-landscape.md) —— 按领域和服务对象整理的记忆产品全景。
+5. [`docs/benchmarks-landscape.md`](docs/benchmarks-landscape.md) —— benchmark 使用、证据等级和跨来源统计。
+6. [`docs/products-landscape.md`](docs/products-landscape.md) —— 按领域和服务对象整理的记忆产品全景。
+7. [`docs/product-memory-architectures.md`](docs/product-memory-architectures.md) —— 跨产品 memory 架构模式与图谱。
 
 ## 仓库结构
 
@@ -80,6 +86,10 @@ flowchart LR
 | [`docs/information-sources.md`](docs/information-sources.md) | 10 类信息源 catalog,含 zh-CN 独立节。 |
 | [`docs/related-work.md`](docs/related-work.md) | 发现线索归因与抓取来源记录。 |
 | [`docs/products-landscape.md`](docs/products-landscape.md) | 记忆产品按**领域 × 服务对象**全景。 |
+| [`docs/product-discovery-log.md`](docs/product-discovery-log.md) | 多子 agent 产品搜索日志,记录 Tier A / Tier B / 拒绝理由。 |
+| [`docs/product-memory-architectures.md`](docs/product-memory-architectures.md) | 跨产品 memory 架构模式与对比图谱。 |
+| [`docs/product-architecture-diagrams.md`](docs/product-architecture-diagrams.md) | 基于公开资料的逐产品 Mermaid 架构图。 |
+| [`docs/benchmarks-landscape.md`](docs/benchmarks-landscape.md) | 按能力、使用方式和独立性拆分的 benchmark 全景。 |
 | [`docs/signals.md`](docs/signals.md) | 2026 H1 反时序日志(release / memory product / blog)。 |
 
 ### 逐条笔记
@@ -90,8 +100,11 @@ flowchart LR
 | [`papers/stubs/`](papers/stubs/) | 988 个尚未 full 阅读论文的自动生成 stub。 |
 | [`papers/pdfs/`](papers/pdfs/) | 534 个本地 PDF(~1.8 GB)。详见存档策略。 |
 | [`papers/_scrape/`](papers/_scrape/) | 可复现产物:抓取脚本 + dedup JSON。 |
-| [`products/`](products/) | 10 个记忆产品笔记。 |
-| [`products/archives/`](products/archives/) | 记忆产品页面的 markdown 快照。 |
+| [`products/`](products/) | 34 个记忆产品笔记。 |
+| [`products/archives/`](products/archives/) | 33 个记忆产品页面的 markdown 快照。 |
+| [`benchmarks/`](benchmarks/) | 12 个 benchmark seed 条目和一等评测协议笔记。 |
+| [`benchmarks/claims/`](benchmarks/claims/) | benchmark 使用、厂商自报、批评和复现的事件 ledger。 |
+| [`benchmarks/archives/`](benchmarks/archives/) | benchmark 页面、repo、dataset card 的可选审计快照。 |
 | [`docs/ymem-binding/`](docs/ymem-binding/) | 维护者所在的 [Ymem](https://github.com/Snseam/Ymem) 项目特定绑定;如果你不维护 Ymem,可以跳过。 |
 
 ## License 与存档策略
@@ -129,6 +142,8 @@ kernel)项目发起,但顶层文档应当对任何 agent-memory kernel 都有用
   值得写 ImpactReport。
 - **新记忆产品** → 在 `products/` 加笔记并存档页面到 `products/archives/`,再
   决定是否需要进入 [`docs/products-landscape.md`](docs/products-landscape.md)。
+- **新 benchmark** → 在 `benchmarks/` 加协议笔记,并在
+  [`benchmarks/claims/claims.yaml`](benchmarks/claims/claims.yaml) 记录来源和使用事件。
 - **新信息源** → 加进 [`docs/information-sources.md`](docs/information-sources.md)
   对应的类目。
 - **新发现来源** → 加进 [`docs/related-work.md`](docs/related-work.md) 并记录来源范围。
@@ -140,7 +155,9 @@ kernel)项目发起,但顶层文档应当对任何 agent-memory kernel 都有用
 **[活综述](docs/agent-memory-survey.md)** ·
 **[文档地图](docs/README.md)** ·
 **[Papers 索引](papers/index.md)** ·
+**[Benchmark](benchmarks/index.md)** ·
 **[记忆产品全景](docs/products-landscape.md)** ·
+**[产品架构图谱](docs/product-memory-architectures.md)** ·
 **[信号日志](docs/signals.md)** ·
 **[English](README.md)**
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -9,7 +9,7 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Papers](https://img.shields.io/badge/papers-989-brightgreen.svg)](papers/index.md)
 [![PDFs](https://img.shields.io/badge/local_PDFs-534-orange.svg)](papers/pdfs/)
-[![记忆产品](https://img.shields.io/badge/memory_products-10-purple.svg)](products/)
+[![记忆产品](https://img.shields.io/badge/memory%20products-10-purple.svg)](products/)
 [![Surveys](https://img.shields.io/badge/meta_surveys-6-yellow.svg)](docs/meta-surveys.md)
 [![Updated](https://img.shields.io/badge/updated-2026--05-lightgrey.svg)](docs/signals.md)
 

--- a/benchmarks/_template.md
+++ b/benchmarks/_template.md
@@ -1,0 +1,84 @@
+---
+title:
+benchmark_id:
+name:
+aliases: []
+status: candidate
+origin_type: unknown
+origin_source:
+first_public_date:
+domain:
+modality:
+task_grain:
+capability_axes: []
+dataset_size:
+data_nature: unknown
+metrics: []
+judge_type:
+code_available: unknown
+data_available: unknown
+license: check
+known_limitations: []
+canonical_sources: []
+confidence: low
+memory_modules:
+  - evaluator-benchmark
+last_revised:
+---
+
+# <Benchmark name>
+
+## What It Measures
+
+- Capability:
+- Evaluation target:
+- Scope:
+
+## Dataset / Scale
+
+- Data source:
+- Size:
+- Time/session span:
+- Synthetic / human / real-world status:
+
+## Protocol
+
+- Inputs:
+- Expected outputs:
+- Baselines:
+- Splits/subsets:
+
+## Metrics and Judging
+
+- Metrics:
+- Judge:
+- Repeats / confidence reporting:
+
+## Baselines and Reported Results
+
+Use this section for normalized result provenance only. Do not mix vendor
+self-claims with independent reproductions without labeling both.
+
+## Validity / Contamination / License Caveats
+
+- Statistical caveats:
+- Data contamination risk:
+- License / redistribution status:
+
+## Comparability Notes
+
+- What can be compared:
+- What should not be compared:
+
+## Related Papers
+
+-
+
+## Related Products
+
+-
+
+## Impact Use
+
+- `evaluator-benchmark` relevance:
+- Ready for ImpactReport: no

--- a/benchmarks/archives/README.md
+++ b/benchmarks/archives/README.md
@@ -1,0 +1,19 @@
+---
+title: Benchmark source archives
+date: 2026-06-11
+status: seed
+language: zh-CN
+---
+
+# Benchmark Source Archives
+
+Use this directory for markdown snapshots of benchmark project pages, official
+repositories, dataset cards, or leaderboard pages when a claim needs audit
+stability.
+
+Rules:
+
+- Keep the original `source_url` in the snapshot header.
+- Do not treat an archive as independent evidence; it only mirrors the original
+  source.
+- Link archived benchmark claims back to `../claims/claims.yaml`.

--- a/benchmarks/beam.md
+++ b/benchmarks/beam.md
@@ -1,0 +1,90 @@
+---
+title: BEAM — million-token long-term memory scale benchmark
+benchmark_id: beam
+name: BEAM
+aliases:
+  - BEAM (1M)
+  - BEAM (10M)
+status: candidate
+origin_type: paper_origin
+origin_source: ../papers/stubs/beyond-a-million-tokens-benchmarking-and-enhancing-long.md
+first_public_date: check
+domain: long_scale_memory
+modality: text
+task_grain: qa
+capability_axes:
+  - long_scale_recall
+  - temporal_reasoning
+  - scale_degradation
+dataset_size:
+  token_scale: "1M / 10M variants reported in product claims"
+data_nature: check
+metrics:
+  - score
+  - tokens_per_query
+judge_type: check
+code_available: check
+data_available: check
+license: check
+known_limitations:
+  - tracked here from product claims before full source-note upgrade
+canonical_sources:
+  - ../papers/stubs/beyond-a-million-tokens-benchmarking-and-enhancing-long.md
+  - ../products/mem0.md
+confidence: low
+memory_modules:
+  - evaluator-benchmark
+  - context-packer
+last_revised: 2026-06-11
+---
+
+# BEAM
+
+## What It Measures
+
+BEAM is tracked here because Mem0 reports BEAM 1M and BEAM 10M scores in its
+2026 memory benchmark blog. The local source is still candidate quality, so this
+note is a placeholder for long-scale memory evaluation evidence.
+
+## Dataset / Scale
+
+The current repo evidence records 1M and 10M variants through Mem0 product/blog
+claims. The benchmark source note must be upgraded before BEAM supports
+ImpactReport-grade conclusions.
+
+## Protocol
+
+Protocol details are check.
+
+## Metrics and Judging
+
+Mem0 reports absolute scores and tokens/query. Judge details need source
+verification.
+
+## Baselines and Reported Results
+
+The current usage ledger records Mem0 vendor self-claims only. Do not treat
+these rows as independent reproduction.
+
+## Validity / Contamination / License Caveats
+
+All BEAM claims are low-confidence until the benchmark source is read and
+availability/license details are recorded.
+
+## Comparability Notes
+
+BEAM is useful as a scale-stress placeholder, not yet as a normalized ranking
+surface.
+
+## Related Papers
+
+- [`../papers/stubs/beyond-a-million-tokens-benchmarking-and-enhancing-long.md`](../papers/stubs/beyond-a-million-tokens-benchmarking-and-enhancing-long.md)
+
+## Related Products
+
+- [`../products/mem0.md`](../products/mem0.md)
+
+## Impact Use
+
+- Ready for ImpactReport: no
+- Recommended use: backlog item for million-token memory scale evaluation.

--- a/benchmarks/claims/claims.yaml
+++ b/benchmarks/claims/claims.yaml
@@ -1,0 +1,516 @@
+events:
+  - event_id: longmemeval-origin-2024
+    benchmark_id: longmemeval
+    source_kind: paper
+    source_id: papers/longmemeval.md
+    source_date: 2024-10
+    actor: LongMemEval authors
+    actor_type: paper_authors
+    usage_type: originates_benchmark
+    claim_direction: methodological_only
+    compared_systems: []
+    reported_metrics: []
+    experimental_setup: "500 human-annotated QA; LongMemEval_S and LongMemEval_M; LLM-as-judge."
+    reproduction_status: not_reproduced
+    evidence_level: primary_pdf
+    independence_class: survey_only
+    comparability_notes: "Origin protocol; not counted as reuse."
+    evidence_refs:
+      - papers/longmemeval.md
+    extract_confidence: high
+  - event_id: locomo-origin-2024
+    benchmark_id: locomo
+    source_kind: paper
+    source_id: papers/locomo.md
+    source_date: 2024
+    actor: LoCoMo authors
+    actor_type: paper_authors
+    usage_type: originates_benchmark
+    claim_direction: methodological_only
+    compared_systems: []
+    reported_metrics: []
+    experimental_setup: "Very long-term conversational memory QA with temporal and causal dimensions."
+    reproduction_status: not_reproduced
+    evidence_level: primary_pdf
+    independence_class: survey_only
+    comparability_notes: "Origin protocol; local note is seed quality."
+    evidence_refs:
+      - papers/locomo.md
+    extract_confidence: medium
+  - event_id: convomem-origin-2025
+    benchmark_id: convomem
+    source_kind: paper
+    source_id: papers/convomem.md
+    source_date: 2025-11
+    actor: ConvoMem authors
+    actor_type: paper_authors
+    usage_type: originates_benchmark
+    claim_direction: methodological_only
+    compared_systems: []
+    reported_metrics: []
+    experimental_setup: "75,336 QA; six evidence categories; conversation lengths 2-300."
+    reproduction_status: not_reproduced
+    evidence_level: primary_pdf
+    independence_class: survey_only
+    comparability_notes: "Synthetic data; strong for protocol, not product-independent by itself."
+    evidence_refs:
+      - papers/convomem.md
+    extract_confidence: high
+  - event_id: memoryagentbench-origin-2026
+    benchmark_id: memoryagentbench
+    source_kind: paper
+    source_id: papers/memoryagentbench.md
+    source_date: 2026
+    actor: MemoryAgentBench authors
+    actor_type: paper_authors
+    usage_type: originates_benchmark
+    claim_direction: methodological_only
+    compared_systems: []
+    reported_metrics: []
+    experimental_setup: "Four memory-agent ability dimensions."
+    reproduction_status: not_reproduced
+    evidence_level: primary_pdf
+    independence_class: survey_only
+    comparability_notes: "Local note is seed quality."
+    evidence_refs:
+      - papers/memoryagentbench.md
+    extract_confidence: medium
+  - event_id: mem0-paper-locomo-2025
+    benchmark_id: locomo
+    source_kind: paper
+    source_id: papers/mem0-paper.md
+    source_date: 2025-04
+    actor: Mem0
+    actor_type: paper_authors
+    usage_type: baseline_comparison
+    claim_direction: positive_result
+    compared_systems:
+      - Mem0
+      - Mem0g
+      - OpenAI memory
+      - RAG
+      - full-context
+      - Zep
+      - LangMem
+    reported_metrics:
+      - metric: llm_as_judge
+        value: "reported by category in source note"
+        unit: score
+      - metric: token_cost
+        value: "reported in source note"
+        unit: tokens
+    experimental_setup: "LoCoMo with GPT-4o-mini extraction/update/judge according to local note."
+    reproduction_status: not_reproduced
+    evidence_level: primary_pdf
+    independence_class: affiliated_eval
+    comparability_notes: "Mem0 authors evaluate their own system; LoCoMo sample size is small."
+    evidence_refs:
+      - papers/mem0-paper.md
+    extract_confidence: high
+  - event_id: mem0-blog-locomo-2026
+    benchmark_id: locomo
+    source_kind: product_note
+    source_id: products/mem0.md
+    source_date: 2026-04
+    actor: Mem0
+    actor_type: vendor
+    usage_type: vendor_claim
+    claim_direction: positive_result
+    compared_systems:
+      - Mem0 algorithm v2
+    reported_metrics:
+      - metric: score
+        value: 91.6
+        unit: score
+      - metric: tokens_per_query
+        value: 6956
+        unit: tokens
+    experimental_setup: "Mem0 blog self-report; exact setup not independently reproduced in repo."
+    reproduction_status: vendor_self_report
+    evidence_level: primary_product_page
+    independence_class: self_claim
+    comparability_notes: "Do not mix with independent evaluations."
+    evidence_refs:
+      - products/mem0.md
+      - products/archives/mem0-blog-state-of-2026.md
+    extract_confidence: medium
+  - event_id: mem0-blog-longmemeval-2026
+    benchmark_id: longmemeval
+    source_kind: product_note
+    source_id: products/mem0.md
+    source_date: 2026-04
+    actor: Mem0
+    actor_type: vendor
+    usage_type: vendor_claim
+    claim_direction: positive_result
+    compared_systems:
+      - Mem0 algorithm v2
+    reported_metrics:
+      - metric: score
+        value: 93.4
+        unit: score
+      - metric: tokens_per_query
+        value: 6787
+        unit: tokens
+    experimental_setup: "Mem0 blog self-report."
+    reproduction_status: vendor_self_report
+    evidence_level: primary_product_page
+    independence_class: self_claim
+    comparability_notes: "LongMemEval subset and judge setup need source verification."
+    evidence_refs:
+      - products/mem0.md
+      - products/archives/mem0-blog-state-of-2026.md
+    extract_confidence: medium
+  - event_id: mem0-blog-beam-1m-2026
+    benchmark_id: beam
+    source_kind: product_note
+    source_id: products/mem0.md
+    source_date: 2026-04
+    actor: Mem0
+    actor_type: vendor
+    usage_type: vendor_claim
+    claim_direction: mixed
+    compared_systems:
+      - Mem0 algorithm v2
+    reported_metrics:
+      - metric: score
+        value: 64.1
+        unit: score
+      - metric: tokens_per_query
+        value: 6719
+        unit: tokens
+    experimental_setup: "BEAM 1M self-report in Mem0 blog."
+    reproduction_status: vendor_self_report
+    evidence_level: primary_product_page
+    independence_class: self_claim
+    comparability_notes: "BEAM source note is candidate quality."
+    evidence_refs:
+      - products/mem0.md
+      - products/archives/mem0-blog-state-of-2026.md
+    extract_confidence: medium
+  - event_id: mem0-blog-beam-10m-2026
+    benchmark_id: beam
+    source_kind: product_note
+    source_id: products/mem0.md
+    source_date: 2026-04
+    actor: Mem0
+    actor_type: vendor
+    usage_type: vendor_claim
+    claim_direction: mixed
+    compared_systems:
+      - Mem0 algorithm v2
+    reported_metrics:
+      - metric: score
+        value: 48.6
+        unit: score
+      - metric: tokens_per_query
+        value: 6914
+        unit: tokens
+    experimental_setup: "BEAM 10M self-report in Mem0 blog."
+    reproduction_status: vendor_self_report
+    evidence_level: primary_product_page
+    independence_class: self_claim
+    comparability_notes: "Mem0 note interprets this as scale degradation; not independently reproduced."
+    evidence_refs:
+      - products/mem0.md
+      - products/archives/mem0-blog-state-of-2026.md
+    extract_confidence: medium
+  - event_id: convomem-critiques-longmemeval-2025
+    benchmark_id: longmemeval
+    source_kind: paper
+    source_id: papers/convomem.md
+    source_date: 2025-11
+    actor: ConvoMem authors
+    actor_type: paper_authors
+    usage_type: critique
+    claim_direction: negative_result
+    compared_systems: []
+    reported_metrics:
+      - metric: preference_subgroup_size
+        value: 30
+        unit: questions
+      - metric: estimated_error_bar
+        value: "+/-18%"
+        unit: percentage_points
+    experimental_setup: "Methodological critique of LongMemEval sample size and filler conversation source."
+    reproduction_status: not_reproduced
+    evidence_level: primary_pdf
+    independence_class: independent_eval
+    comparability_notes: "Critique only; do not count as an independent reproduction score."
+    evidence_refs:
+      - papers/convomem.md
+    extract_confidence: high
+  - event_id: convomem-critiques-locomo-2025
+    benchmark_id: locomo
+    source_kind: paper
+    source_id: papers/convomem.md
+    source_date: 2025-11
+    actor: ConvoMem authors
+    actor_type: paper_authors
+    usage_type: critique
+    claim_direction: negative_result
+    compared_systems: []
+    reported_metrics:
+      - metric: conversation_count
+        value: 10
+        unit: conversations
+    experimental_setup: "Methodological critique of LoCoMo sample size."
+    reproduction_status: not_reproduced
+    evidence_level: primary_pdf
+    independence_class: independent_eval
+    comparability_notes: "Critique only; do not count as independent reproduction."
+    evidence_refs:
+      - papers/convomem.md
+    extract_confidence: high
+  - event_id: convomem-uses-mem0-baseline-2025
+    benchmark_id: convomem
+    source_kind: paper
+    source_id: papers/convomem.md
+    source_date: 2025-11
+    actor: ConvoMem authors
+    actor_type: paper_authors
+    usage_type: baseline_comparison
+    claim_direction: mixed
+    compared_systems:
+      - long-context
+      - Mem0
+      - block-based extraction
+    reported_metrics:
+      - metric: accuracy
+        value: "70-82 long-context; 30-45 Mem0 range in local note"
+        unit: percent
+      - metric: cost
+        value: "Mem0 about 1/95 full context at 300 conversations"
+        unit: relative
+    experimental_setup: "ConvoMem benchmark over variable conversation length and evidence categories."
+    reproduction_status: not_reproduced
+    evidence_level: primary_pdf
+    independence_class: affiliated_eval
+    comparability_notes: "Only Mem0 is the RAG baseline; do not generalize to all memory layers."
+    evidence_refs:
+      - papers/convomem.md
+    extract_confidence: high
+  - event_id: hindsight-longmemeval-2026
+    benchmark_id: longmemeval
+    source_kind: product_note
+    source_id: products/hindsight.md
+    source_date: 2026-05-31
+    actor: Hindsight
+    actor_type: vendor
+    usage_type: vendor_claim
+    claim_direction: positive_result
+    compared_systems:
+      - Hindsight
+    reported_metrics:
+      - metric: benchmark_performance
+        value: "claimed; exact score not normalized in local note"
+        unit: claim
+    experimental_setup: "Vendor README/product claim; local note says external collaborator reproduction is claimed."
+    reproduction_status: vendor_self_report
+    evidence_level: primary_product_page
+    independence_class: self_claim
+    comparability_notes: "External reproduction claim needs independent source before reclassification."
+    evidence_refs:
+      - products/hindsight.md
+      - products/archives/hindsight-overview.md
+    extract_confidence: medium
+  - event_id: zep-locomo-2026
+    benchmark_id: locomo
+    source_kind: product_note
+    source_id: products/zep.md
+    source_date: 2026-05
+    actor: Zep
+    actor_type: vendor
+    usage_type: vendor_claim
+    claim_direction: positive_result
+    compared_systems:
+      - Zep
+    reported_metrics:
+      - metric: locomo_retrieval
+        value: 80.32
+        unit: percent
+    experimental_setup: "Product-page claim; setup not normalized in repo."
+    reproduction_status: vendor_self_report
+    evidence_level: primary_product_page
+    independence_class: self_claim
+    comparability_notes: "Zep note warns comparability with Mem0/LangMem is unclear."
+    evidence_refs:
+      - products/zep.md
+    extract_confidence: medium
+  - event_id: graphiti-locomo-zep-foundation-2026
+    benchmark_id: locomo
+    source_kind: product_note
+    source_id: products/graphiti.md
+    source_date: 2026-05
+    actor: Graphiti
+    actor_type: vendor
+    usage_type: survey_mention
+    claim_direction: methodological_only
+    compared_systems:
+      - Zep
+      - Graphiti
+    reported_metrics: []
+    experimental_setup: "Graphiti appears as the foundation for Zep's LoCoMo number; Graphiti standalone benchmark data is sparse."
+    reproduction_status: not_reproduced
+    evidence_level: primary_product_page
+    independence_class: survey_only
+    comparability_notes: "Not a standalone Graphiti LoCoMo score."
+    evidence_refs:
+      - products/graphiti.md
+    extract_confidence: medium
+  - event_id: memoryos-locomo-2026
+    benchmark_id: locomo
+    source_kind: product_note
+    source_id: products/memoryos.md
+    source_date: 2026-05-31
+    actor: MemoryOS
+    actor_type: paper_authors
+    usage_type: vendor_claim
+    claim_direction: positive_result
+    compared_systems:
+      - MemoryOS
+    reported_metrics:
+      - metric: locomo_related_improvement
+        value: "claimed; exact value not normalized in local note"
+        unit: claim
+    experimental_setup: "Research/product README style claim."
+    reproduction_status: vendor_self_report
+    evidence_level: primary_product_page
+    independence_class: self_claim
+    comparability_notes: "Treat as official project claim until source protocol is normalized."
+    evidence_refs:
+      - products/memoryos.md
+      - products/archives/memoryos-overview.md
+    extract_confidence: medium
+  - event_id: hy-memory-longmemeval-2026
+    benchmark_id: longmemeval
+    source_kind: product_note
+    source_id: products/hy-memory.md
+    source_date: 2026-05-31
+    actor: Hy-Memory
+    actor_type: vendor
+    usage_type: vendor_claim
+    claim_direction: positive_result
+    compared_systems:
+      - Hy-Memory
+    reported_metrics:
+      - metric: longmemeval_claim
+        value: "claimed; exact score not normalized in local note"
+        unit: claim
+    experimental_setup: "Official site/product claim."
+    reproduction_status: vendor_self_report
+    evidence_level: primary_product_page
+    independence_class: self_claim
+    comparability_notes: "Hy-Memory note warns benchmark numbers are not independently verified."
+    evidence_refs:
+      - products/hy-memory.md
+      - products/archives/hy-memory-overview.md
+    extract_confidence: medium
+  - event_id: hy-memory-personamem-2026
+    benchmark_id: personamem-v2
+    source_kind: product_note
+    source_id: products/hy-memory.md
+    source_date: 2026-05-31
+    actor: Hy-Memory
+    actor_type: vendor
+    usage_type: vendor_claim
+    claim_direction: positive_result
+    compared_systems:
+      - Hy-Memory
+    reported_metrics:
+      - metric: personamem_claim
+        value: "claimed; exact score not normalized in local note"
+        unit: claim
+    experimental_setup: "Official site/product claim."
+    reproduction_status: vendor_self_report
+    evidence_level: primary_product_page
+    independence_class: self_claim
+    comparability_notes: "Benchmark id remains candidate until PersonaMem-v2 note is full."
+    evidence_refs:
+      - products/hy-memory.md
+      - products/archives/hy-memory-overview.md
+    extract_confidence: medium
+  - event_id: tencentdb-personamem-2026
+    benchmark_id: personamem-v2
+    source_kind: product_note
+    source_id: products/tencentdb-agent-memory.md
+    source_date: 2026-05-31
+    actor: TencentDB Agent Memory
+    actor_type: vendor
+    usage_type: vendor_claim
+    claim_direction: positive_result
+    compared_systems:
+      - TencentDB Agent Memory
+    reported_metrics:
+      - metric: personamem_claim
+        value: "claimed; exact score not normalized in local note"
+        unit: claim
+      - metric: token_reduction
+        value: "claimed; exact value not normalized in local note"
+        unit: claim
+    experimental_setup: "Official product-page claim."
+    reproduction_status: vendor_self_report
+    evidence_level: primary_product_page
+    independence_class: self_claim
+    comparability_notes: "Official self-test only in current repo evidence."
+    evidence_refs:
+      - products/tencentdb-agent-memory.md
+      - products/archives/tencentdb-agent-memory-overview.md
+    extract_confidence: medium
+  - event_id: survey-memoryagentbench-2026
+    benchmark_id: memoryagentbench
+    source_kind: paper
+    source_id: papers/memory-for-autonomous-llm-agents-survey.md
+    source_date: 2026-03
+    actor: Memory for Autonomous LLM Agents survey
+    actor_type: paper_authors
+    usage_type: survey_mention
+    claim_direction: methodological_only
+    compared_systems: []
+    reported_metrics: []
+    experimental_setup: "Survey classifies MemoryAgentBench in the evaluation landscape."
+    reproduction_status: not_reproduced
+    evidence_level: primary_pdf
+    independence_class: survey_only
+    comparability_notes: "Survey mention only."
+    evidence_refs:
+      - papers/memory-for-autonomous-llm-agents-survey.md
+    extract_confidence: high
+  - event_id: survey-membench-2026
+    benchmark_id: membench
+    source_kind: paper
+    source_id: papers/memory-for-autonomous-llm-agents-survey.md
+    source_date: 2026-03
+    actor: Memory for Autonomous LLM Agents survey
+    actor_type: paper_authors
+    usage_type: survey_mention
+    claim_direction: methodological_only
+    compared_systems: []
+    reported_metrics: []
+    experimental_setup: "Survey names MemBench as write-stage candidate extraction/dedup evaluation."
+    reproduction_status: not_reproduced
+    evidence_level: primary_pdf
+    independence_class: survey_only
+    comparability_notes: "Survey mention only; benchmark note remains candidate."
+    evidence_refs:
+      - papers/memory-for-autonomous-llm-agents-survey.md
+    extract_confidence: high
+  - event_id: survey-memoryarena-2026
+    benchmark_id: memoryarena
+    source_kind: paper
+    source_id: papers/memory-for-autonomous-llm-agents-survey.md
+    source_date: 2026-03
+    actor: Memory for Autonomous LLM Agents survey
+    actor_type: paper_authors
+    usage_type: survey_mention
+    claim_direction: methodological_only
+    compared_systems: []
+    reported_metrics: []
+    experimental_setup: "Survey names MemoryArena as manage/conflict evaluation."
+    reproduction_status: not_reproduced
+    evidence_level: primary_pdf
+    independence_class: survey_only
+    comparability_notes: "Survey note says original MemoryArena source should be checked."
+    evidence_refs:
+      - papers/memory-for-autonomous-llm-agents-survey.md
+    extract_confidence: medium

--- a/benchmarks/claims/index.md
+++ b/benchmarks/claims/index.md
@@ -1,0 +1,72 @@
+---
+title: Benchmark claims ledger
+date: 2026-06-11
+status: seed
+language: zh-CN
+---
+
+# Benchmark Claims Ledger
+
+`claims.yaml` records each observed use of a benchmark by a paper, product note,
+archive, blog, leaderboard, or independent report. The ledger is intentionally
+event-based: a benchmark can be strong as a protocol while a particular product
+score remains a vendor self-claim.
+
+Path values in `source_id` and `evidence_refs` are repository-root-relative
+when they point to local files.
+
+## Required Fields
+
+Each event must include:
+
+- `event_id`
+- `benchmark_id`
+- `source_kind`
+- `source_id`
+- `source_date`
+- `actor`
+- `actor_type`
+- `usage_type`
+- `reported_metrics`
+- `experimental_setup`
+- `reproduction_status`
+- `independence_class`
+- `evidence_refs`
+- `extract_confidence`
+
+## Classification Rules
+
+- `originates_benchmark`: the source introduces the benchmark protocol or
+  dataset.
+- `uses_for_eval`: the source runs or reports an evaluation on the benchmark.
+- `baseline_comparison`: the source compares multiple systems on the benchmark.
+- `vendor_claim`: a vendor-controlled source reports a score or improvement.
+- `independent_reproduction`: an unaffiliated party reruns or reproduces enough
+  of the setup to compare.
+- `critique`: methodological criticism without a documented rerun.
+- `survey_mention`: survey or planning mention only; count separately from
+  actual evaluation use.
+
+## Counting Rules
+
+- Count one benchmark once per source document per `usage_type`.
+- Do not double-count a product note and its archive unless they contain
+  distinct claims.
+- Do not merge aliases unless `benchmarks/index.md` lists them under the same
+  `benchmark_id`.
+- Do not average scores across different models, splits, judges, or context
+  budgets.
+- Keep vendor self-claims and independent reproductions in separate tables.
+
+## Validation Checklist
+
+Before using ledger rows in a landscape table:
+
+1. Every `benchmark_id` appears in [`../index.md`](../index.md).
+2. Every event has at least one `evidence_refs` entry.
+3. Every event with `reported_metrics` has `reproduction_status` and
+   `independence_class`.
+4. ConvoMem critiques of LongMemEval/LoCoMo are `critique`, not
+   `independent_reproduction`.
+5. Mem0 blog/product rows are `vendor_self_report` and `self_claim`.
+6. Stub-only evidence remains `candidate` or `survey_mention`.

--- a/benchmarks/convomem.md
+++ b/benchmarks/convomem.md
@@ -1,0 +1,106 @@
+---
+title: ConvoMem — conversational memory scaling benchmark
+benchmark_id: convomem
+name: ConvoMem
+aliases:
+  - ConvoMem Benchmark
+status: full
+origin_type: paper_origin
+origin_source: ../papers/convomem.md
+first_public_date: 2025-11
+domain: long_term_chat_memory
+modality: text
+task_grain: qa
+capability_axes:
+  - user_facts
+  - assistant_facts
+  - abstention
+  - preferences
+  - changing_facts
+  - implicit_connections
+  - multi_evidence
+dataset_size:
+  qa_count: 75336
+  token_scale: "1k-3M token configurable context"
+data_nature: synthetic
+metrics:
+  - accuracy
+  - cost
+  - latency
+judge_type: hybrid
+code_available: yes
+data_available: yes
+license: check
+known_limitations:
+  - synthetic data
+  - Mem0 is the main RAG baseline in the published comparison
+  - headline conclusion depends on strong long-context models
+canonical_sources:
+  - ../papers/convomem.md
+  - https://github.com/SalesforceAIResearch/ConvoMem
+  - https://huggingface.co/datasets/Salesforce/ConvoMem
+confidence: high
+memory_modules:
+  - evaluator-benchmark
+  - retriever-reranker
+  - dream-consolidator
+  - context-packer
+last_revised: 2026-06-11
+---
+
+# ConvoMem
+
+## What It Measures
+
+ConvoMem evaluates when conversation history is small enough for long-context
+reading and when RAG-style memory becomes worthwhile. It covers six evidence
+categories and multi-message evidence requirements.
+
+## Dataset / Scale
+
+The local full note records 75,336 QA items, conversation lengths from 2 to 300,
+and configurable context token ranges from 1k to 3M.
+
+## Protocol
+
+The benchmark generates persona, use case, evidence core, and conversations
+through one pipeline, then evaluates long-context, block extraction, and
+RAG-style memory approaches on the same tasks.
+
+## Metrics and Judging
+
+The paper reports accuracy plus cost/latency curves. Exact-match and rubric
+judging are used depending on the category.
+
+## Baselines and Reported Results
+
+ConvoMem is tracked both as a benchmark origin and as a critique source for
+LongMemEval and LoCoMo. Critique events must not be counted as independent
+reproduction unless a rerun is documented.
+
+## Validity / Contamination / License Caveats
+
+The data is synthetic and enterprise-persona weighted. Do not generalize the
+"first 150 conversations do not need RAG" claim to all memory products without
+checking model, domain, and context-window assumptions.
+
+## Comparability Notes
+
+ConvoMem is most useful for cost/quality crossover analysis. It should be
+reported separately from LongMemEval-style ability diagnosis.
+
+## Related Papers
+
+- [`../papers/convomem.md`](../papers/convomem.md)
+- [`../papers/longmemeval.md`](../papers/longmemeval.md)
+- [`../papers/mem0-paper.md`](../papers/mem0-paper.md)
+
+## Related Products
+
+- [`../products/mem0.md`](../products/mem0.md)
+
+## Impact Use
+
+- Ready for ImpactReport: yes
+- Recommended use: host-side context-packer policy and RAG-vs-long-context
+  crossover tests.

--- a/benchmarks/index.md
+++ b/benchmarks/index.md
@@ -1,0 +1,71 @@
+---
+title: Benchmark catalog — agent-memory evaluation protocols
+date: 2026-06-11
+status: seed
+language: zh-CN
+---
+
+# Benchmark Catalog
+
+This directory is the benchmark layer of `awesome-agent-memory`. It sits beside
+[`../papers/`](../papers/) and [`../products/`](../products/): paper notes own
+scholarly claims, product notes own product behavior and vendor claims, and
+benchmark notes own evaluation protocol, dataset shape, metrics, caveats, and
+cross-source usage evidence.
+
+## Scope
+
+Include benchmarks that evaluate long-term memory, multi-session agent behavior,
+personalization, forgetting, temporal reasoning, or memory-layer cost/quality
+trade-offs. Adjacent RAG, long-context, and general agent benchmarks enter this
+catalog only when memory papers or memory products use them for comparison.
+
+Stub-quality paper entries can seed this index, but claims, score comparisons,
+and recommendations must point to a full note, product archive, original paper,
+official repository, dataset card, or independent reproduction.
+
+## Seed Inventory
+
+| Benchmark | Status | Origin | Task family | Capabilities | Primary local anchor | Claim coverage |
+|---|---|---|---|---|---|---|
+| LongMemEval | full | paper-origin | long-term chat memory | retrieval / update / temporal / abstention | [`longmemeval.md`](longmemeval.md) | yes |
+| LoCoMo | seed | paper-origin | very long-term conversational memory | retrieval / temporal / causal | [`locomo.md`](locomo.md) | yes |
+| ConvoMem | full | paper-origin | conversational memory scaling | multi-evidence / preference / abstention | [`convomem.md`](convomem.md) | yes |
+| MemoryAgentBench | seed | paper-origin | incremental multi-turn agent memory | retrieval / learning / long-range / forgetting | [`memoryagentbench.md`](memoryagentbench.md) | yes |
+| BEAM | candidate | paper-origin | million-token memory scale | long-scale recall / temporal degradation | [`beam.md`](beam.md) | yes |
+| RealMem | candidate | paper-origin | real-world memory-driven interaction | multi-source / real-world interaction | [`../papers/stubs/realmem-benchmarking-llms-in-real-world-memory-driven.md`](../papers/stubs/realmem-benchmarking-llms-in-real-world-memory-driven.md) | backlog |
+| CloneMem | candidate | paper-origin | AI clone memory | identity continuity / personalization | [`../papers/stubs/clonemem-benchmarking-long-term-memory-for-ai-clones.md`](../papers/stubs/clonemem-benchmarking-long-term-memory-for-ai-clones.md) | backlog |
+| KnowMe-Bench | candidate | paper-origin | lifelong digital companion memory | person understanding / personalization | [`../papers/stubs/knowme-bench-benchmarking-person-understanding-for-lifelong.md`](../papers/stubs/knowme-bench-benchmarking-person-understanding-for-lifelong.md) | backlog |
+| PersonaMem-v2 | candidate | paper-origin | implicit persona memory | personalization / user modeling | [`../papers/stubs/personamem-v2-towards-personalized-intelligence-via.md`](../papers/stubs/personamem-v2-towards-personalized-intelligence-via.md) | yes |
+| LoCoBench-Agent | candidate | paper-origin | long-context coding agents | software task memory / long-horizon context | [`../papers/stubs/locobench-agent-an-interactive-benchmark-for-llm-agents-in.md`](../papers/stubs/locobench-agent-an-interactive-benchmark-for-llm-agents-in.md) | backlog |
+| MemoryArena | candidate | paper-origin | interdependent multi-session agent tasks | conflict resolution / shared memory | [`../papers/stubs/memoryarena-benchmarking-agent-memory-in-interdependent.md`](../papers/stubs/memoryarena-benchmarking-agent-memory-in-interdependent.md) | yes |
+| MemBench | candidate | paper-origin | memory of LLM-based agents | write / manage / memory mechanism | [`../papers/stubs/membench-towards-more-comprehensive-evaluation-on-the.md`](../papers/stubs/membench-towards-more-comprehensive-evaluation-on-the.md) | yes |
+
+## Evidence Ledgers
+
+- [`claims/index.md`](claims/index.md) explains the usage-event schema and
+  counting rules.
+- [`claims/claims.yaml`](claims/claims.yaml) is the first structured ledger for
+  benchmark usage, vendor self-claims, paper-origin events, and critiques.
+
+## Counting Rules
+
+Frequency tables must be split by evidence class:
+
+- Raw mentions: all deduplicated benchmark events.
+- Evaluation uses: `uses_for_eval`, `baseline_comparison`, and leaderboard use.
+- Vendor claims: vendor-controlled product pages, blogs, and repos.
+- Independent reproductions: third-party reruns with enough setup detail.
+- Product-used benchmarks: benchmarks that memory products report against.
+- Paper-origin reuse: paper-origin benchmarks used outside their origin paper.
+
+Do not average scores across different models, splits, judges, or benchmark
+subsets unless the setup matches and the comparison caveat is explicit.
+
+## Maintenance
+
+1. Add or update a benchmark note from [`_template.md`](_template.md).
+2. Add usage events to [`claims/claims.yaml`](claims/claims.yaml).
+3. Update [`../docs/benchmarks-landscape.md`](../docs/benchmarks-landscape.md)
+   when the ledger changes enough to affect counts or conclusions.
+4. Promote only full benchmark notes into ImpactReport evidence.

--- a/benchmarks/locomo.md
+++ b/benchmarks/locomo.md
@@ -1,0 +1,102 @@
+---
+title: LoCoMo — very long-term conversational memory benchmark
+benchmark_id: locomo
+name: LoCoMo
+aliases:
+  - LOCOMO
+status: seed
+origin_type: paper_origin
+origin_source: ../papers/locomo.md
+first_public_date: 2024
+domain: long_term_chat_memory
+modality: text
+task_grain: qa
+capability_axes:
+  - factual_recall
+  - temporal_reasoning
+  - causal_reasoning
+  - multi_session_consistency
+dataset_size:
+  conversation_count: 10
+  qa_count: check
+data_nature: synthetic_hybrid
+metrics:
+  - f1
+  - bleu
+  - llm_as_judge
+judge_type: hybrid
+code_available: check
+data_available: check
+license: check
+known_limitations:
+  - small conversation count
+  - product scores often use incompatible setups
+canonical_sources:
+  - ../papers/locomo.md
+  - https://aclanthology.org/2024.acl-long.747.pdf
+confidence: medium
+memory_modules:
+  - evaluator-benchmark
+  - retriever-reranker
+last_revised: 2026-06-11
+---
+
+# LoCoMo
+
+## What It Measures
+
+LoCoMo targets very long-term conversational memory: factual recall, temporal
+reasoning, causal reasoning, and consistency over month-scale dialogue history.
+
+## Dataset / Scale
+
+The local seed note records a small long-dialogue setup and flags that the full
+method summary still needs precision work. Mem0's full paper note also treats
+LoCoMo as its primary benchmark.
+
+## Protocol
+
+LoCoMo is commonly used to compare memory systems under long conversation
+history. Because product pages frequently cite LoCoMo without identical setup
+details, usage events must preserve model, memory method, judge, and context
+budget when available.
+
+## Metrics and Judging
+
+The Mem0 paper note reports F1, BLEU-1, and LLM-as-judge style scores on LoCoMo.
+Any score table must identify whether it comes from a paper evaluation, vendor
+self-report, or independent reproduction.
+
+## Baselines and Reported Results
+
+Tracked usage events include Mem0 paper results, Mem0 blog algorithm-v2 claims,
+Zep product-page claims, MemoryOS claims, and Graphiti-as-Zep-foundation notes.
+
+## Validity / Contamination / License Caveats
+
+The main caveat is sample size: the Mem0 note and ConvoMem note both flag that
+LoCoMo has limited statistical power for broad product claims.
+
+## Comparability Notes
+
+LoCoMo is useful for temporal/causal schema pressure. It is not a universal
+memory-product leaderboard unless setup parity is documented.
+
+## Related Papers
+
+- [`../papers/locomo.md`](../papers/locomo.md)
+- [`../papers/mem0-paper.md`](../papers/mem0-paper.md)
+- [`../papers/convomem.md`](../papers/convomem.md)
+
+## Related Products
+
+- [`../products/mem0.md`](../products/mem0.md)
+- [`../products/zep.md`](../products/zep.md)
+- [`../products/graphiti.md`](../products/graphiti.md)
+- [`../products/memoryos.md`](../products/memoryos.md)
+
+## Impact Use
+
+- Ready for ImpactReport: no, seed note should be upgraded first.
+- Recommended use: schema validation for temporal reasoning, valid-time fields,
+  and causal/multi-session consistency.

--- a/benchmarks/longmemeval.md
+++ b/benchmarks/longmemeval.md
@@ -1,0 +1,108 @@
+---
+title: LongMemEval — long-term interactive memory benchmark
+benchmark_id: longmemeval
+name: LongMemEval
+aliases:
+  - LongMemEval_S
+  - LongMemEval_M
+status: full
+origin_type: paper_origin
+origin_source: ../papers/longmemeval.md
+first_public_date: 2024-10
+domain: long_term_chat_memory
+modality: text
+task_grain: qa
+capability_axes:
+  - information_extraction
+  - multi_session_reasoning
+  - knowledge_update
+  - temporal_reasoning
+  - abstention
+dataset_size:
+  qa_count: 500
+  token_scale: "115k tokens (S) / 1.5M tokens (M)"
+data_nature: human_annotated
+metrics:
+  - accuracy
+  - llm_as_judge
+judge_type: llm_judge
+code_available: yes
+data_available: yes
+license: MIT (check)
+known_limitations:
+  - small subgroup sample sizes
+  - possible benchmark contamination after publication
+  - LLM-as-judge bias
+canonical_sources:
+  - ../papers/longmemeval.md
+  - https://arxiv.org/abs/2410.10813
+  - https://github.com/xiaowu0162/LongMemEval
+confidence: high
+memory_modules:
+  - evaluator-benchmark
+  - retriever-reranker
+  - dream-consolidator
+last_revised: 2026-06-11
+---
+
+# LongMemEval
+
+## What It Measures
+
+LongMemEval evaluates whether a chat assistant can answer questions grounded in
+multi-session, long-term conversation history. It is useful because it separates
+five memory abilities: information extraction, multi-session reasoning,
+knowledge update, temporal reasoning, and abstention.
+
+## Dataset / Scale
+
+The local full note records 500 human-annotated QA items, two context scales,
+and seven question types. LongMemEval_S covers a single-session scale around
+115k tokens; LongMemEval_M covers 500 sessions at roughly 1.5M tokens.
+
+## Protocol
+
+The paper frames chat memory as indexing -> retrieval -> reading, with control
+points for value, key, query, and reading. This makes it a direct input for
+`evaluator-benchmark` and `retriever-reranker` design.
+
+## Metrics and Judging
+
+The benchmark uses ground-truth answers and LLM-as-judge scoring. Any reuse
+should keep the judge model, subset, and question type visible.
+
+## Baselines and Reported Results
+
+Tracked usage events live in [`claims/claims.yaml`](claims/claims.yaml).
+Current repo evidence includes Mem0 and Hindsight product claims using
+LongMemEval, plus ConvoMem's methodological critique of the benchmark's sample
+size and filler-conversation leakage risk.
+
+## Validity / Contamination / License Caveats
+
+The local note flags subgroup error bars, LLM-as-judge bias, and possible
+training contamination as the main caveats. Do not use small subgroup deltas as
+strong evidence without independent reruns.
+
+## Comparability Notes
+
+LongMemEval is best for capability-level diagnosis. Scores should not be mixed
+with LoCoMo or ConvoMem unless the report separates task family, dataset scale,
+and judge setup.
+
+## Related Papers
+
+- [`../papers/longmemeval.md`](../papers/longmemeval.md)
+- [`../papers/convomem.md`](../papers/convomem.md)
+
+## Related Products
+
+- [`../products/mem0.md`](../products/mem0.md)
+- [`../products/hindsight.md`](../products/hindsight.md)
+- [`../products/hy-memory.md`](../products/hy-memory.md)
+
+## Impact Use
+
+- Ready for ImpactReport: yes
+- Recommended use: v0 regression suite for long-term chat-memory retrieval,
+  knowledge update, temporal reasoning, and abstention.

--- a/benchmarks/memoryagentbench.md
+++ b/benchmarks/memoryagentbench.md
@@ -1,0 +1,91 @@
+---
+title: MemoryAgentBench — incremental multi-turn memory-agent evaluation
+benchmark_id: memoryagentbench
+name: MemoryAgentBench
+aliases: []
+status: seed
+origin_type: paper_origin
+origin_source: ../papers/memoryagentbench.md
+first_public_date: 2026
+domain: agent_task_memory
+modality: text
+task_grain: multi_turn_interaction
+capability_axes:
+  - accurate_retrieval
+  - test_time_learning
+  - long_range_understanding
+  - selective_forgetting
+dataset_size:
+  qa_count: check
+data_nature: check
+metrics:
+  - accuracy
+judge_type: check
+code_available: check
+data_available: check
+license: check
+known_limitations:
+  - local note is seed quality
+canonical_sources:
+  - ../papers/memoryagentbench.md
+  - https://iclr.cc/virtual/2026/poster/10010781
+confidence: medium
+memory_modules:
+  - evaluator-benchmark
+  - retriever-reranker
+  - dream-consolidator
+last_revised: 2026-06-11
+---
+
+# MemoryAgentBench
+
+## What It Measures
+
+MemoryAgentBench decomposes memory-agent quality into four dimensions: accurate
+retrieval, test-time learning, long-range understanding, and selective
+forgetting. This makes it a useful organizing frame even before all protocol
+details are promoted from seed to full.
+
+## Dataset / Scale
+
+The local note is seed quality and needs a full read before this benchmark can
+support ImpactReport-grade evidence.
+
+## Protocol
+
+Each dimension corresponds to a different interaction pattern. This lets a
+memory kernel distinguish retrieval failures from update, consolidation, or
+forgetting failures.
+
+## Metrics and Judging
+
+Metrics and judging details are not yet normalized in this repo.
+
+## Baselines and Reported Results
+
+The claims ledger currently records survey and product-question usage, not
+independent score comparisons.
+
+## Validity / Contamination / License Caveats
+
+Treat all details beyond the four capability axes as check until the source note
+is upgraded.
+
+## Comparability Notes
+
+MemoryAgentBench is best used as a capability taxonomy for test planning until
+the note is full.
+
+## Related Papers
+
+- [`../papers/memoryagentbench.md`](../papers/memoryagentbench.md)
+- [`../papers/memory-for-autonomous-llm-agents-survey.md`](../papers/memory-for-autonomous-llm-agents-survey.md)
+
+## Related Products
+
+- [`../products/mem0.md`](../products/mem0.md)
+
+## Impact Use
+
+- Ready for ImpactReport: no, upgrade source note first.
+- Recommended use: define evaluator-benchmark ability dimensions.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,10 +9,17 @@ decide what to read before opening the 989-paper index or the product notes.
    and the current synthesis of the field.
 2. [`taxonomy.md`](taxonomy.md) — shared vocabulary for classifying agent memory
    systems and papers.
-3. [`research-radar.md`](research-radar.md) — workflow for turning papers and
-   products into ResearchItems, ImpactReports, experiments, and ADRs.
-4. [`products-landscape.md`](products-landscape.md) — product map by domain and
+3. [`research-radar.md`](research-radar.md) — workflow for turning papers,
+   products, and benchmark evidence into ResearchItems, ImpactReports,
+   experiments, and ADRs.
+4. [`benchmarks-landscape.md`](benchmarks-landscape.md) — benchmark map by
+   capability, usage type, and evidence independence.
+5. [`products-landscape.md`](products-landscape.md) — product map by domain and
    audience.
+6. [`product-architecture-diagrams.md`](product-architecture-diagrams.md) —
+   architecture diagrams for the current memory product notes.
+7. [`product-memory-architectures.md`](product-memory-architectures.md) —
+   cross-product memory architecture patterns and comparison tables.
 
 ## Concept docs
 
@@ -22,12 +29,16 @@ decide what to read before opening the 989-paper index or the product notes.
 | [`taxonomy.md`](taxonomy.md) | Cross-walk of external taxonomies and common memory-kernel responsibilities. |
 | [`meta-surveys.md`](meta-surveys.md) | External survey index from late 2025 through 2026 H1. |
 | [`signals.md`](signals.md) | Reverse-chronological release, comparison, and blog signal log. |
+| [`benchmarks-landscape.md`](benchmarks-landscape.md) | Benchmark usage landscape split by raw mentions, eval uses, vendor claims, and independent evidence. |
+| [`product-discovery-log.md`](product-discovery-log.md) | Multi-agent product discovery log with Tier A / Tier B / reject decisions. |
+| [`product-memory-architectures.md`](product-memory-architectures.md) | Cross-product architecture patterns across memory OS, graph, MCP/local, platform-managed, and personal memory. |
+| [`product-architecture-diagrams.md`](product-architecture-diagrams.md) | Mermaid architecture diagrams for product notes and public implementation patterns. |
 
 ## Research workflow
 
 | File | Purpose |
 |---|---|
-| [`research-radar.md`](research-radar.md) | Generic Radar loop: paper/product -> ResearchItem -> ImpactReport -> sandbox -> ADR. |
+| [`research-radar.md`](research-radar.md) | Generic Radar loop: paper/product/benchmark -> ResearchItem or BenchmarkItem -> ImpactReport -> sandbox -> ADR. |
 | [`information-sources.md`](information-sources.md) | Source catalog for papers, products, communities, and zh-CN information channels. |
 | [`related-work.md`](related-work.md) | Positioning against sibling agent-memory awesome-lists. |
 
@@ -36,9 +47,12 @@ decide what to read before opening the 989-paper index or the product notes.
 | File | Purpose |
 |---|---|
 | [`products-landscape.md`](products-landscape.md) | Agent-memory products grouped by domain and buyer/audience. |
+| [`product-discovery-log.md`](product-discovery-log.md) | Evidence index and inclusion-boundary record for product-search runs. |
 | [`ymem-binding/README.md`](ymem-binding/README.md) | Ymem-specific module names, stance, and radar bindings. Safe to skip if you only need the generic reading list. |
 
 The detailed paper index lives outside this directory at
 [`../papers/index.md`](../papers/index.md). Product notes live under
 [`../products/`](../products/), with archived source-page snapshots in
-[`../products/archives/`](../products/archives/).
+[`../products/archives/`](../products/archives/). Benchmark protocol notes live
+under [`../benchmarks/`](../benchmarks/), with usage events in
+[`../benchmarks/claims/claims.yaml`](../benchmarks/claims/claims.yaml).

--- a/docs/agent-memory-survey.md
+++ b/docs/agent-memory-survey.md
@@ -56,7 +56,9 @@ language: zh-CN
 
 ## 3. 评测体系
 
-(占位 — 待写)
+规范化 benchmark 记录见 [`../benchmarks/index.md`](../benchmarks/index.md);
+跨论文/产品使用事件和证据等级见
+[`benchmarks-landscape.md`](benchmarks-landscape.md)。
 
 四类能力(借用 MemoryAgentBench 的划分):
 
@@ -69,10 +71,10 @@ language: zh-CN
 
 | Benchmark | 笔记 | 覆盖能力 | 备注 |
 |---|---|---|---|
-| LongMemEval | [`papers/longmemeval.md`](../papers/longmemeval.md) | accurate retrieval / long-range | 经典基线 |
-| MemoryAgentBench | [`papers/memoryagentbench.md`](../papers/memoryagentbench.md) | 四种能力划分的来源 | 同上 |
-| LoCoMo | [`papers/locomo.md`](../papers/locomo.md) | 长对话记忆 | Mem0 ECAI 2025 横评的主要 benchmark |
-| ConvoMem | (papers/index)| 对话记忆 | 2025-12 新增 |
+| LongMemEval | [`benchmarks/longmemeval.md`](../benchmarks/longmemeval.md) | accurate retrieval / long-range | 经典基线 |
+| MemoryAgentBench | [`benchmarks/memoryagentbench.md`](../benchmarks/memoryagentbench.md) | 四种能力划分的来源 | 同上 |
+| LoCoMo | [`benchmarks/locomo.md`](../benchmarks/locomo.md) | 长对话记忆 | Mem0 ECAI 2025 横评的主要 benchmark |
+| ConvoMem | [`benchmarks/convomem.md`](../benchmarks/convomem.md) | 对话记忆 | 2025-12 新增 |
 | CloneMem | (papers/index)| AI clone / 长程一致性 | 2025-12 |
 | KnowMe-Bench | (papers/index)| digital companion | 2025-12 |
 | RealMem | (papers/index)| real-world 多模态交互 | 2025-12,arXiv 2601.06966 |
@@ -144,7 +146,7 @@ verbs。
 
 每次更新本综述时:
 
-1. 在 `papers/` 或 `products/` 新增/更新对应笔记;
+1. 在 `papers/`、`products/` 或 `benchmarks/` 新增/更新对应笔记;
 2. 如果对你 kernel 有结构性影响,在 [`../impact-reports/`](../impact-reports/)
    起一份 ImpactReport;
 3. 回到本文档,更新相关章节,标记新的 last_revised 日期。

--- a/docs/benchmarks-landscape.md
+++ b/docs/benchmarks-landscape.md
@@ -1,0 +1,126 @@
+---
+title: Benchmarks landscape — agent memory evaluation by capability and evidence
+date: 2026-06-11
+status: seed
+language: zh-CN
+---
+
+# Benchmark 全景:按能力 × 证据等级
+
+这页回答一个具体问题:**agent memory 领域哪些 benchmark 最常被论文和产品拿来
+互相衡量?这些使用是论文评测、厂商自报、独立复现,还是仅仅 survey 提及?**
+
+数据源是 [`../benchmarks/`](../benchmarks/) 和
+[`../benchmarks/claims/claims.yaml`](../benchmarks/claims/claims.yaml)。本页不
+做混合总榜,因为 LoCoMo、LongMemEval、ConvoMem、BEAM 等 benchmark 的任务、
+模型、judge 和样本量不可直接平均。
+
+## A. 分类地图
+
+| 领域 | Benchmark | 主要测什么 | 当前证据状态 |
+|---|---|---|---|
+| 长程对话记忆 | [`LongMemEval`](../benchmarks/longmemeval.md) | information extraction / knowledge update / temporal / abstention | full,多产品自报引用 |
+| 长程对话记忆 | [`LoCoMo`](../benchmarks/locomo.md) | factual recall / temporal / causal / multi-session | seed,产品横评最常见 |
+| 对话记忆规模曲线 | [`ConvoMem`](../benchmarks/convomem.md) | long-context vs block extraction vs RAG crossover | full,同时批评 LongMemEval/LoCoMo |
+| agent 记忆能力维度 | [`MemoryAgentBench`](../benchmarks/memoryagentbench.md) | retrieval / test-time learning / long-range / forgetting | seed,适合定义能力轴 |
+| 百万 token 规模 | [`BEAM`](../benchmarks/beam.md) | 1M/10M 长尺度记忆退化 | candidate,目前主要来自 Mem0 自报 |
+| 真实交互 / persona | RealMem / CloneMem / KnowMe-Bench / PersonaMem-v2 | real-world memory, identity continuity, companion personalization | candidate,先列入 backlog |
+| agent 任务 / 多 agent | LoCoBench-Agent / MemoryArena / MemBench | coding agent, shared memory conflict, write/manage 评测 | candidate,需升级 source note |
+
+## B. 初始交叉统计
+
+这些计数来自 seed ledger,只用于指导下一轮精读优先级。
+
+### B1. Raw mentions / usage events
+
+| Benchmark | Raw events | Notes |
+|---|---:|---|
+| LongMemEval | 5 | origin + Mem0 + Hindsight + Hy-Memory + ConvoMem critique counted by event type |
+| LoCoMo | 7 | origin + Mem0 paper/blog + Zep + Graphiti mention + MemoryOS + ConvoMem critique counted by event type |
+| ConvoMem | 2 | origin + baseline comparison |
+| BEAM | 2 | Mem0 BEAM 1M / 10M vendor claims |
+| MemoryAgentBench | 2 | origin + survey mention |
+| PersonaMem-v2 | 2 | Hy-Memory + TencentDB Agent Memory self-claims |
+| MemBench | 1 | survey mention |
+| MemoryArena | 1 | survey mention |
+
+### B2. Evaluation uses / baseline comparisons
+
+| Benchmark | Eval-use events | Evidence class |
+|---|---:|---|
+| LoCoMo | 1 | Mem0 paper affiliated evaluation; useful for paper analysis, not independent reproduction |
+| ConvoMem | 1 | Origin paper baseline comparison against Mem0-style RAG; useful for protocol/crossover analysis |
+
+### B3. Vendor claims
+
+| Benchmark | Vendor-claim events | Actors |
+|---|---:|---|
+| LoCoMo | 3 | Mem0 blog, Zep, MemoryOS |
+| LongMemEval | 3 | Mem0 blog, Hindsight, Hy-Memory |
+| BEAM | 2 | Mem0 BEAM 1M and 10M self-reports |
+| PersonaMem-v2 | 2 | Hy-Memory, TencentDB Agent Memory |
+
+### B4. Independent reproductions
+
+| Benchmark | Independent reproduction events | Notes |
+|---|---:|---|
+| LongMemEval / LoCoMo / BEAM / PersonaMem-v2 | 0 | Hindsight claims external reproduction, but no normalized independent source is in this repo yet |
+| ConvoMem | 0 | Current rows are origin-paper protocol and baseline comparison, not third-party reruns |
+
+### B5. Product-used benchmarks
+
+| Benchmark | Products currently using/claiming it | Evidence class |
+|---|---|---|
+| LoCoMo | Mem0, Zep, MemoryOS; Graphiti appears via Zep foundation note | vendor / affiliated claims, no normalized independent reproduction in repo |
+| LongMemEval | Mem0, Hindsight, Hy-Memory | vendor claims, Hindsight claims external reproduction but source not normalized |
+| BEAM | Mem0 | vendor self-claim only |
+| PersonaMem-v2 | Hy-Memory, TencentDB Agent Memory | vendor self-claim only |
+
+### B6. Paper-origin reuse
+
+| Benchmark | Reuse events outside origin | Reuse shape |
+|---|---:|---|
+| LoCoMo | 6 | Mem0 paper/blog, Zep, Graphiti foundation mention, MemoryOS, ConvoMem critique |
+| LongMemEval | 4 | Mem0 blog, Hindsight, Hy-Memory, ConvoMem critique |
+| BEAM | 2 | Mem0 vendor claims, source note still candidate |
+| PersonaMem-v2 | 2 | Hy-Memory and TencentDB Agent Memory vendor claims |
+| MemoryAgentBench | 1 | Survey mention only |
+
+### B7. Independent or methodological pressure
+
+| Benchmark | Pressure source | Interpretation |
+|---|---|---|
+| LongMemEval | ConvoMem critique | sample-size and filler-source critique, not a rerun |
+| LoCoMo | ConvoMem critique | small-conversation-count critique, not a rerun |
+| ConvoMem | own baseline comparison | strong protocol for cost/accuracy crossover, but synthetic data and Mem0-only RAG baseline caveat |
+
+## C. What Counts As Evidence
+
+| Evidence class | Use in this repo |
+|---|---|
+| `primary_pdf` | Can support benchmark protocol claims when the local note is full or source is directly cited. |
+| `primary_product_page` | Can support "vendor claims X"; cannot support independent performance conclusions. |
+| `archived_page` | Audit mirror for a product claim; not an independent source. |
+| `independent_report` | Needed before a claim becomes independent reproduction. |
+| `survey_mention` | Useful for discovery and prioritization, not score/ranking evidence. |
+
+## D. Next Upgrade Queue
+
+1. Upgrade LoCoMo from seed to full because it is the most product-used
+   benchmark in current notes.
+2. Upgrade BEAM source before using Mem0's 1M/10M claims in any decision.
+3. Upgrade PersonaMem-v2 because TencentDB Agent Memory and Hy-Memory both cite
+   PersonaMem-style claims.
+4. Promote MemoryArena and MemBench if multi-agent conflict or write/manage
+   evaluation becomes a kernel priority.
+5. Add independent reproduction rows only when the source gives enough setup
+   detail to distinguish reruns from marketing summaries.
+
+## E. Maintenance Contract
+
+- New benchmark protocol -> add or update `../benchmarks/<slug>.md`.
+- New product score -> add a `vendor_claim` event, not a leaderboard row.
+- New paper rerun -> add `uses_for_eval` or `baseline_comparison`.
+- New third-party rerun -> add `independent_reproduction`.
+- New methodological objection -> add `critique`.
+- Any chart or "most used" statement must show `independence_class`.

--- a/docs/information-sources.md
+++ b/docs/information-sources.md
@@ -1,6 +1,6 @@
 ---
 title: Information sources for the agent-memory Research Radar
-date: 2026-05-19
+date: 2026-06-11
 status: working-spec
 language: zh-CN
 ---
@@ -43,6 +43,24 @@ language: zh-CN
 | memory 专门 | Mem0 / Letta / Zep / Cognee / Graphiti 博客与 changelog | 直接对标 memory kernel |
 | 上下文协议 | MCP spec 与官方 server 列表 | memory 与 tool / prompt 的边界 |
 | IDE/Agent host | Cursor / Windsurf / Replit / Devin / Claude Code blog | memory 在真实 agent 工作流里的露出形态 |
+
+### 3.1 Memory 产品搜索专用源(2026-06 补充)
+
+2026-06-11 的产品补漏发现,单靠传统 "Mem0 / Zep / Letta" 视角会漏掉平台 managed
+memory、coding-agent memory、MCP memory server 和国内云平台。后续产品搜索要把
+这些源作为固定 lane:
+
+| Lane | 主源 | 关注点 |
+|---|---|---|
+| Official/vendor | EverMind/EverOS、Mem0、Zep、Supermemory、Hindsight、LangMem、Letta、Cognee 官网/docs/release | 一等 memory 能力、release 状态、官方 benchmark 是否自报 |
+| Hyperscaler/platform | AWS Bedrock AgentCore、Google Agent Platform Memory Bank、Microsoft Foundry、Cloudflare Agents、Oracle AI Agent Memory、Alibaba Bailian | scope、TTL、CRUD、strategy、IAM/RBAC、preview/private beta 标签 |
+| GitHub/OSS | GitHub topics/trending + MemOS、Redis AMS、OpenViking、PowerMem、Basic Memory、Honcho、ByteRover | license、stars 只是弱信号;优先看 README/API/docs 是否定义 memory lifecycle |
+| MCP/catalog | Glama、MCP Market、LobeHub、mcpservers、Claude/Cursor/Codex memory server lists | catalog 只能做发现入口,必须回到 canonical repo/docs 验证 |
+| Academic-to-product | `papers/index.md`、arXiv、OpenReview、论文作者 GitHub | 找"论文已有但产品未入库"的 EverMemOS、MemOS、MIRIX、HippoRAG-like 条目 |
+| Domestic | 腾讯云、混元 Hy-Memory、OceanBase PowerMem、火山 OpenViking、阿里百炼、百度千帆、智谱/Kimi/豆包 | 官方中文文档优先,媒体报道只做补充 |
+| Adjacent product | PKM、企业知识库、数字伴侣、客服/销售、coding agents | 只在显式暴露 durable/editable memory 时进入轻量索引 |
+
+产品入库和拒绝理由记录到 [`product-discovery-log.md`](product-discovery-log.md)。
 
 ## 4. 同生态 awesome-list
 

--- a/docs/product-architecture-diagrams.md
+++ b/docs/product-architecture-diagrams.md
@@ -1,0 +1,843 @@
+---
+title: Memory product architecture diagrams
+date: 2026-06-11
+status: working-note
+language: zh-CN
+---
+
+# Memory 产品架构图
+
+范围:本页覆盖当前 `products/` 下的 34 个产品/模式笔记。图是基于公开页面、
+GitHub README、论文摘要与本仓快照的**架构归纳**;闭源 SaaS 与厂商内建记忆没有
+底层实现披露时,图只表达可观察产品边界和合理推断,不当作内部实现事实。
+
+跨产品架构模式的总览与对比表见
+[`product-memory-architectures.md`](product-memory-architectures.md);本页保留
+逐产品/逐模式 Mermaid 图。
+
+## 1. 总体分型
+
+```mermaid
+flowchart TB
+    Products["Memory products"]
+    Dedicated["独立 memory layer / SDK"]
+    Runtime["Agent runtime 内嵌记忆"]
+    Graph["Temporal / ontology graph memory"]
+    Layered["分层认知 / OS-style memory"]
+    Personal["个人可携带 memory vault"]
+    Vendor["厂商内建 managed memory"]
+    Wiki["Markdown / wiki 编译型记忆"]
+    Coding["MCP / coding-agent memory"]
+    DBMemory["DB / context database memory"]
+
+    Products --> Dedicated
+    Products --> Runtime
+    Products --> Graph
+    Products --> Layered
+    Products --> Personal
+    Products --> Vendor
+    Products --> Wiki
+    Products --> Coding
+    Products --> DBMemory
+
+    Dedicated --> Mem0["Mem0"]
+    Dedicated --> Hindsight["Hindsight"]
+    Dedicated --> Supermemory["Supermemory"]
+    Dedicated --> RedisAMS["Redis Agent Memory Server"]
+    Dedicated --> PowerMem["PowerMem"]
+    Dedicated --> Honcho["Honcho"]
+    Runtime --> LangMem["LangMem"]
+    Runtime --> Letta["Letta"]
+    Runtime --> MemGPT["MemGPT"]
+    Graph --> Zep["Zep"]
+    Graph --> Graphiti["Graphiti"]
+    Graph --> Cognee["Cognee"]
+    Graph --> OpenViking["OpenViking"]
+    Layered --> TencentDB["TencentDB Agent Memory"]
+    Layered --> HyMemory["Hy-Memory"]
+    Layered --> MemoryOS["MemoryOS"]
+    Layered --> EverOS["EverOS"]
+    Layered --> MemOS["MemOS"]
+    Layered --> AMEM["A-MEM"]
+    Layered --> MemX["MemX"]
+    Personal --> Anuma["Anuma"]
+    Personal --> Kinic["Kinic"]
+    Personal --> PersonalAI["Personal AI"]
+    Vendor --> OpenAI["OpenAI ChatGPT Memory"]
+    Vendor --> ClaudeDreams["Claude Dreams"]
+    Vendor --> AWS["AWS AgentCore Memory"]
+    Vendor --> Google["Google Memory Bank"]
+    Vendor --> Microsoft["Microsoft Foundry Memory"]
+    Vendor --> Cloudflare["Cloudflare Agent Memory"]
+    Vendor --> Oracle["Oracle AI Agent Memory"]
+    Vendor --> Alibaba["Alibaba Bailian Memory"]
+    Wiki --> KarpathyWiki["Karpathy LLM Wiki"]
+    Coding --> BasicMemory["Basic Memory"]
+    Coding --> ByteRover["ByteRover"]
+    DBMemory --> RedisAMS
+    DBMemory --> Oracle
+    DBMemory --> OpenViking
+```
+
+## 2. 独立 memory layer / SDK
+
+### Mem0
+
+核心是 conversation/message 输入经 LLM 抽取成 memory,按 `user/session/agent`
+等 scope 写入向量/元数据/实体链接索引;查询时做多信号召回,再把 memory 注入
+应用上下文。
+
+```mermaid
+flowchart LR
+    App["Agent / app"]
+    Add["mem0.add(messages, scope)"]
+    Extract["LLM fact extraction"]
+    Store["Memory store: vectors + metadata + entity links"]
+    Search["mem0.search(query, filters)"]
+    Fusion["Semantic + BM25 + entity fusion"]
+    Context["Retrieved memories"]
+    LLM["Application LLM response"]
+
+    App --> Add --> Extract --> Store
+    App --> Search --> Fusion --> Context --> LLM
+    Store --> Fusion
+    LLM --> Add
+```
+
+### Hindsight
+
+Hindsight 把记忆放进 memory banks,写入路径分成 world facts 与 experiences;
+`retain / recall / reflect` 是主要 API。检索并行使用语义、关键词、图关系和时间
+过滤,再融合/重排。
+
+```mermaid
+flowchart LR
+    Agent["Agent / LLM wrapper"]
+    Retain["retain(content, bank)"]
+    Extract["LLM extracts facts, entities, relations, time"]
+    Normalize["Normalize to canonical entities / time series / indexes"]
+    Bank["Memory bank"]
+    Paths["World facts + experiences"]
+    Recall["recall(query)"]
+    Reflect["reflect(query)"]
+    Retrieval["Semantic + BM25 + graph + temporal"]
+    Rerank["RRF + cross-encoder rerank"]
+    Output["Memories / observations"]
+
+    Agent --> Retain --> Extract --> Normalize --> Bank --> Paths
+    Agent --> Recall --> Retrieval --> Rerank --> Output --> Agent
+    Agent --> Reflect --> Retrieval
+    Bank --> Retrieval
+```
+
+### Supermemory
+
+Supermemory 更像 context cloud:connectors、extractors、profiles、RAG 和 memory
+共享同一张可查询图;agent 通过 API/MCP/插件实时遍历图获得上下文。
+
+```mermaid
+flowchart LR
+    Sources["Slack / Notion / Drive / Gmail / GitHub / files"]
+    Connectors["Connectors + sync"]
+    Extractors["Extractors: PDF / web / image / audio / files"]
+    Understand["User understanding + entity model"]
+    Graph["Unified queryable graph: memory + RAG + profiles"]
+    Retrieve["SuperRAG / graph traversal"]
+    Interfaces["API / SDK / MCP / plugins / filesystem"]
+    Agent["Agent"]
+
+    Sources --> Connectors --> Extractors --> Understand --> Graph
+    Agent --> Interfaces --> Retrieve --> Graph
+    Graph --> Retrieve --> Agent
+```
+
+## 3. Temporal / ontology graph memory
+
+### Zep
+
+Zep 是托管 agent memory / context engineering 层。输入可以是聊天、业务数据、
+应用事件和文档;系统抽取 entity/fact,维护 temporal context graph,在事实变化时
+保留旧事实的时间边界并让最新事实进入上下文。
+
+```mermaid
+flowchart LR
+    Inputs["Chat history / business data / events / documents"]
+    ZepAPI["Zep thread + graph APIs"]
+    Extract["Entity and relationship extraction"]
+    TKG["Temporal context graph"]
+    Invalidator["Fact invalidation + history preservation"]
+    Context["Token-efficient context assembly"]
+    Agent["Agent"]
+    Governance["Access control / retention / provenance / audit"]
+
+    Inputs --> ZepAPI --> Extract --> TKG
+    TKG --> Invalidator --> Context --> Agent
+    Governance --- TKG
+    Agent --> ZepAPI
+```
+
+### Graphiti
+
+Graphiti 是 Zep 的开源 temporal knowledge graph 底座。它把 episodes 转为 entities
+与带有效时间窗的 facts,使用语义向量、BM25 和图遍历三路混合检索。
+
+```mermaid
+flowchart LR
+    Episodes["Episodes: text / JSON / messages"]
+    Add["Graphiti add_episode"]
+    Extract["LLM extraction"]
+    Nodes["Entities / communities"]
+    Edges["Facts / relationships with validity windows"]
+    Backend["Graph backend: Neo4j / Neptune / FalkorDB / Kuzu"]
+    Query["Temporal + semantic + keyword + graph query"]
+    Results["Edges / nodes / context"]
+    Agent["Agent / MCP client"]
+
+    Episodes --> Add --> Extract
+    Extract --> Nodes --> Backend
+    Extract --> Edges --> Backend
+    Agent --> Query --> Backend --> Results --> Agent
+```
+
+### Cognee
+
+Cognee 的公开架构是 Capture -> Model -> Recall:接数据源,解析/嵌入/保留
+provenance;再抽取实体、关系、ontology、权限和 feedback,形成跨 agent 的共享
+memory layer。
+
+```mermaid
+flowchart LR
+    Sources["Files / warehouses / vector stores / APIs / Slack / chat logs"]
+    Capture["Capture: parse, chunk, embed, provenance"]
+    Model["Model: entities, relations, ontologies, permissions, feedback"]
+    Memory["Graph memory / world model"]
+    Recall["Recall tuning + memory API"]
+    Agents["Claude Code / LangGraph / OpenClaw / MCP / custom agents"]
+
+    Sources --> Capture --> Model --> Memory --> Recall --> Agents
+    Agents --> Recall
+```
+
+## 4. Agent runtime 内嵌记忆
+
+### Letta
+
+Letta 继承 MemGPT 的 stateful agent 思路:agent state 持有 memory blocks
+(如 `human`、`persona`)与 tools;应用通过 API/SDK 创建 agent 并发送消息,记忆是
+agent runtime 的一部分。
+
+```mermaid
+flowchart LR
+    App["Application / Letta Code"]
+    API["Letta API / SDK"]
+    AgentState["Stateful agent"]
+    Blocks["Memory blocks: human / persona / custom"]
+    Tools["Tools"]
+    Model["Model"]
+    Messages["Message loop"]
+
+    App --> API --> AgentState
+    AgentState --> Blocks
+    AgentState --> Tools
+    AgentState --> Model
+    Messages --> AgentState --> Messages
+    Blocks --> Model
+    Tools --> Model
+```
+
+### LangMem
+
+LangMem 是 LangGraph/LangChain 生态的 memory primitive:hot path 由 agent 工具
+直接管理/搜索记忆;background path 自动抽取、整理和更新知识,底层 store 可替换。
+
+```mermaid
+flowchart LR
+    Agent["LangGraph agent"]
+    ManageTool["create_manage_memory_tool"]
+    SearchTool["create_search_memory_tool"]
+    Store["Store abstraction: InMemory / Postgres / custom"]
+    Background["Background memory manager"]
+    Extract["Extract / consolidate / update"]
+    Context["Relevant memories"]
+
+    Agent --> ManageTool --> Store
+    Agent --> SearchTool --> Store --> Context --> Agent
+    Store --> Background --> Extract --> Store
+```
+
+### MemGPT
+
+MemGPT 是 OS-style virtual context management:把有限 context window 当主内存,
+把外部存储当慢内存,模型通过 function calls 显式把信息分页进出上下文。
+
+```mermaid
+flowchart LR
+    User["User / task"]
+    LLM["LLM processor"]
+    Main["Primary memory: context window"]
+    External["External memory: archival / recall store"]
+    Paging["Function-call memory ops"]
+    Response["Response"]
+
+    User --> LLM
+    LLM --> Main
+    Main <--> Paging <--> External
+    LLM --> Response
+```
+
+## 5. 分层认知 / OS-style memory
+
+### TencentDB Agent Memory
+
+TencentDB Agent Memory 有两条关键线:短期 context offloading 用 Mermaid canvas
+保留任务结构并可回溯原始日志;长期 personalization 走 L0-L3 语义金字塔。
+
+```mermaid
+flowchart TB
+    subgraph ShortTerm["Short-term symbolic memory"]
+        Logs["Verbose tool logs"]
+        Refs["refs/*.md raw logs"]
+        Jsonl["Step summaries / jsonl"]
+        Canvas["Mermaid task canvas with node_id"]
+        AgentContext["Light context injection"]
+        Logs --> Refs
+        Logs --> Jsonl --> Canvas --> AgentContext
+        AgentContext -.-> Refs
+    end
+
+    subgraph LongTerm["Long-term layered memory"]
+        L0["L0 Conversation"]
+        L1["L1 Atom facts"]
+        L2["L2 Scenario blocks"]
+        L3["L3 Persona profile"]
+        L0 --> L1 --> L2 --> L3
+        L3 -.-> L1
+    end
+
+    Agent["OpenClaw / Hermes agent"] --> ShortTerm
+    Agent --> LongTerm
+```
+
+### Hy-Memory
+
+Hy-Memory 是 OpenClaw 插件。OpenClaw pre-chat 同步召回,post-chat 异步捕获;Python
+sidecar 用 Hunyuan/兼容模型抽取,Chroma/BGE-M3 做向量层,上层组织为 6-layer
+cognitive memory。
+
+```mermaid
+flowchart LR
+    OpenClaw["OpenClaw agents"]
+    Pre["Pre-chat autoRecall"]
+    Sidecar["Python sidecar memory server"]
+    VDB["Chroma vector store"]
+    LLM["Hunyuan / OpenAI-compatible extractor"]
+    Layers["L1 raw traces -> L2 atomic facts -> L3 identity profile -> L4-L6 mind and intent"]
+    Post["Post-chat async autoCapture"]
+    Prompt["Facts inserted into system instructions"]
+
+    OpenClaw --> Pre --> Sidecar --> VDB --> Prompt --> OpenClaw
+    OpenClaw --> Post --> Sidecar --> LLM --> Layers --> VDB
+```
+
+### MemoryOS
+
+MemoryOS 用 short-term、mid-term、long-term 三层记忆,由 storage、updating、
+retrieval、generation 模块编排;MCP server 暴露 add/retrieve/profile 三类工具。
+
+```mermaid
+flowchart LR
+    Client["Agent client / MCP"]
+    Tools["add_memory / retrieve_memory / get_user_profile"]
+    Orchestrator["MemoryOS main orchestrator"]
+    Short["Short-term memory"]
+    Mid["Mid-term consolidation"]
+    Long["Long-term persona / knowledge"]
+    Updater["Updater"]
+    Retriever["Retriever"]
+    Generator["Generation context"]
+
+    Client --> Tools --> Orchestrator
+    Orchestrator --> Short --> Updater --> Mid --> Updater --> Long
+    Orchestrator --> Retriever
+    Short --> Retriever
+    Mid --> Retriever
+    Long --> Retriever --> Generator --> Client
+```
+
+### A-MEM
+
+A-MEM 把 memory 当 Zettelkasten 式 note network。新增/更新 note 时,系统通过
+ChromaDB 找语义关系,更新 tags/context/keywords,并建立 note 间链接。
+
+```mermaid
+flowchart LR
+    Agent["LLM agent"]
+    Add["add_note / update"]
+    Note["Structured memory note"]
+    Embed["Embedding model"]
+    Chroma["ChromaDB vector store"]
+    Evolve["Memory evolution"]
+    Links["Semantic links + tags + categories + keywords"]
+    Search["search_agentic / read"]
+
+    Agent --> Add --> Note --> Embed --> Chroma
+    Chroma --> Evolve --> Links --> Chroma
+    Agent --> Search --> Chroma --> Agent
+```
+
+### MemX
+
+MemX 是本地优先单文件 memory。查询走 embed -> dual recall -> RRF -> 四因子
+rerank -> reject gate;低置信时直接返回空结果。
+
+```mermaid
+flowchart LR
+    CLI["AI assistant / CLI"]
+    DB["Single libSQL memory.db"]
+    Query["Query"]
+    Embed["Embedding model"]
+    Vector["Vector search"]
+    Keyword["Keyword search"]
+    RRF["RRF fusion"]
+    Rerank["Semantic + recency + frequency + importance"]
+    Gate["Reject gate"]
+    Result["Memory hit or empty"]
+
+    CLI --> DB
+    CLI --> Query --> Embed
+    Embed --> Vector --> RRF
+    Query --> Keyword --> RRF
+    DB --> Vector
+    DB --> Keyword
+    RRF --> Rerank --> Gate --> Result --> CLI
+```
+
+## 6. 个人可携带 memory vault
+
+### Anuma
+
+Anuma 的公开架构强调两层:设备端加密 private memory 与跨模型 interoperability。
+服务器负责路由到模型,但产品声明不持有可读 plaintext memory。
+
+```mermaid
+flowchart LR
+    User["User"]
+    Device["Device memory vault"]
+    Encrypt["AES-256 on-device encryption"]
+    Controls["Add / edit / private / delete / export"]
+    Router["Anuma routing layer"]
+    Policy["Per-model sharing policy"]
+    Models["ChatGPT / Claude / Gemini / DeepSeek / others"]
+    Context["Selected portable context"]
+
+    User --> Controls --> Device --> Encrypt
+    Device --> Policy --> Context --> Router --> Models
+    Models --> Router --> User
+```
+
+### Kinic
+
+Kinic 把 personal AI memory 与 verifiable datastore 绑定:浏览器插件收集数据,
+个人 vector DB 运行在 Internet Computer canister,由用户控制 key,支持更新/删除和
+AI-powered query。
+
+```mermaid
+flowchart LR
+    Plugin["Browser plugin"]
+    Sources["Emails / socials / bookmarks / notes / documents"]
+    Canister["Personal canister smart contract"]
+    VectorDB["Kinic Vector DB"]
+    Crypto["Keys / biometrics / zero-knowledge claims"]
+    Query["Trusted AI-powered query"]
+    Agents["AI agents / LLMs"]
+    Market["Shared or rented memory stores"]
+
+    Sources --> Plugin --> Canister --> VectorDB
+    Crypto --- Canister
+    Agents --> Query --> VectorDB --> Agents
+    VectorDB --> Market
+```
+
+### Personal AI
+
+Personal AI 的产品分三层:My AI 是终端 assistant,Persona Studio 是配置/部署
+persona 的 builder,Memory Core 是 encode/stabilize/recall/evolve 的基础设施层。
+
+```mermaid
+flowchart TB
+    MyAI["Application: My AI"]
+    Studio["AI builder platform: Persona Studio"]
+    Core["Infrastructure: Memory Core"]
+    Encode["Encode"]
+    Stabilize["Stabilize"]
+    Recall["Recall"]
+    Evolve["Evolve"]
+    Personas["Personality / knowledge domains / memory behavior / guardrails"]
+    Users["End users / AI builders / developers"]
+
+    Users --> MyAI --> Core
+    Users --> Studio --> Personas --> Core
+    Core --> Encode --> Stabilize --> Recall --> Evolve --> Core
+```
+
+## 7. 厂商内建 managed memory
+
+### OpenAI ChatGPT Memory
+
+OpenAI 的 ChatGPT memory 是账号级 managed memory。公开说明显示它会从聊天、
+文件、连接应用和 saved memories/past chats 中提取/综合相关上下文,用户通过
+Memory controls、Memory summary 和 sources 管理。
+
+```mermaid
+flowchart LR
+    Chats["Past chats"]
+    Saved["Saved memories"]
+    Files["Files / connected apps where available"]
+    MemorySystem["ChatGPT managed memory synthesis"]
+    Summary["Memory summary + controls"]
+    Sources["Memory sources shown in responses"]
+    Chat["Current chat"]
+    Response["Personalized response"]
+
+    Chats --> MemorySystem
+    Saved --> MemorySystem
+    Files --> MemorySystem
+    MemorySystem --> Summary
+    Chat --> MemorySystem --> Response
+    MemorySystem --> Sources --> Response
+```
+
+### Claude Dreams
+
+Claude Dreams 是离线整理 job,不是在线检索层。它读取已有 memory store 和过去
+sessions,输出一个新的 memory store;输入 store 不被就地修改,适合审阅后替换或丢弃。
+
+```mermaid
+flowchart LR
+    StoreIn["Input memory store"]
+    Sessions["1-100 past sessions"]
+    Dream["Dream async job"]
+    Synthesis["Deduplicate / merge / replace stale facts / surface insights"]
+    StoreOut["Output memory store"]
+    Review["Review via API / Console"]
+    Future["Attach to future sessions"]
+
+    StoreIn --> Dream
+    Sessions --> Dream --> Synthesis --> StoreOut --> Review --> Future
+    StoreIn -.-> Review
+```
+
+## 8. Markdown / wiki 编译型记忆
+
+### Karpathy LLM Wiki
+
+LLM Wiki 不是 SaaS 产品,而是一种 personal knowledge architecture:raw sources
+只读,LLM 持续维护 wiki 这个中间表示,AGENTS/CLAUDE schema 约束维护协议,再通过
+index/log/lint 保持健康。
+
+```mermaid
+flowchart LR
+    Raw["Raw sources: immutable documents"]
+    Schema["Schema: AGENTS.md / CLAUDE.md conventions"]
+    Agent["LLM agent maintainer"]
+    Wiki["Generated markdown wiki"]
+    Index["index.md"]
+    Log["log.md"]
+    Lint["Periodic lint: contradictions / stale pages / orphans"]
+    Query["Questions / outputs"]
+    Human["Human reader in Obsidian / git"]
+
+    Raw --> Agent
+    Schema --> Agent
+    Agent --> Wiki
+    Wiki --> Index
+    Wiki --> Log
+    Wiki --> Lint --> Agent
+    Human --> Query --> Agent --> Wiki
+    Wiki --> Human
+```
+
+## 9. Memory OS / layered cognition 扩展
+
+### EverOS
+
+```mermaid
+flowchart LR
+    Inputs["Messages / images / docs / PDFs / URLs"]
+    Add["EverOS add memory"]
+    Tag["Auto-tag Profile / Episodic / Skill"]
+    Case["Case traces"]
+    Distill["Offline skill distillation"]
+    Store["Markdown-exportable memory store"]
+    Retrieve["mRAG retrieval"]
+    Agents["Claude Code / Codex / OpenClaw / MCP agents"]
+
+    Inputs --> Add --> Tag --> Store
+    Agents --> Case --> Distill --> Store
+    Agents --> Retrieve --> Store --> Agents
+```
+
+### MemOS
+
+```mermaid
+flowchart LR
+    Agent["LLM / AI agent"]
+    Events["Interactions / tasks / skills"]
+    Extract["Memory extraction"]
+    OS["MemOS memory resource manager"]
+    Hybrid["Hybrid retrieval index"]
+    Skill["Cross-task skill reuse"]
+    Context["Retrieved memory context"]
+
+    Agent --> Events --> Extract --> OS
+    OS --> Hybrid --> Context --> Agent
+    OS --> Skill --> Context
+```
+
+## 10. Platform-managed memory
+
+### Cloudflare Agent Memory
+
+```mermaid
+flowchart LR
+    Agent["Cloudflare Agent"]
+    Session["Session API"]
+    History["Conversation history tree"]
+    Blocks["Context memory blocks"]
+    SQLite["SQLite / provider-backed store"]
+    Search["FTS / custom searchable provider"]
+    Prompt["System prompt injection"]
+
+    Agent --> Session
+    Session --> History --> SQLite
+    Session --> Blocks --> SQLite
+    Blocks --> Search --> Prompt --> Agent
+```
+
+### AWS Bedrock AgentCore Memory
+
+```mermaid
+flowchart LR
+    Agent["AgentCore agent"]
+    Events["Session events"]
+    Short["Short-term memory"]
+    Strategy["Long-term memory strategy"]
+    Extract["Extract insights / preferences / facts / summaries"]
+    Store["Managed memory resource"]
+    Recall["Cross-session recall"]
+
+    Agent --> Events --> Short --> Store
+    Events --> Strategy --> Extract --> Store
+    Store --> Recall --> Agent
+```
+
+### Google Agent Platform Memory Bank
+
+```mermaid
+flowchart LR
+    Conversation["User-agent conversation"]
+    Scope["Scope: agent + user"]
+    Extract["Async memory generation"]
+    Bank["Managed Memory Bank"]
+    Govern["TTL / revisions / IAM / poisoning controls"]
+    Retrieve["Scoped retrieval"]
+    Agent["Agent Platform app"]
+
+    Conversation --> Scope --> Extract --> Bank
+    Govern --- Bank
+    Bank --> Retrieve --> Agent
+```
+
+### Microsoft Foundry Agent Service Memory
+
+```mermaid
+flowchart LR
+    Agent["Foundry agent"]
+    Tools["remember / forget / memory tools"]
+    Scope["Request scope"]
+    Items["Memory items"]
+    TTL["Default TTL / lifecycle"]
+    Types["Profile / summaries / procedural memory"]
+    Context["Retrieved context"]
+
+    Agent --> Tools --> Scope --> Items
+    Items --> TTL
+    Items --> Types --> Context --> Agent
+```
+
+### Oracle AI Agent Memory
+
+```mermaid
+flowchart LR
+    Agent["Enterprise agent"]
+    Short["Thread context cards / summaries"]
+    Long["add / search workflows"]
+    DB["Oracle AI Database"]
+    Providers["LLM / embedding providers"]
+    MCP["MCP server / external frameworks"]
+    Governance["Auth, scoping, database governance"]
+
+    Agent --> Short --> DB
+    Agent --> Long --> DB
+    Providers --> Long
+    DB --> MCP --> Agent
+    Governance --- DB
+```
+
+### Alibaba Bailian Memory Library
+
+```mermaid
+flowchart LR
+    App["Agent app"]
+    Dialogue["Historical dialogue"]
+    Add["AddMemory"]
+    Extract["Fragments + user profile extraction"]
+    Library["Bailian memory library / memoryId"]
+    Search["SearchMemory"]
+    Prompt["Prompt injection by app"]
+
+    App --> Dialogue --> Add --> Extract --> Library
+    App --> Search --> Library --> Prompt --> App
+```
+
+## 11. MCP / local-first / coding-agent memory
+
+### Redis Agent Memory Server
+
+```mermaid
+flowchart LR
+    Agent["Agent / app / MCP client"]
+    API["REST API / MCP / SDK"]
+    Working["Working memory"]
+    Long["Long-term memory"]
+    Extract["Extraction / grounding / dedup / edit"]
+    Search["Semantic + keyword + hybrid search"]
+    Redis["Redis-backed store"]
+
+    Agent --> API
+    API --> Working --> Redis
+    API --> Extract --> Long --> Redis
+    Redis --> Search --> API --> Agent
+```
+
+### OpenViking
+
+```mermaid
+flowchart LR
+    Sources["Memory / resources / skills"]
+    FS["viking:// filesystem"]
+    Layers["L0 abstracts / L1 overviews / L2 full details"]
+    Session["Session commit"]
+    Six["Profile, preferences, entities, events, cases, patterns"]
+    Retrieve["Directory recursive retrieval"]
+    Agent["OpenClaw / OpenCode / MCP agent"]
+
+    Sources --> FS --> Layers
+    Agent --> Session --> Six --> FS
+    Agent --> Retrieve --> FS --> Agent
+```
+
+### PowerMem
+
+```mermaid
+flowchart LR
+    Clients["CLI / HTTP / MCP / IDE plugins"]
+    Memory["PowerMem Memory API"]
+    Extract["LLM extraction + auto-merge"]
+    Exp["Experience layer"]
+    Skill["Skill distillation"]
+    Hybrid["Vector + full-text + graph retrieval"]
+    Store["OceanBase / seekdb / SQLite / Postgres"]
+
+    Clients --> Memory --> Extract --> Exp --> Skill --> Store
+    Store --> Hybrid --> Memory --> Clients
+```
+
+### Basic Memory
+
+```mermaid
+flowchart LR
+    Human["Human editor"]
+    Agent["AI assistant / MCP client"]
+    Markdown["Plain Markdown files"]
+    Graph["Semantic knowledge graph"]
+    Search["Meaning search + wikilinks"]
+    Cloud["Optional cloud sync / backups"]
+
+    Human --> Markdown
+    Agent --> Markdown
+    Markdown --> Graph --> Search --> Agent
+    Markdown --> Cloud
+```
+
+### ByteRover
+
+```mermaid
+flowchart LR
+    Agents["Claude Code / Codex / Cursor / other coding agents"]
+    CLI["brv CLI / MCP"]
+    Events["Project decisions / code activity / tasks"]
+    Tree["Project context tree"]
+    Index["Recall index"]
+    Context["Portable coding-agent context"]
+
+    Agents --> CLI --> Events --> Tree --> Index --> Context --> Agents
+```
+
+### Honcho
+
+```mermaid
+flowchart LR
+    App["Agent app"]
+    Session["Sessions / messages / documents"]
+    Peers["Peers: users, agents, groups, projects"]
+    Reason["Background reasoning"]
+    Rep["Peer representations / conclusions"]
+    Search["Hybrid search / session context"]
+    Inject["Prompt-ready context"]
+
+    App --> Session --> Peers
+    Session --> Reason --> Rep
+    Session --> Search
+    Rep --> Inject --> App
+    Search --> Inject
+```
+
+## 12. 证据索引
+
+| 产品 | 本仓笔记 | 上游主源 |
+|---|---|---|
+| Mem0 | [`../products/mem0.md`](../products/mem0.md) | <https://github.com/mem0ai/mem0> |
+| Zep | [`../products/zep.md`](../products/zep.md) | <https://www.getzep.com> |
+| Graphiti | [`../products/graphiti.md`](../products/graphiti.md) | <https://github.com/getzep/graphiti> |
+| Cognee | [`../products/cognee.md`](../products/cognee.md) | <https://www.cognee.ai/> |
+| Letta | [`../products/letta.md`](../products/letta.md) | <https://github.com/letta-ai/letta> |
+| LangMem | [`../products/langmem.md`](../products/langmem.md) | <https://langchain-ai.github.io/langmem/> |
+| Supermemory | [`../products/supermemory.md`](../products/supermemory.md) | <https://supermemory.ai/> |
+| Hindsight | [`../products/hindsight.md`](../products/hindsight.md) | <https://github.com/vectorize-io/hindsight> |
+| TencentDB Agent Memory | [`../products/tencentdb-agent-memory.md`](../products/tencentdb-agent-memory.md) | <https://github.com/Tencent/TencentDB-Agent-Memory> |
+| EverOS | [`../products/everos.md`](../products/everos.md) | <https://evermind.ai/everos> |
+| MemOS | [`../products/memos.md`](../products/memos.md) | <https://github.com/MemTensor/MemOS> |
+| Redis Agent Memory Server | [`../products/redis-agent-memory-server.md`](../products/redis-agent-memory-server.md) | <https://redis.github.io/agent-memory-server/> |
+| PowerMem | [`../products/powermem.md`](../products/powermem.md) | <https://github.com/oceanbase/powermem> |
+| Basic Memory | [`../products/basic-memory.md`](../products/basic-memory.md) | <https://docs.basicmemory.com/> |
+| ByteRover | [`../products/byterover.md`](../products/byterover.md) | <https://www.byterover.dev/> |
+| Honcho | [`../products/honcho.md`](../products/honcho.md) | <https://github.com/plastic-labs/honcho> |
+| OpenViking | [`../products/openviking.md`](../products/openviking.md) | <https://volcengine-openviking.mintlify.app/> |
+| Hy-Memory | [`../products/hy-memory.md`](../products/hy-memory.md) | <https://hy-memory.com/> |
+| MemoryOS | [`../products/memoryos.md`](../products/memoryos.md) | <https://github.com/BAI-LAB/MemoryOS> |
+| A-MEM | [`../products/a-mem.md`](../products/a-mem.md) | <https://github.com/agiresearch/A-mem> |
+| MemX | [`../products/memx.md`](../products/memx.md) | <https://memx.me/> |
+| Anuma | [`../products/anuma.md`](../products/anuma.md) | <https://www.anuma.ai/ai-memory> |
+| Kinic | [`../products/kinic.md`](../products/kinic.md) | <https://www.kinic.io/> |
+| Personal AI | [`../products/personal-ai.md`](../products/personal-ai.md) | <https://www.personal.ai/products> |
+| OpenAI Memory | [`../products/openai-memory.md`](../products/openai-memory.md) | <https://help.openai.com/en/articles/8590148> |
+| Claude Dreams | [`../products/claude-dreams.md`](../products/claude-dreams.md) | <https://platform.claude.com/docs/en/managed-agents/dreams> |
+| Cloudflare Agent Memory | [`../products/cloudflare-agent-memory.md`](../products/cloudflare-agent-memory.md) | <https://blog.cloudflare.com/introducing-agent-memory/> |
+| AWS AgentCore Memory | [`../products/aws-agentcore-memory.md`](../products/aws-agentcore-memory.md) | <https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/memory.html> |
+| Google Memory Bank | [`../products/google-memory-bank.md`](../products/google-memory-bank.md) | <https://docs.cloud.google.com/gemini-enterprise-agent-platform/scale/memory-bank> |
+| Microsoft Foundry Memory | [`../products/microsoft-foundry-memory.md`](../products/microsoft-foundry-memory.md) | <https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/what-is-memory> |
+| Oracle AI Agent Memory | [`../products/oracle-ai-agent-memory.md`](../products/oracle-ai-agent-memory.md) | <https://docs.oracle.com/en/database/oracle/agent-memory/26.4/agmea/about.html> |
+| Alibaba Bailian Memory | [`../products/alibaba-bailian-memory.md`](../products/alibaba-bailian-memory.md) | <https://help.aliyun.com/zh/model-studio/memory-library> |
+| MemGPT | [`../products/memgpt.md`](../products/memgpt.md) | <https://arxiv.org/abs/2310.08560> |
+| Karpathy LLM Wiki | [`../products/karpathy-llm-wiki.md`](../products/karpathy-llm-wiki.md) | <https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f> |

--- a/docs/product-discovery-log.md
+++ b/docs/product-discovery-log.md
@@ -1,0 +1,131 @@
+---
+title: Product discovery log — agent memory products
+date: 2026-06-11
+status: working-log
+language: zh-CN
+---
+
+# Product discovery log
+
+本日志记录 2026-06-11 的多子 agent 产品搜索、证据审查和最终入库决定。它不是
+产品介绍页,而是解释**为什么某个候选被深度入库、只进入轻量索引、或被拒绝**。
+
+## 1. 执行模型
+
+| Wave | 角色 | 并发 | 产出 |
+|---|---:|---:|---|
+| Wave 0 | Coordinator | 1 | 候选池、去重、Tier 判定、最终写入 |
+| Wave 1 | Discovery researchers | 6 | vendor / OSS / MCP / academic / domestic / adjacent lanes |
+| Wave 2 | Evidence reviewers | 3 | Tier A、source quality、inclusion boundary review |
+| Wave 3 | Architecture writers | 4 | 架构模式草稿,不直接改共享文件 |
+| Wave 4 | Integration writer | 1 | 本次仓库写入与验证 |
+
+并发上限控制在 6 个 native subagents。子 agent 只负责搜索、评审和草稿;最终文件写入
+由主 agent 单点完成,避免多个 agent 修改同一文件。
+
+## 2. 搜索范围与查询主题
+
+| Lane | 子 agent 范围 | 查询主题 |
+|---|---|---|
+| Official/vendor | EverMind/EverOS、Mem0、Zep、Supermemory、Hindsight、LangMem、Letta、Cognee、hyperscaler memory docs | 官方站、docs、release、GitHub README、pricing/status |
+| GitHub/OSS | MemOS、agentmemory、SimpleMem、PowerMem、OpenViking、Redis AMS、Dakera、SuperLocalMemory 等 | GitHub topics/trending、stars、license、release、README |
+| MCP/catalog | Glama、MCP Market、LobeHub、mcpservers、Claude/Cursor/Codex memory server lists | MCP server catalog、canonical repo/docs、tool surface |
+| Academic-to-product | `papers/index.md` 中已有论文和 arXiv/OpenReview 新线索 | EverMemOS、MemOS、MemoryOS、HiMeS、HippoRAG、Memory-T1 |
+| China/domestic | 腾讯云、混元、OceanBase、火山、阿里百炼、百度千帆、智谱/Kimi/豆包 | 官方云文档、国内产品页、GitHub、中文报道 |
+| Adjacent products | PKM、企业知识库、数字伴侣、客服/销售、coding agents | 是否显式暴露 durable/editable memory |
+
+## 3. 最终 Tier 规则
+
+| Tier | 标准 | 写入动作 |
+|---|---|---|
+| Tier A core | memory 是一等产品能力;有官方/源码证据;能映射到 memory 架构;不是纯 RAG/vector DB | 产品笔记 + archive snapshot + landscape 行 + 架构归类 |
+| Tier B adjacent | 暴露 memory 能力但不是独立 memory 产品,或证据/成熟度不足 | 轻量索引 + discovery log;后续跟踪 |
+| Reject | 只是普通知识库、纯向量库、普通 chat history、二手无证据营销项 | 记录拒绝原因,不入产品笔记 |
+
+## 4. 本次新增 Tier A core
+
+| name | canonical_url | repo/docs | category | evidence | suggested_tier | why_include | why_not_core | sources_checked |
+|---|---|---|---|---|---|---|---|---|
+| EverOS (EverMind / EverMemOS) | https://evermind.ai/everos | https://github.com/EverMind-AI/EverOS | memory OS / skill memory | official product page + repo | Tier A | Profile/Episodic/Skill、self-evolving skills、Markdown export、MCP/agent integrations | benchmark/latency 是 vendor-claimed | Official/vendor, academic |
+| MemOS (MemTensor) | https://github.com/MemTensor/MemOS | https://memos.openmem.net/ | memory OS | GitHub repo + docs | Tier A | self-evolving memory OS、hybrid retrieval、cross-task skill reuse | 与 MemoryOS/EverMemOS 易混淆;需后续读代码 | OSS, academic |
+| Cloudflare Agent Memory | https://blog.cloudflare.com/introducing-agent-memory/ | https://developers.cloudflare.com/agents/concepts/conversation-state-and-memory/ | platform-managed memory | official blog + docs | Tier A | platform memory primitive、Session/context memory、SQLite/provider model | private beta / experimental | Official/vendor, adjacent |
+| AWS Bedrock AgentCore Memory | https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/memory.html | https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/memory-strategies.html | platform-managed memory | official docs | Tier A | short-term + long-term managed memory, extraction strategies | AWS-only managed service | Official/vendor, adjacent |
+| Google Agent Platform Memory Bank | https://docs.cloud.google.com/gemini-enterprise-agent-platform/scale/memory-bank | same | platform-managed memory | official docs | Tier A | scoped long-term memories, TTL, revisions, poisoning guidance | Preview / Pre-GA | Official/vendor, adjacent |
+| Microsoft Foundry Agent Service Memory | https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/what-is-memory | same | platform-managed memory | official docs | Tier A | scoped store, CRUD/TTL, profile/summary/procedural memory | public preview | Official/vendor, adjacent |
+| Oracle AI Agent Memory | https://docs.oracle.com/en/database/oracle/agent-memory/26.4/agmea/about.html | same | enterprise DB memory | official docs | Tier A | Oracle AI Database as governed memory substrate | Oracle platform-bound | Adjacent, reviewer |
+| Redis Agent Memory Server | https://redis.github.io/agent-memory-server/ | https://github.com/redis/agent-memory-server | memory API server | official docs + repo | Tier A | two-tier memory, REST+MCP, hybrid search, extraction/dedup/edit | human-readable artifact not primary path | OSS, MCP |
+| OpenViking | https://volcengine-openviking.mintlify.app/ | https://github.com/volcengine/OpenViking | context DB with memory | docs + repo | Tier A | memory/resources/skills filesystem, L0/L1/L2, session memory extraction | not pure memory layer; benchmark self-reported | OSS, domestic |
+| PowerMem | https://github.com/oceanbase/powermem | https://www.powermem.ai/ | memory API/plugin | repo + site | Tier A | Experience + Skill distillation, hybrid retrieval, MCP/HTTP/CLI/plugins | benchmark self-reported | OSS, domestic |
+| Alibaba Bailian Memory Library | https://help.aliyun.com/zh/model-studio/memory-library | https://help.aliyun.com/zh/model-studio/long-term-memory-2-0 | platform-managed memory | official docs | Tier A | automatic extraction, memory fragments, user profile, Add/Search APIs | cloud black box | Domestic, personal/platform |
+| Basic Memory | https://docs.basicmemory.com/ | https://github.com/basicmachines-co/basic-memory | local-first memory | docs + repo | Tier A | Markdown source of truth, knowledge graph, MCP-native, cloud/local | PKM crossover and AGPL | MCP, OSS |
+| ByteRover (Cipher) | https://www.byterover.dev/ | https://github.com/campfirein/byterover-cli | coding-agent memory | site + repo + docs | Tier A | portable memory layer for autonomous coding agents, CLI/MCP/context tree | ELv2/source-available; maturity needs follow-up | MCP, OSS |
+| Honcho | https://github.com/plastic-labs/honcho | https://docs.honcho.dev/ | memory infrastructure | repo + docs | Tier A | peer-centric memory, async reasoning, representations, MCP/SDK/self-host | eval claims vendor-side, AGPL | OSS, MCP |
+
+## 5. Tier B / lightweight index
+
+| name | canonical_url | category | evidence | suggested_tier | why_include | why_not_core | sources_checked |
+|---|---|---|---|---|---|---|---|
+| Volcengine AgentKit Memory | https://www.volcengine.com/ | platform memory | domestic lane official/product signals | Tier B | platform memory capability signal | evidence less direct than OpenViking | Domestic |
+| Alibaba PolarSearch Memory Container | https://www.aliyun.com/ | database memory | domestic lane official/product signals | Tier B | memory container signal | canary / product boundary distinct from Bailian | Domestic |
+| Baidu Qianfan AppBuilder memory | https://cloud.baidu.com/product/AppBuilder | platform memory | domestic lane | Tier B | AppBuilder memory capability | not standalone memory infra | Domestic |
+| MIRIX | https://github.com/Mirix-AI/MIRIX | personal assistant memory | repo + paper/product signal | Tier B | screen/activity memory assistant is relevant | app/product scope broader than memory infra | Academic, adjacent |
+| Pieces LTM MCP | https://docs.pieces.app/products/mcp | local workflow memory | official docs | Tier B | coding workflow LTM surfaced through MCP | product is broader PiecesOS stack | MCP |
+| MemMachine | n/a | coding-agent memory | OSS lane signal | Tier B | memory-focused OSS candidate | source/license/release not verified enough | OSS |
+| mem9 | n/a | memory SDK | OSS lane signal | Tier B | memory-focused candidate | source quality incomplete | OSS |
+| Memstate AI | n/a | memory server | MCP lane signal | Tier B | memory-focused candidate | canonical evidence incomplete | MCP |
+| ClawMem | https://github.com/yoloshii/ClawMem | local memory vault | repo | Tier B | on-device coding-agent memory | release/license maturity not reviewed | MCP |
+| agentmemory | https://github.com/rohitg00/agentmemory | coding-agent memory | repo | Tier B | shared memory server signal | reviewers split; kept lightweight until source health check | OSS |
+| SimpleMem | n/a | coding-agent memory | OSS lane signal | Tier B | memory candidate | evidence/maturity weaker than Tier A set | OSS |
+| SuperLocalMemory | arXiv | research architecture | paper | Tier B | local-first architecture pressure | not productized enough | Academic |
+| Decagon / Sierra | vendor sites | customer-service memory | product signals | Tier B | embedded user/customer memory in vertical agents | not standalone memory infrastructure | Adjacent |
+| Cursor / Windsurf / Devin | vendor sites | coding-agent embedded memory | product signals | Tier B | visible durable context/memory UX | implementation and memory API not public | Adjacent |
+| Mem.ai / Reflect / mymind / Notion AI | vendor sites | PKM / workspace AI | product signals | Tier B | adjacent personal/workspace memory | memory not first-class agent infra | Adjacent |
+| Character.AI / Replika / Nomi | vendor sites | companion memory | product signals | Tier B | long-term persona consistency pressure | ethical/safety scope differs; infra not exposed | Adjacent |
+
+`n/a` 表示本轮子 agent 找到候选名,但主 agent 没有足够官方/源码证据支持深度入库。
+
+## 6. Reject / boundary decisions
+
+| pattern | decision | reason |
+|---|---|---|
+| Pure vector DB / pure RAG | reject as core product | 提供存储/检索但不处理记忆生命周期、更新、遗忘、冲突 |
+| MCP reference memory server | reject as product | 是协议示例/参考实现,不是面向市场的一等产品 |
+| Generic agent frameworks | reject unless memory is first-class | AutoGen/CrewAI/LlamaIndex 等不能因为有 memory feature 就计入核心产品 |
+| Ordinary chat history | reject | 缺少 extraction/consolidation/retrieval/governance lifecycle |
+| Catalog-only MCP servers | reject or Tier B | 没有 canonical repo/docs 时不写产品笔记 |
+
+## 7. Reviewer synthesis
+
+| Reviewer focus | Key output | Coordinator decision |
+|---|---|---|
+| Tier A reviewer | 批准 hyperscaler/platform memory、EverOS、MemOS、Redis AMS、OpenViking、PowerMem、Basic Memory、ByteRover、Honcho 等 | 采纳,但把证据弱的小型 OSS/MCP 候选降到 Tier B |
+| Source-quality reviewer | 标记 Cloudflare private beta、Microsoft preview、OpenViking context DB 边界、vendor benchmark 风险 | 采纳并写入产品笔记风险段 |
+| Inclusion-boundary reviewer | 防止纯 RAG、纯 vector DB、普通框架误入核心 | 采纳;保留二层结构 |
+
+## 8. Evidence index for Tier A products
+
+| Product | Product note | Archive | Source attributes |
+|---|---|---|---|
+| EverOS | [`../products/everos.md`](../products/everos.md) | [`../products/archives/everos-overview.md`](../products/archives/everos-overview.md) | official page + GitHub; vendor benchmark claims labeled |
+| MemOS | [`../products/memos.md`](../products/memos.md) | [`../products/archives/memos-overview.md`](../products/archives/memos-overview.md) | GitHub/docs; token-saving claims labeled |
+| Cloudflare Agent Memory | [`../products/cloudflare-agent-memory.md`](../products/cloudflare-agent-memory.md) | [`../products/archives/cloudflare-agent-memory-overview.md`](../products/archives/cloudflare-agent-memory-overview.md) | official blog/docs; private beta / experimental label |
+| AWS AgentCore Memory | [`../products/aws-agentcore-memory.md`](../products/aws-agentcore-memory.md) | [`../products/archives/aws-agentcore-memory-overview.md`](../products/archives/aws-agentcore-memory-overview.md) | official docs; cloud managed service |
+| Google Memory Bank | [`../products/google-memory-bank.md`](../products/google-memory-bank.md) | [`../products/archives/google-memory-bank-overview.md`](../products/archives/google-memory-bank-overview.md) | official docs; Preview / Pre-GA label |
+| Microsoft Foundry Memory | [`../products/microsoft-foundry-memory.md`](../products/microsoft-foundry-memory.md) | [`../products/archives/microsoft-foundry-memory-overview.md`](../products/archives/microsoft-foundry-memory-overview.md) | official docs; preview label |
+| Oracle AI Agent Memory | [`../products/oracle-ai-agent-memory.md`](../products/oracle-ai-agent-memory.md) | [`../products/archives/oracle-ai-agent-memory-overview.md`](../products/archives/oracle-ai-agent-memory-overview.md) | official docs; database substrate |
+| Redis AMS | [`../products/redis-agent-memory-server.md`](../products/redis-agent-memory-server.md) | [`../products/archives/redis-agent-memory-server-overview.md`](../products/archives/redis-agent-memory-server-overview.md) | official docs + repo |
+| OpenViking | [`../products/openviking.md`](../products/openviking.md) | [`../products/archives/openviking-overview.md`](../products/archives/openviking-overview.md) | docs + repo; benchmark claims labeled |
+| PowerMem | [`../products/powermem.md`](../products/powermem.md) | [`../products/archives/powermem-overview.md`](../products/archives/powermem-overview.md) | repo + site; benchmark claims labeled |
+| Alibaba Bailian Memory | [`../products/alibaba-bailian-memory.md`](../products/alibaba-bailian-memory.md) | [`../products/archives/alibaba-bailian-memory-overview.md`](../products/archives/alibaba-bailian-memory-overview.md) | official Aliyun docs |
+| Basic Memory | [`../products/basic-memory.md`](../products/basic-memory.md) | [`../products/archives/basic-memory-overview.md`](../products/archives/basic-memory-overview.md) | docs + repo; AGPL/local-first |
+| ByteRover | [`../products/byterover.md`](../products/byterover.md) | [`../products/archives/byterover-overview.md`](../products/archives/byterover-overview.md) | site + repo/docs; alias Cipher |
+| Honcho | [`../products/honcho.md`](../products/honcho.md) | [`../products/archives/honcho-overview.md`](../products/archives/honcho-overview.md) | repo + docs; vendor eval claims labeled |
+
+## 9. Coordinator notes
+
+- EverMind/EverOS/EverMemOS 已深度入库为 Tier A,满足本轮 spot-check 要求。
+- Google/Microsoft/Alibaba 在 reviewer 间有分歧,最终以官方 developer docs 为准纳入
+  Tier A,但保留 preview/cloud black-box 风险。
+- MIRIX、Pieces LTM、MemMachine、mem9、Memstate、ClawMem、agentmemory、SimpleMem
+  等不删除,但先作为 Tier B 轻量索引,等待源码/许可/release health 补证。
+- 所有 vendor benchmark 或性能 claim 都按 vendor-claimed / 自报处理,不写成独立实证。

--- a/docs/product-memory-architectures.md
+++ b/docs/product-memory-architectures.md
@@ -1,0 +1,257 @@
+---
+title: Product memory architectures — cross-product patterns
+date: 2026-06-11
+status: working-note
+language: zh-CN
+---
+
+# 产品整体 memory 架构
+
+这份文档不是逐产品介绍,而是把当前 `products/` 里的 memory 产品抽象成可比较的
+架构模式。详细单品图见 [`product-architecture-diagrams.md`](product-architecture-diagrams.md),
+入库证据见 [`product-discovery-log.md`](product-discovery-log.md)。
+
+## 1. 总览图
+
+```mermaid
+flowchart TB
+    Products["Agent memory products"]
+    OS["Memory OS / layered cognition"]
+    Graph["Graph / temporal / ontology"]
+    MCP["MCP / local-first / coding-agent memory"]
+    Managed["Platform-managed memory"]
+    Personal["Personal / portable memory"]
+    Adjacent["Adjacent embedded memory"]
+
+    Products --> OS
+    Products --> Graph
+    Products --> MCP
+    Products --> Managed
+    Products --> Personal
+    Products --> Adjacent
+
+    OS --> EverOS["EverOS"]
+    OS --> MemOS["MemOS"]
+    OS --> MemoryOS["MemoryOS"]
+    OS --> TencentDB["TencentDB Agent Memory"]
+    OS --> HyMemory["Hy-Memory"]
+    Graph --> Zep["Zep"]
+    Graph --> Graphiti["Graphiti"]
+    Graph --> Cognee["Cognee"]
+    Graph --> OpenViking["OpenViking"]
+    MCP --> BasicMemory["Basic Memory"]
+    MCP --> ByteRover["ByteRover"]
+    MCP --> RedisAMS["Redis AMS"]
+    MCP --> PowerMem["PowerMem"]
+    MCP --> Honcho["Honcho"]
+    Managed --> AWS["AWS AgentCore Memory"]
+    Managed --> Google["Google Memory Bank"]
+    Managed --> Microsoft["Microsoft Foundry Memory"]
+    Managed --> Cloudflare["Cloudflare Agent Memory"]
+    Managed --> Oracle["Oracle AI Agent Memory"]
+    Managed --> Alibaba["Alibaba Bailian Memory"]
+    Personal --> OpenAI["OpenAI Memory"]
+    Personal --> Claude["Claude Dreams / memory"]
+    Personal --> PersonalAI["Personal AI"]
+    Personal --> Anuma["Anuma"]
+    Personal --> Kinic["Kinic"]
+```
+
+## 2. Memory OS / layered cognition
+
+| Field | Synthesis |
+|---|---|
+| architecture pattern | 把 memory 当作操作系统/认知层资源管理:raw trace -> atomic memories -> scenario/task summaries -> profile/skill/procedure |
+| products mapped | EverOS、MemOS、MemoryOS、TencentDB Agent Memory、Hy-Memory、A-MEM、MemX |
+| common data flow | host runtime 捕获消息/工具/文件 -> 抽取 facts/cases -> 分层整合 -> hybrid index -> pre-action retrieval -> context pack |
+| memory types | working memory、episodic、semantic、profile、procedural/skill、task canvas |
+| retrieval/consolidation strategy | 多信号召回 + 离线 consolidation;重复成功轨迹提升为 skill/procedure;低价值或过期记忆合并/降权 |
+| governance/inspectability | Markdown export、Mermaid canvas、分层 artifact 是强 inspectability 信号;云端/自动蒸馏仍需要 diff/audit |
+| confidence/unknowns | 高置信于模式;中置信于各家内部 schema。EverOS/PowerMem benchmark 均为 vendor-claimed。 |
+
+```mermaid
+flowchart TB
+    Host["Host runtime: chat, tools, files, tasks"]
+    Trace["Raw trace / episodic log"]
+    Extract["Extraction: facts, preferences, cases, procedures"]
+    Atom["Atomic memories"]
+    Scenario["Scenario / task summaries"]
+    Profile["Profile / long-term knowledge"]
+    Skill["Skill / procedure memory"]
+    Index["Hybrid indexes: vector + keyword + graph/wiki"]
+    Retrieve["Pre-action retrieval + rerank"]
+    Gate["Policy / confidence / permission gate"]
+    Pack["Context packer"]
+    Agent["LLM agent"]
+    Async["Post-action async capture"]
+    Consolidate["Consolidation: merge, link, supersede, expire"]
+    Audit["Diff / audit / human or policy review"]
+
+    Host --> Trace --> Extract --> Atom
+    Agent --> Async --> Extract
+    Atom --> Scenario --> Profile
+    Scenario --> Skill
+    Atom --> Index
+    Profile --> Index
+    Skill --> Index
+    Agent --> Retrieve --> Index --> Gate --> Pack --> Agent
+    Extract --> Consolidate --> Audit --> Index
+```
+
+## 3. Graph / temporal / ontology memory
+
+| Field | Synthesis |
+|---|---|
+| architecture pattern | 把对话、事件、文档转成 entities/facts/relations,并保留时间、来源和 ontology 类型 |
+| products mapped | Zep、Graphiti、Cognee、OpenViking、HippoRAG-like systems、Oracle AI Agent Memory |
+| common data flow | episodes/docs -> parse/chunk -> entity/relation extraction -> temporal/ontology graph + vector/keyword index -> hybrid retrieval |
+| memory types | entity facts、relationship edges、valid-time facts、source episodes、ontology nodes、summary/context cards |
+| retrieval/consolidation strategy | semantic + BM25 + graph traversal + temporal filters;新事实 supersede 旧事实而非直接覆盖 |
+| governance/inspectability | provenance、valid time、audit logs、graph explainability 是关键;闭源托管图需要额外审计接口 |
+| confidence/unknowns | Zep/Graphiti/Cognee/OpenViking 公开材料充分;Oracle 以官方 docs 为主,底层实现细节有限。 |
+
+```mermaid
+flowchart TB
+    Sources["Episodes / conversations / docs / business data"]
+    Ingest["Ingest + parse + chunk"]
+    Extract["Extract entities, facts, relations, ontology, timestamps"]
+    Provenance["Raw episodes / source refs"]
+    TemporalGraph["Temporal / ontology graph"]
+    VectorKeyword["Vector + keyword indexes"]
+    Consolidate["Supersede, dedup, summarize, retain/delete"]
+    Retrieve["Hybrid retrieval: semantic + keyword + graph + temporal"]
+    Pack["Rank, filter, compress, cite"]
+    Agent["Agent / app / MCP client"]
+    Governance["ACL, tenant isolation, retention, audit"]
+
+    Sources --> Ingest --> Extract
+    Sources --> Provenance
+    Extract --> TemporalGraph
+    Extract --> VectorKeyword
+    Provenance --> TemporalGraph
+    TemporalGraph --> Consolidate
+    VectorKeyword --> Consolidate
+    Consolidate --> Retrieve
+    TemporalGraph --> Retrieve
+    VectorKeyword --> Retrieve
+    Retrieve --> Pack --> Agent
+    Governance --- Provenance
+    Governance --- TemporalGraph
+```
+
+## 4. MCP / local-first / coding-agent memory
+
+| Field | Synthesis |
+|---|---|
+| architecture pattern | sidecar memory substrate: IDE/agent hooks capture work, MCP exposes recall/write/delete/export tools, local files or DB store state |
+| products mapped | Basic Memory、ByteRover、Redis Agent Memory Server、PowerMem、Honcho、Supermemory MCP、Pieces LTM、ClawMem、agentmemory |
+| common data flow | IDE/session hooks -> extraction -> Markdown/context tree/local DB -> hybrid index -> MCP recall -> session briefing/context injection |
+| memory types | project decisions、file history、debug episodes、preferences、skills、timeline、audit trail |
+| retrieval/consolidation strategy | vector + BM25 + graph/timeline;session stop 或 compaction 前做总结,重复模式提升为 skills |
+| governance/inspectability | 最强模式是 artifact-first:Markdown/context tree/git diff。DB-first 需要 export/audit/delete trail。 |
+| confidence/unknowns | Basic Memory/Redis/PowerMem/Honcho 证据强;小型 MCP servers 需要补 license/release/source health。 |
+
+```mermaid
+flowchart LR
+    IDE["IDE / coding agent"]
+    Hooks["Hooks: session start/stop, tool use, prompt submit"]
+    MCP["MCP tools: remember, search, get, delete, export"]
+    Extract["Extraction + normalization"]
+    Artifacts["Local artifacts: Markdown, context tree, vault"]
+    DB["Local/server DB: SQLite, Redis, Milvus, OceanBase, Postgres"]
+    Index["Hybrid indexes: vector + BM25 + graph + timeline"]
+    Context["Retrieved context / session briefing"]
+    Consolidate["Dedup, decay, summarize, promote skills"]
+    Audit["Provenance, snapshots, diff, export"]
+
+    IDE --> Hooks --> Extract
+    IDE --> MCP --> Extract
+    Extract --> Artifacts
+    Extract --> DB
+    Artifacts --> Index
+    DB --> Index
+    Index --> Context --> IDE
+    Index --> Consolidate
+    Consolidate --> Artifacts
+    Consolidate --> DB
+    Artifacts --> Audit
+    DB --> Audit
+```
+
+## 5. Platform-managed memory
+
+| Field | Synthesis |
+|---|---|
+| architecture pattern | 云平台提供 managed memory store + identity scope + retrieval tools;开发者配置 scope、TTL、strategy、权限 |
+| products mapped | AWS AgentCore Memory、Google Memory Bank、Microsoft Foundry Memory、Cloudflare Agent Memory、Oracle AI Agent Memory、Alibaba Bailian Memory |
+| common data flow | app/agent events -> managed extraction -> scoped store -> semantic/search retrieval -> prompt/tool injection -> cloud governance |
+| memory types | session events、user profile、facts、chat summaries、procedural memory、thread context cards |
+| retrieval/consolidation strategy | 平台内置抽取/合并/过期;部分平台暴露 strategy、TTL、CRUD 或 provider abstraction |
+| governance/inspectability | IAM/RBAC、tenant isolation、TTL、CRUD、export、audit 是核心;内部提取/排序通常黑箱 |
+| confidence/unknowns | 官方 docs 证据强;Cloudflare private beta、Google Preview/Pre-GA、Microsoft preview 需要时间标签。 |
+
+```mermaid
+flowchart TB
+    App["Agent app / cloud runtime"]
+    Events["Chat turns, tool results, files, business events"]
+    Strategy["Extraction strategy / provider / topic config"]
+    Scope["Identity scope: user, agent, tenant, session, memoryId"]
+    Store["Managed memory store"]
+    Retrieve["Scoped semantic/search retrieval"]
+    Inject["Prompt or tool context injection"]
+    Govern["IAM/RBAC, TTL, CRUD, audit, poisoning defense"]
+    Response["Agent response/action"]
+
+    App --> Events --> Strategy --> Scope --> Store
+    Store --> Retrieve --> Inject --> Response --> Events
+    Govern --- Scope
+    Govern --- Store
+    Govern --- Retrieve
+```
+
+## 6. Personal / portable memory
+
+| Field | Synthesis |
+|---|---|
+| architecture pattern | 账号级或用户拥有的 memory vault,从日常聊天/文件/浏览器/应用数据抽取可跨模型使用的个人上下文 |
+| products mapped | OpenAI Memory、Claude memory/Dreams、Gemini personal context、Personal AI、Anuma、Kinic |
+| common data flow | personal interactions -> extraction -> account/vault store -> scoped recall -> personalized response |
+| memory types | saved facts、chat-history memory、preferences、persona、private entries、portable vault memories |
+| retrieval/consolidation strategy | consumer assistants 多为黑箱排序;portable memory 产品强调 edit/delete/export/private flags |
+| governance/inspectability | 消费者需要 memory on/off、per-memory delete、temporary/incognito chat、export/wipe;企业需要 admin disable |
+| confidence/unknowns | 用户控制面证据较强;内部 schema、冲突解决、保留策略通常不公开。 |
+
+```mermaid
+flowchart TB
+    Raw["Raw inputs: chats, files, browser/app data"]
+    Extract["Extraction: facts, summaries, profiles"]
+    Scope["Account / vault / app / project scope"]
+    Store["Managed memory store or user vault"]
+    Retrieve["Scoped recall / RAG / memory tool"]
+    Inject["Context injection into assistant"]
+    Response["Personalized response"]
+    Controls["Edit, delete, export, temporary chat, private flags"]
+
+    Raw --> Extract --> Scope --> Store
+    Store --> Retrieve --> Inject --> Response --> Raw
+    Controls --- Scope
+    Controls --- Store
+    Controls --- Retrieve
+```
+
+## 7. 对比表
+
+| Pattern | Best signal | Weakness | Best Ymem design pressure |
+|---|---|---|---|
+| Memory OS / layered cognition | 明确处理 episodic/semantic/profile/skill lifecycle | 自动抽取和 skill distillation 容易黑箱 | `dream-consolidator` + diff review |
+| Graph / temporal / ontology | provenance、valid time、关系可解释 | graph schema 和 ontology 成本高 | `ProvenanceRef` + temporal conflict policy |
+| MCP / local-first / coding-agent | host integration 强,人类可审计 artifact 可行 | 小项目证据噪声大,协议安全边界复杂 | host-agnostic tools + audit/export/delete |
+| Platform-managed memory | IAM/ops/scale 强,企业可直接采购 | 云黑箱、preview 状态、lock-in | scope/TTL/policy 最低治理基线 |
+| Personal / portable memory | 贴近真实用户长期使用 | safety/consent/ownership 风险高 | mnemonic sovereignty + user controls |
+
+## 8. 总结
+
+当前产品集合说明一个明显趋势:agent memory 正从 "SDK + vector store" 扩展成五类
+基础设施路线。最重要的分水岭不是用不用向量库,而是产品是否公开处理**写入、整合、
+召回、遗忘、治理、审计**这六个生命周期问题。只有把这些问题作为一等能力的产品,
+才进入核心产品层;其他 memory-adjacent 产品保持轻量索引。

--- a/docs/products-landscape.md
+++ b/docs/products-landscape.md
@@ -1,6 +1,6 @@
 ---
 title: Products landscape — agent memory by domain × audience
-date: 2026-05-19
+date: 2026-06-11
 status: working-spec
 language: zh-CN
 ---
@@ -14,14 +14,57 @@ language: zh-CN
 分类与对照。条目可能与 [`related-work.md`](related-work.md) 的论文交叉(产品的
 原始论文也在 papers/ 里),不重复。
 
+入库/拒绝理由见 [`product-discovery-log.md`](product-discovery-log.md),跨产品
+架构模式见 [`product-memory-architectures.md`](product-memory-architectures.md)。
+
 ## 阅读说明
 
 **Domain**(领域)= 这个产品最自然落到的应用场景。
 **Audience**(服务对象)= 真实掏钱 / 部署的人。同一产品可对多个 audience。
-**Mode**:OSS / OSS+SaaS / SaaS / Big-tech-builtin / Research-only。
+**Mode**:OSS / OSS+SaaS / SaaS / Big-tech-builtin / Research-only / Plugin。
 
 下表条目的判定标准是:**产品本身把"记忆"作为一等公民设计**;只是顺带做向量
 检索或 RAG 的不算。
+
+## 分类标准
+
+### 入库边界
+
+一个产品进入 `products/` 或本页核心表,需要满足三项:
+
+1. 记忆是公开产品能力,不是普通 chat history、日志留存或单次 RAG 检索。
+2. 产品公开处理至少两类 memory lifecycle 问题:写入、抽取、整合、召回、遗忘、
+   权限、审计、导出、跨会话复用。
+3. 有官方页面、官方文档、源码仓库、论文作者仓库或可审计页面快照作为主证据。
+
+只提供向量库、普通知识库、通用 agent 框架、catalog-only MCP 条目或二手营销材料的
+候选,不进入核心产品表;最多进入 discovery log 的轻量索引。
+
+### 主分类维度
+
+每个产品只选一个主类,按以下优先级归类:
+
+| 主类 | 判定标准 | 典型问题 |
+|---|---|---|
+| Agent memory 专门层 | 产品直接销售或开源 memory layer / memory SDK / memory server | 如何写入、更新、检索、治理长期记忆 |
+| Agent runtime / 平台内嵌 | memory 是 agent runtime、插件或框架的一等能力,但不是独立产品 | host runtime 如何把 memory 暴露给 agent |
+| LLM / cloud 厂商 managed memory | 由模型厂商、云平台或数据库平台托管 memory store 与治理面 | scope、TTL、IAM、黑箱抽取和平台锁定 |
+| Coding & Dev agents | 主要服务 IDE、coding agent、多 agent 开发工作流 | 项目上下文、决策、debug episode 如何跨 session 保留 |
+| PKM / personal portable memory | 面向个人知识、跨模型上下文或用户拥有的 memory vault | 用户能否编辑、删除、导出和迁移 memory |
+| 数字伴侣 / 垂直应用 | memory 是终端体验核心,但底层 memory infra 不公开 | persona 连续性、关系记忆和安全边界 |
+| Enterprise workspace / DB-derived memory | 企业知识、数据库或平台能力显式暴露 memory lifecycle | 治理、审计、合规和底层存储边界 |
+
+### 二级标签
+
+主类之外,可叠加这些标签帮助交叉统计:
+
+- **delivery mode**:OSS / OSS+SaaS / SaaS / source-available / cloud platform /
+  big-tech-builtin / plugin / research.
+- **memory substrate**:vector, keyword, graph, temporal graph, Markdown/files,
+  relational DB, managed store, hybrid.
+- **control surface**:API, SDK, MCP, CLI, UI, cloud console, local files.
+- **evidence class**:official docs, official repo, product page, paper-origin,
+  archive snapshot, vendor benchmark claim, independent reproduction.
 
 ## A. 按领域分类
 
@@ -35,6 +78,20 @@ language: zh-CN
 | Cognee | [`../products/cognee.md`](../products/cognee.md) | OSS+SaaS | 个人开发者 / 中小团队 | 记忆 + ontology + KG;偏 PKM/研究方向 |
 | Letta(原 MemGPT)| [`../products/letta.md`](../products/letta.md) | OSS+SaaS | 研究者 / 个人开发者 | agent runtime 内置分层记忆 |
 | LangMem | [`../products/langmem.md`](../products/langmem.md) | OSS | LangChain 用户 | LangChain/LangGraph 系的 memory primitive |
+| Supermemory | [`../products/supermemory.md`](../products/supermemory.md) | OSS+SaaS | SaaS 团队 / 企业 / 个人 | context cloud:memory、RAG、profiles、connectors 一体化 |
+| Hindsight | [`../products/hindsight.md`](../products/hindsight.md) | OSS+SaaS | agent builder / 企业 | "learns over time" 的服务化开源 agent memory |
+| TencentDB Agent Memory | [`../products/tencentdb-agent-memory.md`](../products/tencentdb-agent-memory.md) | OSS+SaaS | OpenClaw 用户 / 企业 / 腾讯云客户 | 腾讯云 + 本地 OSS 的 L0-L3 分层 agent memory |
+| EverOS | [`../products/everos.md`](../products/everos.md) | OSS+SaaS | coding agent 用户 / agent builder / 企业 | EverMind/EverMemOS 产品族;Profile/Episodic/Skill + self-evolving skills |
+| MemOS | [`../products/memos.md`](../products/memos.md) | OSS | 研究者 / agent builder | MemTensor 的 self-evolving memory OS;注意与 MemoryOS 区分 |
+| Redis Agent Memory Server | [`../products/redis-agent-memory-server.md`](../products/redis-agent-memory-server.md) | OSS | Redis 用户 / agent builder | working + long-term 双层 memory API server,提供 REST 与 MCP |
+| PowerMem | [`../products/powermem.md`](../products/powermem.md) | OSS | coding agent 用户 / agent builder / OceanBase 生态 | Experience + Skill distillation,多接口 memory plugin/API server |
+| Basic Memory | [`../products/basic-memory.md`](../products/basic-memory.md) | OSS+SaaS | 个人开发者 / 团队 / Markdown 用户 | local-first Markdown memory + knowledge graph + MCP |
+| ByteRover(原 Cipher) | [`../products/byterover.md`](../products/byterover.md) | Source-available | coding agent 用户 / 团队 | autonomous coding agents 的 portable memory layer |
+| Honcho | [`../products/honcho.md`](../products/honcho.md) | OSS+SaaS | agent builder / multi-agent 产品 | peer-centric stateful agent memory infrastructure |
+| OpenViking | [`../products/openviking.md`](../products/openviking.md) | OSS | coding agent 用户 / OpenClaw 用户 / agent builder | context database:filesystem 管理 memory、resources、skills |
+| MemoryOS | [`../products/memoryos.md`](../products/memoryos.md) | OSS / Research | 研究者 / 个人开发者 | personalized agent 的 memory operating system |
+| A-MEM | [`../products/a-mem.md`](../products/a-mem.md) | OSS / Research | 研究者 | Zettelkasten 式 agentic memory organization |
+| MemX | [`../products/memx.md`](../products/memx.md) | OSS | 本地优先个人开发者 | 单文件 local-first memory,早期观察项 |
 
 ### A2. Agent runtime / 平台(memory 内嵌)
 
@@ -44,14 +101,23 @@ language: zh-CN
 | LlamaIndex memory | — | OSS | 框架用户 |
 | AutoGen / CrewAI | — | OSS | 框架用户 |
 | MemGPT(论文)| [`../products/memgpt.md`](../products/memgpt.md) | OSS(已演化为 Letta)| 研究者 |
+| Hy-Memory | [`../products/hy-memory.md`](../products/hy-memory.md) | Plugin | OpenClaw 用户 / 混元生态 |
+| OpenViking | [`../products/openviking.md`](../products/openviking.md) | OSS | OpenClaw / OpenCode / Claude Desktop 用户 |
+| Cloudflare Agents Session Memory | [`../products/cloudflare-agent-memory.md`](../products/cloudflare-agent-memory.md) | Big-tech-builtin | Cloudflare Workers/Agents 用户 |
 
-### A3. LLM 厂商内建 memory
+### A3. LLM / cloud 厂商内建 managed memory
 
 | 名称 | 笔记 | Mode | Audience |
 |---|---|---|---|
 | ChatGPT memory + Assistants memory | [`../products/openai-memory.md`](../products/openai-memory.md) | Big-tech-builtin | C 端 + SaaS 团队 |
 | Claude memory / Claude Dreams | [`../products/claude-dreams.md`](../products/claude-dreams.md) | Big-tech-builtin | C 端 + 企业 |
 | Gemini personal context | — | Big-tech-builtin | C 端(Google 账号生态)|
+| Google Agent Platform Memory Bank | [`../products/google-memory-bank.md`](../products/google-memory-bank.md) | Big-tech-builtin / Preview | Google Cloud / Gemini Enterprise agent builder |
+| AWS Bedrock AgentCore Memory | [`../products/aws-agentcore-memory.md`](../products/aws-agentcore-memory.md) | Big-tech-builtin | AWS Bedrock AgentCore 用户 |
+| Microsoft Foundry Agent Service Memory | [`../products/microsoft-foundry-memory.md`](../products/microsoft-foundry-memory.md) | Big-tech-builtin / Preview | Azure Foundry agent builder |
+| Cloudflare Agent Memory | [`../products/cloudflare-agent-memory.md`](../products/cloudflare-agent-memory.md) | Big-tech-builtin / Private beta | Cloudflare Agents 用户 |
+| Oracle AI Agent Memory | [`../products/oracle-ai-agent-memory.md`](../products/oracle-ai-agent-memory.md) | Enterprise platform | Oracle AI Database 客户 |
+| Alibaba Cloud Bailian Memory Library | [`../products/alibaba-bailian-memory.md`](../products/alibaba-bailian-memory.md) | Cloud platform | 百炼 / Model Studio 开发者 |
 
 ### A4. Coding & Dev agents(memory 用于代码上下文)
 
@@ -62,16 +128,28 @@ language: zh-CN
 | Cognition Devin | SaaS | 企业 | 自治 agent 的工作 memory |
 | GitHub Copilot Workspace | SaaS | 团队 / 企业 | repository-level context;memory 形态较弱但在演进 |
 | Claude Code | SaaS | 个人开发者 / 团队 | CLAUDE.md + memory hooks |
+| Supermemory plugins / MCP | OSS+SaaS | 个人开发者 / 团队 | Claude、Cursor、Codex、OpenCode 等 agent 插件入口 |
+| TencentDB Agent Memory OpenClaw plugin | OSS+SaaS | OpenClaw 用户 | 自动 capture / recall,并保留 Mermaid task canvas |
+| Hy-Memory OpenClaw plugin | Plugin | OpenClaw 用户 | 多 agent 共享 userId namespace 的长期记忆 |
+| Basic Memory | OSS+SaaS | Claude / Codex / Cursor / VS Code 用户 | Markdown files + MCP,人和 agent 共用 memory |
+| ByteRover | Source-available | autonomous coding agent 用户 | CLI/MCP/context tree 跨 agent 共享项目 memory |
+| PowerMem | OSS | Claude Code / Codex / Cursor / OpenClaw 用户 | CLI/HTTP/MCP/插件共用后端 memory |
+| Redis Agent Memory Server | OSS | 任意 MCP/REST agent | Redis-backed memory server,支持 working/long-term memory |
+| Honcho | OSS+SaaS | Claude Code / OpenCode / OpenClaw / Hermes 用户 | peer-centric memory + MCP/SDK |
+| OpenViking | OSS | OpenClaw / OpenCode / Claude Desktop 用户 | context DB + MCP,统一 memory/resources/skills |
 
 ### A5. 个人知识管理(PKM)与记忆增强
 
-| 名称 | Mode | Audience |
-|---|---|---|
-| Mem.ai | SaaS | 个人 |
-| Reflect | SaaS | 个人 |
-| Mymind | SaaS | 个人 |
-| Notion AI memory | SaaS | 团队 |
-| Obsidian + 插件 | OSS + 插件市场 | 个人 / 研究者 |
+| 名称 | 笔记 | Mode | Audience |
+|---|---|---|---|
+| Mem.ai | — | SaaS | 个人 |
+| Reflect | — | SaaS | 个人 |
+| Mymind | — | SaaS | 个人 |
+| Notion AI memory | — | SaaS | 团队 |
+| Obsidian + 插件 | — | OSS + 插件市场 | 个人 / 研究者 |
+| Personal AI | [`../products/personal-ai.md`](../products/personal-ai.md) | SaaS | 个人 / creator / 开发者 |
+| Anuma | [`../products/anuma.md`](../products/anuma.md) | SaaS | 个人 |
+| Kinic | [`../products/kinic.md`](../products/kinic.md) | SaaS / tokenized datastore | 个人 / creator |
 
 ### A6. 数字伴侣 / 情感陪伴
 
@@ -104,6 +182,16 @@ language: zh-CN
 | Notion Enterprise AI | SaaS | 大企业 |
 | Slack AI | SaaS | 大企业 |
 | Mem0 Enterprise | SaaS / 内部部署 | 大企业 |
+| Supermemory Enterprise | OSS+SaaS / on-prem | 大企业 |
+| Tencent Cloud Agent Memory | SaaS | 大企业 / 腾讯云客户 |
+| Personal AI Memory Core | SaaS | AI builder / 企业 |
+| AWS Bedrock AgentCore Memory | SaaS | AWS 企业客户 |
+| Google Agent Platform Memory Bank | SaaS / Preview | Google Cloud / Gemini Enterprise 客户 |
+| Microsoft Foundry Agent Service Memory | SaaS / Preview | Azure / Microsoft Foundry 客户 |
+| Cloudflare Agent Memory | SaaS / Private beta | Cloudflare Workers/Agents 客户 |
+| Oracle AI Agent Memory | Enterprise platform | Oracle AI Database 客户 |
+| Alibaba Bailian Memory Library | SaaS | 阿里云百炼客户 |
+| Redis Agent Memory Server | OSS / self-host | Redis 用户 / 企业平台团队 |
 
 ### A9. DB / Vector store 衍生的 memory API
 
@@ -113,6 +201,10 @@ language: zh-CN
 | Weaviate memory features | OSS+SaaS | 个人 / 团队 |
 | Qdrant memory APIs | OSS+SaaS | 个人 / 团队 |
 | pgvector + 应用层 | OSS | 个人 / 团队 |
+| Oracle AI Agent Memory | Enterprise platform | Oracle AI Database 客户 |
+| Redis Agent Memory Server | OSS | Redis 用户 / agent 平台团队 |
+| OpenViking | OSS | agent builder / coding agent 用户 |
+| PowerMem | OSS | OceanBase / 本地后端用户 |
 
 这类"伪 memory"提供存储但不提供更新 / 过期 / 冲突解决,严格意义上不是 memory layer。
 memory kernel 通常的关系是:**复用**它们做底层 vector store,**不取代**它们。
@@ -121,21 +213,33 @@ memory kernel 通常的关系是:**复用**它们做底层 vector store,**不取
 
 ### B1. 个人开发者(self-host 主导)
 Letta self-host / Mem0 self-host / Zep self-host / Graphiti / Cognee /
-Obsidian + 插件 / LangMem。
+Obsidian + 插件 / LangMem / Hindsight / TencentDB Agent Memory /
+EverOS / MemOS / Redis Agent Memory Server / PowerMem / Basic Memory /
+ByteRover / Honcho / OpenViking / MemoryOS / A-MEM / MemX /
+Supermemory self-host。
 
 ### B2. 中小团队 / SaaS startup
-Mem0 cloud / Zep cloud / OpenAI Assistants / Pinecone / Cursor for Teams。
+Mem0 cloud / Zep cloud / Supermemory API / Hindsight cloud / Basic Memory
+Cloud / Honcho API / Redis Agent Memory Server / OpenAI Assistants /
+Pinecone / Cursor for Teams。
 
 ### B3. 大企业
 Glean / Mem0 Enterprise / Notion / Slack AI / Anthropic for Enterprise /
-Cognition Devin / Sierra / Decagon。
+Cognition Devin / Sierra / Decagon / Supermemory Enterprise /
+Tencent Cloud Agent Memory / AWS Bedrock AgentCore Memory /
+Google Agent Platform Memory Bank / Microsoft Foundry Agent Service Memory /
+Cloudflare Agent Memory / Oracle AI Agent Memory / Alibaba Bailian Memory /
+Personal AI Memory Core。
 
 ### B4. C 端最终用户
 ChatGPT memory / Claude memory / Gemini personal context /
-Character.AI / Replika / Mem.ai / Mymind。
+Character.AI / Replika / Mem.ai / Mymind / Personal AI / Anuma / Kinic /
+Personal Supermemory / Gemini personal context。
 
 ### B5. 研究者 / 学术
-Letta(LeStar 学界出身) / MemGPT 论文复现 / Mem0 OSS / Graphiti OSS。
+Letta(LeStar 学界出身) / MemGPT 论文复现 / Mem0 OSS / Graphiti OSS /
+MemoryOS / A-MEM / MemOS / EverMemOS / TencentDB Agent Memory /
+Hy-Memory / MIRIX。
 学术用户主要消费 OSS 框架而非 SaaS。
 
 ## C. 不进入这张图的相邻范畴
@@ -145,7 +249,8 @@ Letta(LeStar 学界出身) / MemGPT 论文复现 / Mem0 OSS / Graphiti OSS。
 - 纯 vector DB / 纯 RAG 中间件(Weaviate / Pinecone 的核心产品)
 - 纯 long-context inference 加速(Together AI / Anthropic prompt cache 等)
 - 通用 agent 框架(AutoGen / CrewAI 的非 memory 部分)
-- 数据集 / 评测平台(已在 [`signals.md`](signals.md))
+- 数据集 / 评测平台(进入 [`../benchmarks/`](../benchmarks/) 和
+  [`benchmarks-landscape.md`](benchmarks-landscape.md),不混入产品图)
 
 这些都和 agent memory 有交集,但**不是把 memory 当一等公民**。把它们排除让
 "memory product" 的定义保持锐利。

--- a/docs/research-radar.md
+++ b/docs/research-radar.md
@@ -19,7 +19,7 @@ agent memory 领域的论文和产品在不断更新。**Radar** 是一套机制
 
 ```text
 定期获取前沿信息
-  → 结构化理解论文/产品更新
+  → 结构化理解论文/产品/benchmark 更新
   → 映射到 memory kernel 能力模块
   → 评估证据强度和适配度
   → 生成 ArchitectureImpactReport
@@ -63,8 +63,44 @@ ResearchItem
 
 - 论文 → `../papers/<short-slug>.md`
 - 产品/工程文章 → `../products/<short-slug>.md`
+- benchmark 协议 → `../benchmarks/<short-slug>.md`
+- benchmark 使用事件 → `../benchmarks/claims/claims.yaml`
 - slug 用 kebab-case,论文以一作姓或工作名为主(`longmemeval`、
   `memoryagentbench`)
+
+## 3.1 BenchmarkItem schema
+
+Benchmark 不是论文 note 的附属字段,而是一等实体。每个 benchmark note 至少记录:
+
+```text
+BenchmarkItem
+- benchmark_id
+- name
+- aliases
+- status              # candidate | seed | full
+- origin_type         # paper_origin | product_origin | community_origin | unknown
+- origin_source
+- first_public_date
+- domain
+- modality
+- task_grain
+- capability_axes
+- dataset_size
+- data_nature
+- metrics
+- judge_type
+- code_available
+- data_available
+- license
+- known_limitations
+- canonical_sources
+- confidence
+```
+
+任何带分数、排名或"最强"判断的 benchmark 使用,都必须进入
+`../benchmarks/claims/claims.yaml`,并拆分 `usage_type`、`reproduction_status`
+和 `independence_class`。厂商博客和产品页只能支持 `vendor_claim`;独立复现
+必须来自非关联第三方并给出足够实验设置。
 
 ## 4. 模块 taxonomy
 
@@ -126,7 +162,7 @@ ADR
 - migration path
 - rollout flag
 - rollback condition
-- benchmark evidence (link back to impact-reports/ here)
+- benchmark evidence (link back to impact-reports/ and benchmarks/claims here)
 ```
 
 ## 8. 演进规划
@@ -135,7 +171,7 @@ ADR
 
 ```text
 v0 (当前):
-- 手动维护 papers/ 和 products/
+- 手动维护 papers/、products/ 和 benchmarks/
 - 不做自动 radar,不做自动 ingest
 
 v0.5:

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -1,6 +1,6 @@
 ---
 title: Signals — agent memory news, releases, comparisons (reverse chrono)
-date: 2026-05-19
+date: 2026-06-11
 status: living-log
 language: zh-CN
 ---
@@ -10,7 +10,7 @@ language: zh-CN
 行业信号反时序日志。比"survey"更轻、比"twitter feed"更结构化。
 每条:**日期 / 来源 URL / 类型 / 一句话摘要 / Radar 动作**。
 
-类型 enum:`release` `comparison` `blog` `paper` `talk` `incident` `funding`
+类型 enum:`release` `comparison` `blog` `paper` `talk` `incident` `funding` `product`
 
 Radar 动作 enum:`stub` `deep-note` `impact-report` `archive-only`
 (`archive-only` 表示有趣但不进入 ResearchItem 流程)
@@ -19,6 +19,19 @@ Radar 动作 enum:`stub` `deep-note` `impact-report` `archive-only`
 
 | 日期 | 来源 | 类型 | 一句话 | Radar 动作 |
 |---|---|---|---|---|
+| 2026-06-11 | [EverOS](https://evermind.ai/everos) / [`EverMind-AI/EverOS`](https://github.com/EverMind-AI/EverOS) | product | EverMind/EverOS/EverMemOS 明确以 Profile/Episodic/Skill、self-evolving skills 和 Markdown export 切入 memory OS | `deep-note` ✅([`../products/everos.md`](../products/everos.md)) |
+| 2026-06-11 | [`MemTensor/MemOS`](https://github.com/MemTensor/MemOS) | release | MemOS 作为独立 self-evolving memory OS 出现,需与已有 MemoryOS/EverMemOS 区分 | `deep-note` ✅([`../products/memos.md`](../products/memos.md)) |
+| 2026-06-11 | [AWS AgentCore Memory](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/memory.html) / [Google Memory Bank](https://docs.cloud.google.com/gemini-enterprise-agent-platform/scale/memory-bank) / [Microsoft Foundry Memory](https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/what-is-memory) | product | hyperscaler agent platforms 同时把 managed long-term memory 做成 scope/TTL/strategy/CRUD 能力 | `deep-note` ✅(见 `products/`) |
+| 2026-06-11 | [Cloudflare Agent Memory](https://blog.cloudflare.com/introducing-agent-memory/) / [Oracle AI Agent Memory](https://docs.oracle.com/en/database/oracle/agent-memory/26.4/agmea/about.html) / [Alibaba Bailian Memory](https://help.aliyun.com/zh/model-studio/memory-library) | product | platform-managed memory 从 edge runtime、enterprise DB 到中文云平台三路扩散 | `deep-note` ✅(见 `products/`) |
+| 2026-06-11 | [Redis Agent Memory Server](https://redis.github.io/agent-memory-server/) / [OpenViking](https://volcengine-openviking.mintlify.app/) / [PowerMem](https://github.com/oceanbase/powermem) | release | OSS/DB 厂商路线开始提供 memory API server、context DB 和 Experience+Skill distillation | `deep-note` ✅(见 `products/`) |
+| 2026-06-11 | [Basic Memory](https://docs.basicmemory.com/) / [ByteRover](https://www.byterover.dev/) / [Honcho](https://github.com/plastic-labs/honcho) | product | coding-agent memory 形成 local-first Markdown、portable context tree、peer-centric memory 三条路线 | `deep-note` ✅(见 `products/`) |
+| 2026-06-11 | 多子 agent discovery log | product | 本轮把核心 memory 产品深度入库、相邻产品轻量索引,并新增整体产品架构文档 | `deep-note` ✅([`product-discovery-log.md`](product-discovery-log.md), [`product-memory-architectures.md`](product-memory-architectures.md)) |
+| 2026-05-31 | [`supermemory.ai`](https://supermemory.ai/) / [`supermemoryai/supermemory`](https://github.com/supermemoryai/supermemory) | release | Supermemory 把 memory、RAG、profiles、connectors 和 MCP/插件整合成 context cloud | `deep-note` ✅([`../products/supermemory.md`](../products/supermemory.md)) |
+| 2026-05-31 | [`Tencent/TencentDB-Agent-Memory`](https://github.com/Tencent/TencentDB-Agent-Memory) | release | TencentDB Agent Memory 开源 L0-L3 分层记忆与 Mermaid context offloading,最新 release `v0.3.6` | `deep-note` ✅([`../products/tencentdb-agent-memory.md`](../products/tencentdb-agent-memory.md)) |
+| 2026-05-31 | [`hy-memory.com`](https://hy-memory.com/) | release | 腾讯混元 Hy-Memory 作为 OpenClaw shared memory plugin 出现,主打 6-layer cognitive memory | `deep-note` ✅([`../products/hy-memory.md`](../products/hy-memory.md)) |
+| 2026-05-31 | [`vectorize-io/hindsight`](https://github.com/vectorize-io/hindsight) | release | Hindsight 以 "Agent Memory That Learns" 切入,提供 retain / recall / reflect 与 LLM wrapper | `deep-note` ✅([`../products/hindsight.md`](../products/hindsight.md)) |
+| 2026-05-31 | [Anuma](https://www.anuma.ai/ai-memory) / [Personal AI](https://www.personal.ai/products) / [Kinic](https://www.kinic.io/) | product | C 端 memory ownership 路线升温:跨模型、可编辑、可携带或可验证的个人 memory | `deep-note` ✅(见 `products/`) |
+| 2026-05-31 | [MemoryOS](https://github.com/BAI-LAB/MemoryOS) / [A-MEM](https://github.com/agiresearch/A-mem) / [MemX](https://memx.me/) | release | 开源框架侧出现 OS-style、agentic organization、local-first single-file 三条不同 memory 路线 | `deep-note` ✅(见 `products/`) |
 | 2026-05 | mem0.ai/blog "State of AI Agent Memory 2026" | comparison | 6 大主流 memory layer 横评,Mem0 自家算法在 LoCoMo / LongMemEval 都报 SOTA | `archive-only`(自评,需交叉验证) |
 | 2026-05 | arXiv 2605.06716 "From Storage to Experience" | paper | Storage → Reflection → Experience 三阶段记忆演进框架 | `deep-note` ✅ |
 | 2026-04 | mem0.ai blog | release | Mem0 算法 v2:single-pass hierarchical extraction + multi-signal retrieval,声称 temporal +29.6 / multi-hop +23.1 | `deep-note` ✅(更新 [`../products/mem0.md`](../products/mem0.md))|
@@ -54,6 +67,9 @@ Radar 动作 enum:`stub` `deep-note` `impact-report` `archive-only`
   靠用户使用反推
 - **LangMem 与 LangGraph checkpoint 的关系**:LangChain 的 memory 故事 2026
   又重写了一遍,等 LangGraph v1 稳定后建笔记
+- **小型 OSS/MCP memory servers 的证据补齐**:MemMachine、mem9、Memstate、ClawMem、
+  agentmemory、SimpleMem 等先留在 discovery log,等 license/release health 与
+  canonical docs 查清再决定是否 deep-note
 
 ## 维护说明
 

--- a/impact-reports/README.md
+++ b/impact-reports/README.md
@@ -1,12 +1,15 @@
 # Impact reports
 
-Impact reports are the bridge between a full ResearchItem and a concrete
-memory-kernel decision. They should be written only when a paper or product note
-is strong enough to affect architecture, experiments, or an ADR.
+Impact reports are the bridge between a full ResearchItem or BenchmarkItem and a
+concrete memory-kernel decision. They should be written only when a paper,
+product, or benchmark note is strong enough to affect architecture,
+experiments, or an ADR.
 
 This directory is intentionally empty except for this guide until the first
 candidate needs review. Do not cite `stub` notes as evidence here; upgrade the
-source note to `full` first.
+source note to `full` first. Benchmark score claims also need a matching event
+in `../benchmarks/claims/claims.yaml`, so vendor claims and independent
+reproductions do not get mixed.
 
 ## Minimal template
 
@@ -14,8 +17,11 @@ source note to `full` first.
 # <short title>
 
 ## Source
-- ResearchItem: ../papers/<slug>.md or ../products/<slug>.md
+- ResearchItem or BenchmarkItem: ../papers/<slug>.md, ../products/<slug>.md,
+  or ../benchmarks/<slug>.md
 - Status: full
+- Claims ledger refs: ../benchmarks/claims/claims.yaml#<event_id> when benchmark
+  usage or score claims are part of the evidence.
 
 ## Problem
 - What memory-kernel problem this candidate addresses.
@@ -29,6 +35,8 @@ source note to `full` first.
 
 ## Evidence
 - Benchmark, product behavior, implementation detail, or source-page evidence.
+- Keep vendor self-report, affiliated evaluation, critique, and independent
+  reproduction in separate bullets.
 
 ## Costs and risks
 - Implementation cost:

--- a/papers/convomem.md
+++ b/papers/convomem.md
@@ -89,6 +89,9 @@ answer),在某些场景下甚至**比 long-context 还高**(70.8% vs 63.5%),且
 - 评测 protocol 完全开源,且声称已经把 LongMemEval 与 LoCoMo 也都迁入此框
   架(可统一回归)。
 
+> Benchmark record: [`../benchmarks/convomem.md`](../benchmarks/convomem.md);
+> usage ledger: [`../benchmarks/claims/claims.yaml`](../benchmarks/claims/claims.yaml)。
+
 ## 决策相关性 / Decision relevance
 
 - **直接进入 `evaluator-benchmark` v0 的金牌评测三件套**:LongMemEval +

--- a/papers/locomo.md
+++ b/papers/locomo.md
@@ -42,6 +42,9 @@ last_revised: 2026-05-19
   需要保留时间序列
 - LoCoMo 可作为 `evaluator-benchmark` 中"事实+时间+因果"维度的标准
 
+> Benchmark record: [`../benchmarks/locomo.md`](../benchmarks/locomo.md);
+> usage ledger: [`../benchmarks/claims/claims.yaml`](../benchmarks/claims/claims.yaml)。
+
 ## 与 LongMemEval / MemoryAgentBench 对比
 
 (待写)

--- a/papers/longmemeval.md
+++ b/papers/longmemeval.md
@@ -70,6 +70,9 @@ TR 两类上仍显著落后于人类(差距 20+ 点),其中 ABS 几乎全员 50%
 - 按能力分层报告,而非单一 overall。
 - 给出 stratified subset 以便快速回归(适合 CI)。
 
+> Benchmark record: [`../benchmarks/longmemeval.md`](../benchmarks/longmemeval.md);
+> usage ledger: [`../benchmarks/claims/claims.yaml`](../benchmarks/claims/claims.yaml)。
+
 但 ConvoMem(papers/convomem.md)在 2025 年 11 月发文挑战 LongMemEval 的统计
 学有效性:Preferences 类别只有 30 题,误差棒接近 ±18%;且 filler conversations
 来自其他 benchmark,可能引入风格泄漏。`evaluator-benchmark` 在采用

--- a/papers/mem0-paper.md
+++ b/papers/mem0-paper.md
@@ -78,6 +78,10 @@ extraction 流程图。关键设计:
 - 局限:Full-context 仍是 J 最高(72.90),Mem0 / Mem0g 都没追平,只能在
   cost / latency 上赢。
 
+> Benchmark record: [`../benchmarks/locomo.md`](../benchmarks/locomo.md);
+> event ledger row: `mem0-paper-locomo-2025` in
+> [`../benchmarks/claims/claims.yaml`](../benchmarks/claims/claims.yaml)。
+
 ## 决策相关性 / Decision relevance
 
 - **ADD / UPDATE / DELETE / NOOP 四 op** 是 memory kernel `memorydiff-generator` 的

--- a/papers/memoryagentbench.md
+++ b/papers/memoryagentbench.md
@@ -30,6 +30,10 @@ selective forgetting
 每个维度独立可评估,可帮助定位 memory 系统的真实瓶颈,而不是混在端到端 QA
 分数里。
 
+> Benchmark record:
+> [`../benchmarks/memoryagentbench.md`](../benchmarks/memoryagentbench.md);
+> usage ledger: [`../benchmarks/claims/claims.yaml`](../benchmarks/claims/claims.yaml)。
+
 ## Method summary
 
 (待精读后填充)

--- a/products/a-mem.md
+++ b/products/a-mem.md
@@ -1,0 +1,81 @@
+---
+title: A-MEM
+type: product
+source: https://github.com/agiresearch/A-mem
+date_first_seen: 2025-02
+domain: research-agent-memory
+business_model: OSS / research
+license: MIT
+memory_modules:
+  - ingest-adapter
+  - semantic-dedup
+  - retriever-reranker
+  - dream-consolidator
+status: seed
+last_revised: 2026-05-31
+archive: archives/a-mem-overview.md
+---
+
+# A-MEM
+
+## 1. 一句话定位
+
+A-MEM 是面向 LLM agents 的 agentic memory 系统,用 Zettelkasten 式动态组织、
+索引和链接记忆,让 memory 在写入时就能自组织和演化。
+
+## 2. 是什么 / 做什么
+
+项目提出的核心问题是:传统 memory system 只做存储/检索,缺少高级组织能力。
+A-MEM 让系统在新增、更新、删除 memory 时自动生成 note、tags、keywords、
+context,并把相关记忆连接起来。
+
+仓库提供可用于 agent construction 的 memory system;论文复现实验另有
+`WujiangXu/AgenticMemory`。
+
+截至 2026-05-31 查询,GitHub metadata 约 1.0k stars / 112 forks,MIT license,
+无正式 release。
+
+## 3. 关键技术选择
+
+- **组织原则**:Zettelkasten / interconnected notes
+- **存储与检索**:ChromaDB vector storage + semantic search
+- **写入时演化**:自动更新 tags、context、semantic links
+- **元数据**:custom tags/categories、keyword extraction、timestamps
+- **LLM backend**:OpenAI 与 Ollama
+
+## 4. 决策相关性 / Decision relevance
+
+- **对照点**:A-MEM 的重点是 write-time organization,不是 query-time rerank;
+  这与 memory kernel 的 consolidate/diff 设计高度相关。
+- **借鉴点**:
+  - "新增记忆时主动找关系并更新 metadata"可作为 `dream-consolidator` 的
+    online 版本参考。
+  - Zettelkasten 类 note graph 给出了比裸向量更可解释的用户层结构。
+  - OpenAI + Ollama 双后端说明研究系统也在追求本地化。
+- **差异点**:A-MEM 的自动 mutation 缺少显式 diff 审批,与本仓强调的
+  audit-first 方向不同。
+
+## 5. 适用 / 不适用场景
+
+- **适用**:研究 agentic memory organization;构建个人或研究型 LLM agent;
+  想测试 Zettelkasten 式 memory graph。
+- **不适用**:企业生产场景;需要 formal release 和稳定 API 的应用;要求
+  mutation 全部可人工审批的高审计系统。
+
+## 6. 注意事项 / 风险
+
+- **无 release**:截至抓取时 GitHub 无正式 releases,API 稳定性未知。
+- **自动演化风险**:记忆关系和 metadata 自动更新可能引入不可见 drift。
+- **复现分离**:系统仓库和论文复现仓库不同,引用实验数字时要指向正确来源。
+
+## 7. 进一步阅读
+
+- archive: [`archives/a-mem-overview.md`](archives/a-mem-overview.md)
+- GitHub:https://github.com/agiresearch/A-mem
+- Paper:https://arxiv.org/abs/2502.12110
+- Reproduction repo:https://github.com/WujiangXu/AgenticMemory
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/alibaba-bailian-memory.md
+++ b/products/alibaba-bailian-memory.md
@@ -1,0 +1,67 @@
+---
+title: Alibaba Cloud Bailian Memory Library
+type: product
+source: https://help.aliyun.com/zh/model-studio/memory-library
+date_first_seen: 2026-06
+domain: platform-managed-memory
+business_model: Alibaba Cloud Model Studio managed API
+license: Proprietary cloud service
+memory_modules:
+  - ingest-adapter
+  - semantic-dedup
+  - retriever-reranker
+  - policy-privacy
+status: seed
+last_revised: 2026-06-11
+archive: archives/alibaba-bailian-memory-overview.md
+---
+
+# Alibaba Cloud Bailian Memory Library
+
+## 1. 一句话定位
+
+阿里云百炼记忆库 / 长期记忆 API 是 Model Studio 的托管长期记忆能力,用于从历史
+对话中自动抽取、结构化存储并检索用户画像和记忆片段。
+
+## 2. 是什么 / 做什么
+
+官方帮助文档描述了 long-term memory API:系统从历史对话自动提取 memory fragments
+和 user profile,开发者再通过检索结果注入 prompt。文档还说明 open API 可接入任意
+应用,并支持共享记忆库。
+
+## 3. 关键技术选择
+
+- **Memory library**:以 memory library / `memoryId` 管理长期记忆体。
+- **Add/Search flow**:`AddMemory` 写入,`SearchMemory` 检索。
+- **结构化抽取**:偏好、事实、画像等从对话中自动抽取。
+- **跨应用共享**:官方文档强调开放 API 和共享记忆库。
+
+## 4. 决策相关性 / Decision relevance
+
+- **对照点**:百炼代表国内云平台把 long-term memory API 产品化的路线。
+- **借鉴点**:memory fragments + user profile 的双层输出很适合对照 `profile` 与
+  atomic memory 的边界。
+- **差异点**:平台托管 API,不暴露底层 store 与 consolidation 细节。
+
+## 5. 适用 / 不适用场景
+
+- **适用**:已在阿里云百炼/Model Studio 上开发对话 agent;需要中文生态和云端托管
+  memory API 的团队。
+- **不适用**:跨云/本地优先 memory;需要 Markdown/git 可审计 artifact 的应用。
+
+## 6. 注意事项 / 风险
+
+- **平台依赖**:与百炼账号、API、限额和地域策略绑定。
+- **透明度**:抽取、去重、冲突合并和排序逻辑由平台控制。
+- **边界**:与 PolarDB/PolarSearch 的 Memory Container 是相邻但不同的产品线。
+
+## 7. 进一步阅读
+
+- archive: [`archives/alibaba-bailian-memory-overview.md`](archives/alibaba-bailian-memory-overview.md)
+- 记忆库:https://help.aliyun.com/zh/model-studio/memory-library
+- 长期记忆 API:https://help.aliyun.com/zh/model-studio/long-term-memory-2-0
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/anuma.md
+++ b/products/anuma.md
@@ -1,0 +1,80 @@
+---
+title: Anuma
+type: product
+source: https://www.anuma.ai/ai-memory
+date_first_seen: 2026-01
+domain: personal-portable-memory
+business_model: SaaS / consumer AI app
+license: proprietary
+memory_modules:
+  - ingest-adapter
+  - semantic-dedup
+  - audit-ui
+  - security-privacy
+status: seed
+last_revised: 2026-05-31
+archive: archives/anuma-ai-memory-overview.md
+---
+
+# Anuma
+
+## 1. 一句话定位
+
+Anuma 是一个主打跨模型、私有、可携带 AI memory 的消费级 AI 平台:同一份
+memory 在 ChatGPT、Claude、Gemini、DeepSeek、Kimi 等模型之间复用。
+
+## 2. 是什么 / 做什么
+
+Anuma 把问题定义为"各大 AI 平台的 memory 被锁在各自生态里"。它提供一个
+统一 memory layer,让用户只建立一次 context,后续不同模型都能读到。
+
+产品页强调:
+
+- memory 加密在用户设备上
+- 服务器只处理路由,不持有可读 plaintext memory
+- 用户可以手动添加、编辑、标记 private、删除 memory
+- memory 可导出
+- 移动端、桌面端和 SMS / iMessage 场景共享同一份加密 memory
+
+## 3. 关键技术选择
+
+- **隐私叙事**:on-device encryption + user-owned memory
+- **跨模型**:同一 memory 可跨 closed-source 与 open-source 模型
+- **控制粒度**:单条 memory 可编辑、删除、标记 private
+- **portable context**:把 memory portability 放在核心卖点
+
+## 4. 决策相关性 / Decision relevance
+
+- **对照点**:Anuma 是"memory ownership"路线的代表,不是 agent developer
+  infra。
+- **借鉴点**:
+  - 单条 memory 的 edit/delete/private 控制是 `audit-ui` 与
+    `security-privacy` 的强需求。
+  - "跨模型记忆"可以作为 vendor-neutral memory kernel 的 C 端价值表达。
+  - device-encrypted memory 提醒我们在 schema 中区分 plaintext、encrypted
+    payload 与 source metadata。
+- **差异点**:技术实现未开源,不能直接借用底层算法。
+
+## 5. 适用 / 不适用场景
+
+- **适用**:个人用户跨多个 AI 模型复用 context;关注 memory ownership 与
+  导出的用户。
+- **不适用**:需要 server-side agent SDK、企业 RAG、开源 self-host 的开发者。
+
+## 6. 注意事项 / 风险
+
+- **实现不透明**:加密、同步、导出格式与 open-source routing 的具体机制需
+  以官方文档为准。
+- **privacy claim 需验证**:官网声明不等于安全审计。
+- **C 端定位**:它解决的是用户跨模型 context,不是团队 agent memory 后端。
+
+## 7. 进一步阅读
+
+- archive: [`archives/anuma-ai-memory-overview.md`](archives/anuma-ai-memory-overview.md)
+- 官方:https://www.anuma.ai/
+- AI memory page:https://www.anuma.ai/ai-memory
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/archives/a-mem-overview.md
+++ b/products/archives/a-mem-overview.md
@@ -1,0 +1,32 @@
+---
+source_url: https://github.com/agiresearch/A-mem
+fetched: 2026-05-31
+purpose: research backup; canonical is the URL above
+---
+
+# A-MEM — snapshot
+
+## Positioning
+
+A-MEM is an agentic memory system for LLM agents. It focuses on dynamically
+organizing and evolving memories rather than only storing and retrieving them.
+
+## Core Ideas
+
+- Zettelkasten-inspired memory organization.
+- ChromaDB-based vector storage and semantic search.
+- Automatic note generation with metadata, tags, keywords, context, and
+  timestamps.
+- Memory evolution that updates metadata and creates semantic links between
+  related memories.
+- OpenAI and Ollama backends.
+
+## Metadata
+
+Repository metadata fetched 2026-05-31: `agiresearch/A-mem` had roughly 1.0k
+stars, 112 forks, MIT license, and no formal release.
+
+## Evidence Boundary
+
+The memory system repository and paper reproduction repository are separate.
+Use the reproduction repository when citing benchmark numbers.

--- a/products/archives/alibaba-bailian-memory-overview.md
+++ b/products/archives/alibaba-bailian-memory-overview.md
@@ -1,0 +1,27 @@
+---
+source_url: https://help.aliyun.com/zh/model-studio/memory-library
+source_api: https://help.aliyun.com/zh/model-studio/long-term-memory-2-0
+fetched: 2026-06-11
+purpose: research backup; canonical sources are the URLs above
+---
+
+# Alibaba Cloud Bailian Memory Library — snapshot
+
+## Positioning
+
+Alibaba Cloud Model Studio / Bailian documents a memory library and long-term
+memory API for extracting, storing, retrieving, and injecting user memory in
+agent applications.
+
+## Public Architecture
+
+- Historical dialogue is processed into memory fragments and user profiles.
+- Developers call APIs such as `AddMemory` and `SearchMemory`.
+- Retrieval results are injected into prompts by the application.
+- The docs describe open API integration and shared memory libraries across
+  applications.
+
+## Evidence Boundary
+
+This is a cloud managed API. Internal extraction, merge, conflict resolution,
+and ranking behavior are not fully public.

--- a/products/archives/anuma-ai-memory-overview.md
+++ b/products/archives/anuma-ai-memory-overview.md
@@ -1,0 +1,28 @@
+---
+source_url: https://www.anuma.ai/ai-memory
+fetched: 2026-05-31
+purpose: research backup; canonical is the URL above
+---
+
+# Anuma AI Memory — snapshot
+
+## Positioning
+
+Anuma presents a unified AI memory that travels across ChatGPT, Claude, Gemini,
+DeepSeek, Kimi, and other models. The product is positioned around private,
+portable context rather than a developer memory SDK.
+
+## Product Claims
+
+- One persistent knowledge base shared across models.
+- Memory encrypted on the user's device.
+- Servers route requests but do not hold readable memory, according to the
+  product page.
+- Users can add, edit, mark private, export, and delete memory entries.
+- Memory syncs across mobile, desktop, and SMS/iMessage surfaces.
+
+## Evidence Boundary
+
+The page is a commercial product description. Encryption and privacy claims
+should be verified against technical docs or audits before being treated as
+security evidence.

--- a/products/archives/aws-agentcore-memory-overview.md
+++ b/products/archives/aws-agentcore-memory-overview.md
@@ -1,0 +1,29 @@
+---
+source_url: https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/memory.html
+source_docs: https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/memory-strategies.html
+fetched: 2026-06-11
+purpose: research backup; canonical sources are the URLs above
+---
+
+# AWS Bedrock AgentCore Memory — snapshot
+
+## Positioning
+
+AWS Bedrock AgentCore Memory is a managed memory layer for AgentCore agents. It
+addresses the statelessness of agent calls by keeping short-term and long-term
+memory across sessions.
+
+## Public Architecture
+
+- Short-term memory stores session events and active conversation state.
+- Long-term memory automatically extracts key insights, preferences, facts, and
+  summaries from sessions.
+- Memory strategies decide which categories are extracted and how they are
+  maintained.
+- Memory is scoped through AgentCore memory resources and sessions.
+
+## Evidence Boundary
+
+This is a cloud-platform memory capability. Internal store implementation,
+conflict resolution, and exact ranking behavior are not fully exposed in the
+overview docs.

--- a/products/archives/basic-memory-overview.md
+++ b/products/archives/basic-memory-overview.md
@@ -1,0 +1,27 @@
+---
+source_url: https://docs.basicmemory.com/
+source_repo: https://github.com/basicmachines-co/basic-memory
+fetched: 2026-06-11
+purpose: research backup; canonical sources are the URLs above
+---
+
+# Basic Memory — snapshot
+
+## Positioning
+
+Basic Memory is a local-first AI memory and knowledge graph where every piece of
+AI context is a human-readable Markdown file.
+
+## Public Architecture
+
+- Plain Markdown files are the source of truth.
+- Observations, wikilinks, and relations form a semantic knowledge graph.
+- MCP connects the memory to Claude, Codex, Cursor, ChatGPT, VS Code, and other
+  clients.
+- Users can run locally or use Basic Memory Cloud for sync, backups, and web/
+  mobile access.
+
+## Evidence Boundary
+
+Basic Memory crosses the boundary between PKM and agent memory. It is included
+as Tier A because memory is first-class, inspectable, and MCP-native.

--- a/products/archives/byterover-overview.md
+++ b/products/archives/byterover-overview.md
@@ -1,0 +1,27 @@
+---
+source_url: https://www.byterover.dev/
+source_repo: https://github.com/campfirein/byterover-cli
+source_docs: https://docs.byterover.dev/connectors/overview
+fetched: 2026-06-11
+purpose: research backup; canonical sources are the URLs above
+---
+
+# ByteRover — snapshot
+
+## Positioning
+
+ByteRover, formerly Cipher, positions itself as a portable memory layer for
+autonomous coding agents.
+
+## Public Architecture
+
+- The CLI/repo exposes the `brv` workflow and coding-agent connectors.
+- Public positioning centers on a project memory/context tree rather than
+  generic chat history.
+- MCP and connector surfaces let multiple agents consume the same context.
+
+## Evidence Boundary
+
+ByteRover and Cipher are treated as aliases of one product family. License and
+cloud/commercial terms should be checked before any production dependency
+decision.

--- a/products/archives/cloudflare-agent-memory-overview.md
+++ b/products/archives/cloudflare-agent-memory-overview.md
@@ -1,0 +1,30 @@
+---
+source_url: https://blog.cloudflare.com/introducing-agent-memory/
+source_docs: https://developers.cloudflare.com/agents/concepts/conversation-state-and-memory/
+fetched: 2026-06-11
+purpose: research backup; canonical sources are the URLs above
+---
+
+# Cloudflare Agent Memory — snapshot
+
+## Positioning
+
+Cloudflare documents memory as part of its Agents platform. The docs separate
+conversation history from context memory, while the Agent Memory announcement
+positions memory as what turns a stateless LLM call into a persistent,
+context-aware agent.
+
+## Public Architecture
+
+- Conversation history persists messages and tool calls in a tree-structured
+  history backed by a Session Provider, defaulting to SQLite.
+- Context memory is injected into the system prompt and can be read-only,
+  writable short-form, searchable, or loadable as Skills.
+- Writable context can auto-wire to a SQLite-backed provider.
+- Searchable context can use the built-in FTS5 provider or an external provider.
+
+## Evidence Boundary
+
+The Session memory API is documented as experimental. Agent Memory availability
+should be treated as private beta / early platform capability unless Cloudflare
+documents GA status later.

--- a/products/archives/everos-overview.md
+++ b/products/archives/everos-overview.md
@@ -1,0 +1,31 @@
+---
+source_url: https://evermind.ai/everos
+source_repo: https://github.com/EverMind-AI/EverOS
+fetched: 2026-06-11
+purpose: research backup; canonical sources are the URLs above
+---
+
+# EverOS — snapshot
+
+## Positioning
+
+EverOS is presented as an AI agent memory operating system by EverMind. The page
+emphasizes self-evolving memory, multimodal input, cross-agent/cross-platform
+operation, cloud deployment, and self-hosting.
+
+## Product Claims
+
+- Compatible with Claude Code, Codex, OpenClaw, Hermes, MCP, OpenAI SDK, and
+  Anthropic SDK.
+- One-call ingestion for messages, images, documents, PDFs, spreadsheets,
+  slides, URLs, and other inputs.
+- Auto-tags memory as Profile, Episodic, or Skill.
+- Case traces can be distilled offline into reusable Skill Memories.
+- Memory can export as Markdown; the page describes the open-source repo as
+  Apache 2.0.
+
+## Evidence Boundary
+
+Accuracy, latency, token/cost, and benchmark numbers on the product page are
+treated as vendor-claimed unless independently reproduced. EverMind, EverOS, and
+EverMemOS are treated as one product family in this repo.

--- a/products/archives/google-memory-bank-overview.md
+++ b/products/archives/google-memory-bank-overview.md
@@ -1,0 +1,25 @@
+---
+source_url: https://docs.cloud.google.com/gemini-enterprise-agent-platform/scale/memory-bank
+fetched: 2026-06-11
+purpose: research backup; canonical source is the URL above
+---
+
+# Google Agent Platform Memory Bank — snapshot
+
+## Positioning
+
+Memory Bank is a Gemini Enterprise Agent Platform capability for managed
+long-term memories generated from user-agent conversations.
+
+## Product Claims
+
+- Dynamically generates long-term memories from conversations.
+- Uses scoped identities such as agent and user.
+- Supports event ingestion, custom extraction, multimodal inputs, TTL, revisions,
+  and integration with Google agent tooling.
+- Docs include guidance around prompt injection and memory poisoning.
+
+## Evidence Boundary
+
+The documentation is marked Preview / Pre-GA. Treat availability and API surface
+as unstable until Google updates the status.

--- a/products/archives/hindsight-overview.md
+++ b/products/archives/hindsight-overview.md
@@ -1,0 +1,38 @@
+---
+source_url: https://github.com/vectorize-io/hindsight
+fetched: 2026-05-31
+purpose: research backup; canonical is the URL above
+---
+
+# Hindsight — snapshot
+
+## Positioning
+
+Hindsight positions itself as an agent memory system that learns over time, not
+only a conversation-history recall layer.
+
+## Product Shape
+
+The repo provides:
+
+- Docker server and UI
+- Python and TypeScript clients
+- LLM wrapper for automatic memory capture/retrieval
+- embedded Python mode
+- APIs around retain, recall, and reflect
+
+It targets conversational agents, per-user memory, and open-ended autonomous
+task agents.
+
+## Metadata
+
+Repository metadata fetched 2026-05-31: `vectorize-io/hindsight` had roughly
+15.2k stars, 857 forks, MIT license, and latest release `v0.7.1` published
+2026-05-28.
+
+## Evidence Boundary
+
+The README presents LongMemEval benchmark claims and says some results were
+reproduced by research collaborators. This snapshot still treats the comparison
+table as project-reported evidence unless the reproduction artifact is reviewed
+directly.

--- a/products/archives/honcho-overview.md
+++ b/products/archives/honcho-overview.md
@@ -1,0 +1,29 @@
+---
+source_url: https://github.com/plastic-labs/honcho
+source_docs: https://docs.honcho.dev/
+fetched: 2026-06-11
+purpose: research backup; canonical sources are the URLs above
+---
+
+# Honcho — snapshot
+
+## Positioning
+
+Honcho is memory infrastructure for stateful agents that understand changing
+people, agents, groups, projects, and ideas over time.
+
+## Public Architecture
+
+- Workspaces isolate use cases.
+- Peers model humans, agents, groups, and other participants.
+- Sessions hold messages and documents.
+- Background reasoning updates peer representations.
+- Query surfaces include peer representations, session context, hybrid search,
+  and natural-language insights.
+- Integrations include SDKs, MCP, Claude Code, OpenCode, OpenClaw, Hermes, and
+  Cursor-compatible clients.
+
+## Evidence Boundary
+
+Evals and "Pareto Frontier" language are official/vendor claims. AGPL-3.0
+license should be considered before closed-source embedding.

--- a/products/archives/hy-memory-overview.md
+++ b/products/archives/hy-memory-overview.md
@@ -1,0 +1,46 @@
+---
+source_url: https://hy-memory.com/
+fetched: 2026-05-31
+purpose: research backup; canonical is the URL above
+---
+
+# Hy-Memory — snapshot
+
+## Positioning
+
+Hy-Memory is presented as an OpenClaw shared memory plugin based on Tencent
+Hunyuan's high-dimensional cognitive memory evolution framework. It is designed
+to let multiple agents query a centralized long-term memory core.
+
+## Core Architecture
+
+The public site describes a six-layer memory kernel:
+
+- L1 raw traces
+- L2 atomic facts
+- L3 identity profile
+- L4-L6 mind and intent layers
+
+The plugin recalls relevant memory before chat processing and captures new facts
+asynchronously after model output.
+
+## Deployment Shape
+
+The documented installation path is through OpenClaw:
+
+```bash
+openclaw plugins install openclaw-hy-memory --dangerously-force-unsafe-install
+openclaw hy-memory init
+openclaw gateway restart
+openclaw hy-memory status
+```
+
+The site indicates a Python sidecar process, Chroma vector store, OpenAI-style
+LLM/embedding configuration, and Hunyuan 3.0 Preview as the recommended
+extraction model.
+
+## Evidence Boundary
+
+The page claims MIT licensing and links to a GitHub repository slot, but the
+resolved link did not expose a concrete repository at fetch time. Benchmark
+numbers shown on the site are treated as vendor claims.

--- a/products/archives/kinic-overview.md
+++ b/products/archives/kinic-overview.md
@@ -1,0 +1,31 @@
+---
+source_url: https://www.kinic.io/
+fetched: 2026-05-31
+purpose: research backup; canonical is the URL above
+---
+
+# Kinic — snapshot
+
+## Positioning
+
+Kinic presents itself as a cryptographically secure, searchable personal memory
+for AI. It focuses on bookmarks, emails, notes, documents, and other personal
+data that can augment AI agents.
+
+## Product Shape
+
+- Browser plugin for collecting personal data.
+- Personal vector database for trusted AI-powered search.
+- User-owned datastore with update/delete controls.
+- Kinic Vector DB on Internet Computer, with claims around tamper-proof storage
+  and privacy-preserving technology.
+
+## Memory Economy Angle
+
+Kinic also promotes a market for shared or rented personal AI memory stores, for
+example expert or creator datasets.
+
+## Evidence Boundary
+
+The blockchain and privacy claims are product claims. They need separate
+technical and legal review before being used as compliance evidence.

--- a/products/archives/memoryos-overview.md
+++ b/products/archives/memoryos-overview.md
@@ -1,0 +1,31 @@
+---
+source_url: https://github.com/BAI-LAB/MemoryOS
+fetched: 2026-05-31
+purpose: research backup; canonical is the URL above
+---
+
+# MemoryOS — snapshot
+
+## Positioning
+
+MemoryOS is an open-source memory operating system for personalized AI agents.
+It draws on operating-system memory management ideas to manage short-term,
+mid-term, and long-term agent memory.
+
+## Components
+
+- Storage, updating, retrieval, and generation modules.
+- Python library examples.
+- MemoryOS-MCP server with add_memory, retrieve_memory, and get_user_profile.
+- ChromaDB-backed implementation.
+- LoCoMo-related evaluation materials.
+
+## Metadata
+
+Repository metadata fetched 2026-05-31: `BAI-LAB/MemoryOS` had roughly 1.4k
+stars, 137 forks, Apache 2.0 license, and release `V1.2` published 2025-07-18.
+
+## Evidence Boundary
+
+The project is research-oriented. Benchmark claims should be checked through the
+paper and reproducibility artifacts before use in decision documents.

--- a/products/archives/memos-overview.md
+++ b/products/archives/memos-overview.md
@@ -1,0 +1,27 @@
+---
+source_url: https://github.com/MemTensor/MemOS
+source_docs: https://memos.openmem.net/
+fetched: 2026-06-11
+purpose: research backup; canonical sources are the URLs above
+---
+
+# MemOS — snapshot
+
+## Positioning
+
+MemTensor MemOS describes itself as a self-evolving memory OS for LLMs and AI
+agents. Its public positioning centers on ultra-persistent memory, hybrid
+retrieval, and cross-task skill reuse.
+
+## Product Claims
+
+- Memory is framed as an OS-like resource for agents.
+- The repo emphasizes hybrid retrieval and skill reuse.
+- Public headline claims include token savings; these are recorded as
+  self-reported.
+
+## Evidence Boundary
+
+This snapshot distinguishes MemTensor MemOS from BAI-LAB MemoryOS and EverMemOS.
+The next review pass should inspect code paths, release health, and any linked
+paper before promoting claims beyond seed status.

--- a/products/archives/memx-overview.md
+++ b/products/archives/memx-overview.md
@@ -1,0 +1,33 @@
+---
+source_url: https://memx.me/
+source_repo: https://github.com/memxlab/memx
+fetched: 2026-05-31
+purpose: research backup; canonical sources are the URLs above
+---
+
+# MemX — snapshot
+
+## Positioning
+
+MemX is a local-first long-term memory system for AI assistants. It emphasizes a
+single local file, no cloud account, no tracking, and no sync server.
+
+## Architecture Claims
+
+- Single libSQL file for storage.
+- Vector search and keyword search with Reciprocal Rank Fusion.
+- Re-ranking based on semantic similarity, recency, retrieval frequency, and
+  explicit importance.
+- Low-confidence queries return no result rather than a weak memory match.
+- Works with OpenAI-compatible embedding APIs, including local options.
+
+## Metadata
+
+Repository metadata fetched 2026-05-31: `memxlab/memx` had roughly 2 stars and
+Apache 2.0 metadata. The product site described v0.1.0 as open source under MIT,
+so the license should be verified from the repository before reuse.
+
+## Evidence Boundary
+
+This is an early project with small benchmarks. It is tracked as a local-first
+design signal, not a mature production memory framework.

--- a/products/archives/microsoft-foundry-memory-overview.md
+++ b/products/archives/microsoft-foundry-memory-overview.md
@@ -1,0 +1,26 @@
+---
+source_url: https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/what-is-memory
+fetched: 2026-06-11
+purpose: research backup; canonical source is the URL above
+---
+
+# Microsoft Foundry Agent Service Memory — snapshot
+
+## Positioning
+
+Microsoft Foundry Agent Service Memory is documented as a preview capability for
+agents built on Microsoft Foundry. It provides a managed memory store and agent
+tools for remembering, forgetting, and retrieving scoped memory.
+
+## Product Claims
+
+- Memory items are scoped and can have default TTL.
+- Developer-visible operations include memory item CRUD and direct remember /
+  forget behavior.
+- Public concepts include user profile memory, chat summaries, and procedural
+  memory.
+
+## Evidence Boundary
+
+The feature is documented as preview/public preview. Treat the API and
+production guarantees as evolving.

--- a/products/archives/openviking-overview.md
+++ b/products/archives/openviking-overview.md
@@ -1,0 +1,30 @@
+---
+source_url: https://volcengine-openviking.mintlify.app/
+source_repo: https://github.com/volcengine/OpenViking
+fetched: 2026-06-11
+purpose: research backup; canonical sources are the URLs above
+---
+
+# OpenViking — snapshot
+
+## Positioning
+
+OpenViking is an open-source context database for AI agents. It unifies memory,
+resources, and skills through a filesystem paradigm and provides hierarchical
+context loading plus semantic retrieval.
+
+## Public Architecture
+
+- Virtual filesystem with `viking://` URIs.
+- L0/L1/L2 layers: abstracts, overviews, and full details loaded on demand.
+- Directory recursive retrieval with intent analysis, directory positioning, and
+  fine exploration.
+- Session management extracts six memory categories: profile, preferences,
+  entities, events, cases, and patterns.
+- Integrations include OpenClaw, OpenCode, Claude Desktop, and MCP.
+
+## Evidence Boundary
+
+OpenClaw completion and token-cost improvements on the docs page are vendor-
+claimed benchmark results. OpenViking should be described as a context database
+with first-class memory, not as a pure memory layer.

--- a/products/archives/oracle-ai-agent-memory-overview.md
+++ b/products/archives/oracle-ai-agent-memory-overview.md
@@ -1,0 +1,27 @@
+---
+source_url: https://docs.oracle.com/en/database/oracle/agent-memory/26.4/agmea/about.html
+fetched: 2026-06-11
+purpose: research backup; canonical source is the URL above
+---
+
+# Oracle AI Agent Memory — snapshot
+
+## Positioning
+
+Oracle AI Agent Memory provides a persistent memory layer for enterprise AI
+agents on Oracle AI Database.
+
+## Public Architecture
+
+- Short-term memory uses thread context cards and conversation summaries to keep
+  recent turns, task state, and intermediate progress.
+- Long-term memory uses `add` and `search` workflows for user preferences,
+  learned rules, and facts from earlier interactions.
+- Oracle positions AI Database as the converged foundation for vector, graph,
+  JSON, and transactional memory needs.
+- The docs mention MCP Server integration and external framework use.
+
+## Evidence Boundary
+
+Oracle explicitly places authentication, authorization, and correct memory
+scoping responsibility on the integrating application.

--- a/products/archives/personal-ai-overview.md
+++ b/products/archives/personal-ai-overview.md
@@ -1,0 +1,27 @@
+---
+source_url: https://www.personal.ai/products
+fetched: 2026-05-31
+purpose: research backup; canonical is the URL above
+---
+
+# Personal AI — snapshot
+
+## Positioning
+
+Personal AI frames memory as the basis of identity. Its product page presents a
+three-layer platform where persistent, evolving memory powers the consumer app,
+persona builder, and infrastructure layer.
+
+## Product Layers
+
+- My AI: a personal assistant that remembers conversations and learns user
+  preferences.
+- Persona Studio: no-code persona configuration with personality, knowledge
+  domains, memory behavior, and guardrails.
+- Memory Core: a unified context and memory service for encoding, stabilizing,
+  recalling, and evolving persistent memory.
+
+## Evidence Boundary
+
+The public page is product-level. It does not expose the underlying memory
+schema, consolidation process, or retrieval mechanism.

--- a/products/archives/powermem-overview.md
+++ b/products/archives/powermem-overview.md
@@ -1,0 +1,27 @@
+---
+source_url: https://github.com/oceanbase/powermem
+source_site: https://www.powermem.ai/
+fetched: 2026-06-11
+purpose: research backup; canonical sources are the URLs above
+---
+
+# PowerMem — snapshot
+
+## Positioning
+
+PowerMem describes itself as persistent, self-evolving memory for AI agents and
+applications.
+
+## Product Claims
+
+- Combines vector, full-text, and graph retrieval.
+- Uses LLM-driven memory extraction and Ebbinghaus-style time decay.
+- Ships Experience + Skill distillation for self-evolving memory.
+- Supports multi-agent isolation, user profiles, text/image/audio signals, CLI,
+  SDKs, HTTP API server, MCP server, dashboard, and IDE/agent plugins.
+- Includes LOCOMO and AppWorld benchmark tables plus reproduction links.
+
+## Evidence Boundary
+
+Benchmark improvements, latency, accuracy, and token numbers are treated as
+vendor-claimed until independently reproduced from the repository.

--- a/products/archives/redis-agent-memory-server-overview.md
+++ b/products/archives/redis-agent-memory-server-overview.md
@@ -1,0 +1,28 @@
+---
+source_url: https://redis.github.io/agent-memory-server/
+source_repo: https://github.com/redis/agent-memory-server
+fetched: 2026-06-11
+purpose: research backup; canonical sources are the URLs above
+---
+
+# Redis Agent Memory Server — snapshot
+
+## Positioning
+
+Redis Agent Memory Server is documented as a production-ready memory system for
+AI agents and applications, with REST API, MCP, and client SDK interfaces.
+
+## Public Architecture
+
+- Two-tier memory system: working memory for session-scoped state and long-term
+  memory for persistent preferences, facts, and important information.
+- Search modes include semantic, keyword, and hybrid search.
+- Filters include time, topics, entities, users, and sessions.
+- Management features include automatic extraction, contextual grounding,
+  deduplication, editing, authentication, background processing, and multi-
+  tenancy.
+
+## Evidence Boundary
+
+Production-ready language and operational maturity are official claims. Actual
+delete/export/audit semantics should be validated in deployment.

--- a/products/archives/supermemory-overview.md
+++ b/products/archives/supermemory-overview.md
@@ -1,0 +1,38 @@
+---
+source_url: https://supermemory.ai/
+source_repo: https://github.com/supermemoryai/supermemory
+fetched: 2026-05-31
+purpose: research backup; canonical sources are the URLs above
+---
+
+# Supermemory — snapshot
+
+## Positioning
+
+Supermemory describes itself as a context cloud for agents. It combines memory,
+RAG, user profiles, connectors, extractors, and a personal app into a single
+context stack.
+
+## Product Primitives
+
+- Memory and continual learning
+- SuperRAG retrieval
+- Filesystem mount
+- User profiles
+- Connectors for Slack, Notion, Drive, Gmail, GitHub, S3, and custom sources
+- Extractors for PDFs, web pages, images, audio, and files
+- Qualitative analysis over memory
+
+## Differentiators
+
+The product page says memories, RAG, and profiles live in the same queryable
+graph. It also emphasizes MCP, plugins, TypeScript/Python SDKs, self-hosting,
+BYOC, on-prem, and air-gapped enterprise deployment.
+
+Repository metadata fetched 2026-05-31: `supermemoryai/supermemory` had roughly
+22.9k stars, 2.0k forks, MIT license, and active updates.
+
+## Evidence Boundary
+
+Benchmark and latency claims on the product page are not treated as independent
+measurements in this repo.

--- a/products/archives/tencentdb-agent-memory-overview.md
+++ b/products/archives/tencentdb-agent-memory-overview.md
@@ -1,0 +1,43 @@
+---
+source_url: https://cloud.tencent.com/product/agm
+source_repo: https://github.com/Tencent/TencentDB-Agent-Memory
+fetched: 2026-05-31
+purpose: research backup; canonical sources are the URLs above
+---
+
+# TencentDB Agent Memory — snapshot
+
+## Positioning
+
+Tencent Cloud presents Agent Memory as a managed memory service for agents. It is
+intended to preserve business knowledge and user/context continuity across
+sessions, long-running tasks, and multi-task agent workflows.
+
+## Product Claims
+
+- L0-L3 progressive memory architecture: raw conversation, key information,
+  scenario summaries, and user persona.
+- Embedding + dual retrieval for semantic and keyword recall.
+- Global memory resource management and visual administration.
+- Context offloading for long tasks; the product page reports token reduction
+  and completion-rate improvements from Tencent lab tests dated 2026-04.
+
+## Open-Source Repo Snapshot
+
+`Tencent/TencentDB-Agent-Memory` describes a local-first implementation using
+layered artifacts:
+
+- L0 conversation records
+- L1 atomic memories
+- L2 Markdown scenario blocks
+- L3 persona profile
+- Mermaid task canvas for short-term context offloading
+
+Repository metadata fetched 2026-05-31: roughly 4.4k stars, 370 forks, latest
+release `v0.3.6` published 2026-05-28.
+
+## Evidence Boundary
+
+Performance numbers are official self-reported claims unless separately
+reproduced. The cloud product and OSS repo should be evaluated as related but
+distinct delivery forms.

--- a/products/aws-agentcore-memory.md
+++ b/products/aws-agentcore-memory.md
@@ -1,0 +1,67 @@
+---
+title: AWS Bedrock AgentCore Memory
+type: product
+source: https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/memory.html
+date_first_seen: 2026-06
+domain: platform-managed-memory
+business_model: AWS managed service
+license: Proprietary cloud service
+memory_modules:
+  - ingest-adapter
+  - dream-consolidator
+  - retriever-reranker
+  - policy-privacy
+status: seed
+last_revised: 2026-06-11
+archive: archives/aws-agentcore-memory-overview.md
+---
+
+# AWS Bedrock AgentCore Memory
+
+## 1. 一句话定位
+
+Bedrock AgentCore Memory 是 AWS 为 AgentCore agents 提供的托管短期/长期记忆层,
+目标是让 stateless agent 跨 session 保留上下文、偏好、事实和摘要。
+
+## 2. 是什么 / 做什么
+
+官方文档把 memory 拆成 short-term memory 和 long-term memory。Short-term 负责
+session events 与当前会话上下文;long-term memory 从 session 中自动抽取 key
+insights、user preferences、facts 和 session summaries,并在未来会话中检索。
+
+## 3. 关键技术选择
+
+- **Memory resource**:agent 绑定一个 managed memory resource。
+- **Session events**:通过 `sessionId` 等范围保存会话历史。
+- **Strategies**:长期记忆由 strategy 决定抽取什么;可用内建、覆盖或自管策略。
+- **Managed lifecycle**:云服务负责存储、检索和跨会话召回。
+
+## 4. 决策相关性 / Decision relevance
+
+- **对照点**:AWS 把 memory 当成 agent runtime 的可配置云资源,说明 hyperscaler
+  正在把长期记忆产品化。
+- **借鉴点**:strategy 化抽取很适合对照 kernel 的 policy-driven consolidation。
+- **差异点**:内部 store、冲突合并和可审计 diff 没有完全公开。
+
+## 5. 适用 / 不适用场景
+
+- **适用**:已在 Bedrock/AgentCore 上构建 agent 的企业;需要 AWS IAM/合规/托管
+  能力的业务 agent。
+- **不适用**:跨云或本地优先 memory;需要 portable Markdown/graph artifact 的场景。
+
+## 6. 注意事项 / 风险
+
+- **平台绑定**:memory 与 Bedrock AgentCore 生态深度绑定。
+- **透明度**:托管服务便利但降低 schema 和 consolidation 的可见度。
+- **成本/权限**:真实生产接入要评估 memory retention、tenant isolation 与 IAM 范围。
+
+## 7. 进一步阅读
+
+- archive: [`archives/aws-agentcore-memory-overview.md`](archives/aws-agentcore-memory-overview.md)
+- Docs:https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/memory.html
+- Strategies:https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/memory-strategies.html
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/basic-memory.md
+++ b/products/basic-memory.md
@@ -1,0 +1,67 @@
+---
+title: Basic Memory
+type: product
+source: https://docs.basicmemory.com/
+date_first_seen: 2026-06
+domain: local-first-memory
+business_model: OSS + cloud subscription
+license: AGPL-3.0
+memory_modules:
+  - ingest-adapter
+  - semantic-dedup
+  - retriever-reranker
+  - policy-privacy
+status: seed
+last_revised: 2026-06-11
+archive: archives/basic-memory-overview.md
+---
+
+# Basic Memory
+
+## 1. 一句话定位
+
+Basic Memory 是 local-first、Markdown-first 的 AI memory / knowledge graph,
+让人和 agent 共同读写同一批可编辑文件,并通过 MCP 接入 Claude、Codex、Cursor、
+ChatGPT 等客户端。
+
+## 2. 是什么 / 做什么
+
+官方文档强调 "Every piece of AI context is a file you can read and edit"。Basic
+Memory 把知识保存为 plain Markdown,再生成 semantic knowledge graph 与搜索索引。
+它提供本地运行和 Basic Memory Cloud 两条路径,云端仍使用同一套 Markdown 文件语义。
+
+## 3. 关键技术选择
+
+- **Markdown source of truth**:记忆不是黑箱数据库记录,而是人类可读/可编辑文件。
+- **Knowledge graph**:observations、wikilinks、relations 形成语义图。
+- **MCP-native**:面向主流 AI clients/IDEs 暴露搜索、读取、写入工具。
+- **Cloud optional**:本地免费/AGPL,云端提供同步、备份和多端访问。
+
+## 4. 决策相关性 / Decision relevance
+
+- **对照点**:Basic Memory 是目前最清晰的 "artifact-first memory" 产品样本。
+- **借鉴点**:Markdown + graph + MCP 的组合非常适合解决 inspectability 和 lock-in。
+- **差异点**:它更像个人/团队知识库与 agent memory 的交叉,不是低层 memory kernel。
+
+## 5. 适用 / 不适用场景
+
+- **适用**:coding agent 长期项目上下文;希望人类可直接审阅/编辑 memory 的团队;
+  Obsidian/Markdown 用户。
+- **不适用**:只需要嵌入式 SDK;不希望 AGPL 约束或文件型工作流的商业产品。
+
+## 6. 注意事项 / 风险
+
+- **许可**:AGPL-3.0 对闭源集成有影响。
+- **性能边界**:大规模企业多租户能力需要实测云端版本。
+- **产品定位**:它既是 memory 又是 PKM/knowledge graph,归类时应标注交叉属性。
+
+## 7. 进一步阅读
+
+- archive: [`archives/basic-memory-overview.md`](archives/basic-memory-overview.md)
+- Docs:https://docs.basicmemory.com/
+- GitHub:https://github.com/basicmachines-co/basic-memory
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/byterover.md
+++ b/products/byterover.md
@@ -1,0 +1,68 @@
+---
+title: ByteRover (formerly Cipher)
+type: product
+source: https://www.byterover.dev/
+date_first_seen: 2026-06
+domain: coding-agent-memory
+business_model: source-available CLI + cloud/service positioning
+license: Elastic License 2.0 (repo)
+memory_modules:
+  - ingest-adapter
+  - semantic-dedup
+  - retriever-reranker
+  - policy-privacy
+status: seed
+last_revised: 2026-06-11
+archive: archives/byterover-overview.md
+---
+
+# ByteRover
+
+## 1. 一句话定位
+
+ByteRover 是面向 autonomous coding agents 的 portable memory layer,前身/别名为
+Cipher,通过 CLI、MCP 和项目 context tree 让多个 coding agents 共享长期上下文。
+
+## 2. 是什么 / 做什么
+
+GitHub 仓库标题直接写明 "The portable memory layer for autonomous coding agents
+(formerly Cipher)"。它的核心定位不是普通笔记,而是把项目上下文、决策、代码活动和
+agent 工作流沉淀为可跨 Claude Code、Codex、Cursor 等工具复用的 memory。
+
+## 3. 关键技术选择
+
+- **Context tree**:用项目级结构组织长期上下文。
+- **CLI + MCP**:开发者通过 `brv` CLI 和 MCP 工具接入不同 coding agents。
+- **Portable memory**:强调跨 agent/client 迁移,避免每个 IDE 自己孤立记忆。
+- **Agent hooks**:适合 session start/stop、tool use 后写入和召回。
+
+## 4. 决策相关性 / Decision relevance
+
+- **对照点**:ByteRover 代表 coding-agent memory 的专门化路线,重点是项目上下文而
+  非用户画像。
+- **借鉴点**:context tree 比 flat vector chunks 更容易审阅和分层检索。
+- **差异点**:source-available/云端路线与 OSS Apache/MIT 项目不同,需看许可和部署条款。
+
+## 5. 适用 / 不适用场景
+
+- **适用**:多人/多 agent 代码库协作;需要把决策、任务和文件关系保留下来的 coding
+  agent 工作流。
+- **不适用**:C 端 assistant memory;需要完全 permissive license 的基础设施产品。
+
+## 6. 注意事项 / 风险
+
+- **命名合并**:ByteRover / Cipher 应作为同一产品族记录。
+- **许可**:Elastic License 2.0 不等于开源 permissive license。
+- **claim 边界**:公开 benchmark/覆盖范围按厂商或仓库自述处理。
+
+## 7. 进一步阅读
+
+- archive: [`archives/byterover-overview.md`](archives/byterover-overview.md)
+- Site:https://www.byterover.dev/
+- GitHub:https://github.com/campfirein/byterover-cli
+- Docs:https://docs.byterover.dev/connectors/overview
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/cloudflare-agent-memory.md
+++ b/products/cloudflare-agent-memory.md
@@ -1,0 +1,72 @@
+---
+title: Cloudflare Agent Memory
+type: product
+source: https://blog.cloudflare.com/introducing-agent-memory/
+date_first_seen: 2026-06
+domain: platform-managed-memory
+business_model: Cloudflare managed service / Agents SDK
+license: Proprietary cloud service; SDK docs public
+memory_modules:
+  - ingest-adapter
+  - retriever-reranker
+  - policy-privacy
+status: seed
+last_revised: 2026-06-11
+archive: archives/cloudflare-agent-memory-overview.md
+---
+
+# Cloudflare Agent Memory
+
+## 1. 一句话定位
+
+Cloudflare Agent Memory 是 Cloudflare Agents 生态里的 managed memory 能力,把
+conversation history、context memory、SQLite-backed Session API 和更 opinionated
+的 Agent Memory service 连成平台级记忆层。
+
+## 2. 是什么 / 做什么
+
+Cloudflare docs 把 agent memory 分成 conversation history 与 context memory:
+前者保存 messages/tool calls,后者是注入 system prompt 的持久信息块,可读、可写、
+可搜索或按 Skills 加载。官方博客另行介绍 Agent Memory,强调让 agents 跨会话记住
+用户、任务和历史。
+
+## 3. 关键技术选择
+
+- **Session tree**:conversation history 是树结构,支持 branch/regenerate。
+- **Context blocks**:read-only、writable short-form、searchable context、loadable
+  Skills 四类公开抽象。
+- **Provider abstraction**:默认可用 SQLite / Durable Object,search provider 可替换。
+- **平台托管**:Agent Memory 是 Cloudflare 平台服务,与 Workers/Agents 生态绑定。
+
+## 4. 决策相关性 / Decision relevance
+
+- **对照点**:它代表 cloud runtime 把 memory 变成 agent platform primitive,不是
+  独立 SDK。
+- **借鉴点**:把 context memory 暴露为带能力边界的 block/provider,比普通全局
+  prompt 更可管理。
+- **差异点**:本仓 kernel 若追求 host-agnostic,不能假设 Cloudflare runtime。
+
+## 5. 适用 / 不适用场景
+
+- **适用**:Cloudflare Workers/Agents 上的生产 agent;需要 Durable Object 与平台
+  存储统一管理的团队。
+- **不适用**:脱离 Cloudflare 的本地优先 agent;需要完全自主管理 memory schema 的
+  研究实验。
+
+## 6. 注意事项 / 风险
+
+- **可用性标签**:Cloudflare docs 的 Session memory API 标为 experimental;Agent
+  Memory 博客介绍的服务需按 private beta/早期能力处理。
+- **供应商锁定**:强平台集成带来 deploy/ops 便利,也限制可移植性。
+- **claim 边界**:所有产品定位和能力描述来自 Cloudflare 官方文档/博客。
+
+## 7. 进一步阅读
+
+- archive: [`archives/cloudflare-agent-memory-overview.md`](archives/cloudflare-agent-memory-overview.md)
+- Blog:https://blog.cloudflare.com/introducing-agent-memory/
+- Docs:https://developers.cloudflare.com/agents/concepts/conversation-state-and-memory/
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/everos.md
+++ b/products/everos.md
@@ -1,0 +1,79 @@
+---
+title: EverOS (EverMind / EverMemOS)
+type: product
+source: https://evermind.ai/everos
+date_first_seen: 2026-06
+domain: memory-os
+business_model: OSS + cloud
+license: Apache 2.0 (GitHub repo / product page claim)
+memory_modules:
+  - ingest-adapter
+  - parser-chunker
+  - semantic-dedup
+  - retriever-reranker
+  - dream-consolidator
+status: seed
+last_revised: 2026-06-11
+archive: archives/everos-overview.md
+---
+
+# EverOS
+
+## 1. 一句话定位
+
+EverOS 是 EverMind 推出的 agent memory operating system,把多模态输入、Profile /
+Episodic / Skill 记忆、self-evolving skill consolidation 和 MCP/agent 集成放在
+同一个可云端或自托管的 memory layer 里。
+
+## 2. 是什么 / 做什么
+
+公开页面把 EverOS 描述为跨 agent、跨平台的 memory layer,兼容 Claude Code、
+Codex、OpenClaw、Hermes、MCP、OpenAI SDK 与 Anthropic SDK。它的核心写入路径
+是 "one call stores messages, images, and docs",然后自动抽取并打标签。
+
+EverMind / EverOS / EverMemOS 在本仓合并为一个产品族:EverMemOS 是论文/研究线索,
+EverOS 是当前产品入口,EverMind 是厂商品牌。
+
+## 3. 关键技术选择
+
+- **记忆类型**:Profile、Episodic、Skill 三类是公开页面的一等概念。
+- **Skill self-evolution**:任务执行轨迹先成为 Case,重复成功路径再离线蒸馏为
+  Skill memories。
+- **多模态 memory ingestion**:PDF、image、docs、excel、slides、URL 等都进入
+  同一 memory 管线。
+- **可携带性**:公开页面强调 Markdown export、cloud 与 self-host 切换。
+- **接口**:MCP / Claude Code / Codex / OpenClaw / Hermes 是主要入口。
+
+## 4. 决策相关性 / Decision relevance
+
+- **对照点**:EverOS 把 procedural memory / skill memory 放到产品叙事中心,比
+  单纯 fact memory 更接近长期 agent 能力积累。
+- **借鉴点**:Case -> Skill 的离线蒸馏路径适合对照 `dream-consolidator` 与
+  `memorydiff-generator`。
+- **差异点**:当前公开资料仍以产品页和 GitHub README 为主,内部 schema、冲突
+  解决和安全边界需要继续观察。
+
+## 5. 适用 / 不适用场景
+
+- **适用**:需要跨 coding agent 共享长期记忆;希望 memory 能沉淀成 procedure /
+  skill 的 agent 团队;希望自托管又保留云端路径的开发者。
+- **不适用**:只需要普通 RAG;不能接受 LLM 自动抽取/蒸馏黑箱的强审计场景。
+
+## 6. 注意事项 / 风险
+
+- **benchmark 自报**:93%+ accuracy、p95 <500ms、~10x cost 等来自官方页面,在本仓
+  只作为 vendor-claimed signal。
+- **命名合并**:EverOS / EverMind / EverMemOS 不应拆成多个产品条目,否则会重复计数。
+- **实现边界**:Apache 2.0 与 Markdown export 是强信号,但云端 control plane 的
+  可审计性仍需实际部署验证。
+
+## 7. 进一步阅读
+
+- archive: [`archives/everos-overview.md`](archives/everos-overview.md)
+- 官方:https://evermind.ai/everos
+- GitHub:https://github.com/EverMind-AI/EverOS
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/google-memory-bank.md
+++ b/products/google-memory-bank.md
@@ -1,0 +1,68 @@
+---
+title: Google Agent Platform Memory Bank
+type: product
+source: https://docs.cloud.google.com/gemini-enterprise-agent-platform/scale/memory-bank
+date_first_seen: 2026-06
+domain: platform-managed-memory
+business_model: Google Cloud managed service
+license: Proprietary cloud service
+memory_modules:
+  - ingest-adapter
+  - dream-consolidator
+  - retriever-reranker
+  - policy-privacy
+status: seed
+last_revised: 2026-06-11
+archive: archives/google-memory-bank-overview.md
+---
+
+# Google Agent Platform Memory Bank
+
+## 1. 一句话定位
+
+Google Agent Platform Memory Bank 是 Gemini Enterprise Agent Platform 的托管
+长期记忆能力,用 scoped identities 从 user-agent conversations 中生成、检索和治理
+长期 memories。
+
+## 2. 是什么 / 做什么
+
+官方文档将 Memory Bank 描述为 managed persistent store。它可从 conversations
+动态生成 long-term memories,支持 event ingestion、customizable extraction、
+multimodal inputs、TTL/configuration、revisions 和 IAM conditions。
+
+## 3. 关键技术选择
+
+- **Scope**:memory 绑定 `agent_name`、`user` 等 identity scope。
+- **Async generation**:对话进入后异步生成可检索的 memories。
+- **Governance**:TTL、revision、IAM condition 和 memory poisoning 指南是文档重点。
+- **ADK integration**:面向 Google ADK/Agent Platform 的开发者入口。
+
+## 4. 决策相关性 / Decision relevance
+
+- **对照点**:Memory Bank 是 hyperscaler 级 scoped memory store 的典型样本。
+- **借鉴点**:memory poisoning 和 prompt-injection 防护被写进官方文档,值得纳入
+  kernel 的 security/privacy 设计。
+- **差异点**:面向 Google Cloud 平台,不是独立 portable memory kernel。
+
+## 5. 适用 / 不适用场景
+
+- **适用**:Google Cloud / Gemini Enterprise 上的业务 agent;需要 IAM 与托管
+  governance 的企业。
+- **不适用**:完全本地或跨云部署;需要用户直接编辑底层 memory artifact 的产品。
+
+## 6. 注意事项 / 风险
+
+- **可用性标签**:官方文档标为 Preview / Pre-GA,生产承诺需按 Google Cloud 条款
+  再确认。
+- **黑箱部分**:抽取、合并和排序逻辑不完全公开。
+- **边界**:不要与 Gemini consumer personal context 混为同一产品。
+
+## 7. 进一步阅读
+
+- archive: [`archives/google-memory-bank-overview.md`](archives/google-memory-bank-overview.md)
+- Docs:https://docs.cloud.google.com/gemini-enterprise-agent-platform/scale/memory-bank
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/graphiti.md
+++ b/products/graphiti.md
@@ -88,6 +88,9 @@ FalkorDB 1.1.2+,Kuzu 0.11.2+,Amazon Neptune(配合 OpenSearch Serverless)。
   商业化策略
 - **benchmark**:作为 Zep 80.32% LoCoMo 数字的底座出现,但 Graphiti 单独的
   公开 benchmark 数据相对稀疏
+- **benchmark ledger**:Graphiti 只作为 Zep LoCoMo 数字的 foundation mention
+  记录在 [`../benchmarks/claims/claims.yaml`](../benchmarks/claims/claims.yaml),
+  不计为 standalone Graphiti score。
 
 ## 7. 进一步阅读
 

--- a/products/hindsight.md
+++ b/products/hindsight.md
@@ -1,0 +1,93 @@
+---
+title: Hindsight
+type: product
+source: https://github.com/vectorize-io/hindsight
+date_first_seen: 2025-12
+domain: learning-agent-memory
+business_model: OSS + managed cloud
+license: MIT
+memory_modules:
+  - ingest-adapter
+  - semantic-dedup
+  - retriever-reranker
+  - dream-consolidator
+  - evaluator-benchmark
+status: seed
+last_revised: 2026-05-31
+archive: archives/hindsight-overview.md
+---
+
+# Hindsight
+
+## 1. 一句话定位
+
+Hindsight 是 Vectorize 推出的开源 agent memory system,口号是 "Agent Memory
+That Learns":重点不是只 recall conversation history,而是让 agent 随反馈和
+长期交互学习。
+
+## 2. 是什么 / 做什么
+
+Hindsight 提供 server、UI、Python/TypeScript clients 和 LLM wrapper。它支持
+retain / recall / reflect 三类操作,也可以作为 wrapper 接到现有 LLM client
+前,自动存取 memory。
+
+官方 README 强调:
+
+- LongMemEval benchmark 表现
+- 可用 Docker 一键跑本地服务
+- 支持多 LLM provider(OpenAI、Anthropic、Gemini、Groq、Ollama、LM Studio 等)
+- 可用于 conversational agents 与 open-ended autonomous task agents
+
+截至 2026-05-31 查询,GitHub metadata 约 15.2k stars / 857 forks,MIT
+license,最新 release 为 `v0.7.1`(2026-05-28)。
+
+## 3. 关键技术选择
+
+- **接口**:HTTP API、SDK、LLM wrapper、embedded Python server
+- **操作**:`retain` / `recall` / `reflect`
+- **部署**:Docker、本地 PostgreSQL、embedded Python;企业路线提到 Oracle AI
+  Database 支持
+- **目标场景**:每用户 memory、chat history、AI employee / task agent
+- **benchmark**:LongMemEval 自报并声称有外部研究协作者复现
+
+> Benchmark record: [`../benchmarks/longmemeval.md`](../benchmarks/longmemeval.md);
+> event ledger row: `hindsight-longmemeval-2026` in
+> [`../benchmarks/claims/claims.yaml`](../benchmarks/claims/claims.yaml)。
+
+## 4. 决策相关性 / Decision relevance
+
+- **对照点**:Hindsight 将"learning"放在"remembering"前面,是 memory kernel
+  后续是否加入 feedback/reflection loop 的重要竞争样本。
+- **借鉴点**:
+  - LLM wrapper 是降低接入成本的强产品形态。
+  - `reflect` 作为与 `recall` 分离的操作,有利于把 memory retrieval 与
+    response shaping 分开。
+  - Docker + UI + SDK 的本地体验比纯库更容易被 agent builder 试用。
+- **差异点**:Hindsight 更像完整服务;本仓 kernel 仍强调 schema/provenance
+  与 host 自治。
+
+## 5. 适用 / 不适用场景
+
+- **适用**:需要本地开源服务快速给 agent 加 memory;希望用 wrapper 接入现有
+  LLM client;需要 UI/服务化部署而非只用 library。
+- **不适用**:只需要极简 in-process memory;不接受额外 server / database;
+  需要完全可解释、diff-first 的 memory mutation。
+
+## 6. 注意事项 / 风险
+
+- **benchmark 比较口径**:官方称部分结果被外部复现,但与其他 vendor 自报分数
+  混在同一图表里,引用时应标注来源。
+- **服务复杂度**:相对轻量 SDK,引入 server、UI、DB 后运维面更大。
+- **managed cloud 边界**:开源仓库与 Vectorize 商业云能力需分别评估。
+
+## 7. 进一步阅读
+
+- archive: [`archives/hindsight-overview.md`](archives/hindsight-overview.md)
+- GitHub:https://github.com/vectorize-io/hindsight
+- Docs:https://hindsight.vectorize.io/
+- Release:https://github.com/vectorize-io/hindsight/releases/tag/v0.7.1
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/honcho.md
+++ b/products/honcho.md
@@ -1,0 +1,70 @@
+---
+title: Honcho
+type: product
+source: https://github.com/plastic-labs/honcho
+date_first_seen: 2026-06
+domain: memory-infrastructure
+business_model: OSS + managed API
+license: AGPL-3.0
+memory_modules:
+  - ingest-adapter
+  - semantic-dedup
+  - retriever-reranker
+  - dream-consolidator
+status: seed
+last_revised: 2026-06-11
+archive: archives/honcho-overview.md
+---
+
+# Honcho
+
+## 1. 一句话定位
+
+Honcho 是用于构建 stateful agents 的 memory infrastructure,把 people、agents、
+groups、projects 和 ideas 都建模为随时间变化的 peers / representations。
+
+## 2. 是什么 / 做什么
+
+Honcho 让应用保存 conversations、events、documents 和 tool traces,后台异步 reason,
+再让开发者查询 peer representations、session context、search results 或自然语言
+insights。它提供 managed API 和 self-host FastAPI server,并有 SDK、MCP 与 agent
+integrations。
+
+## 3. 关键技术选择
+
+- **Peer-centric model**:human/user/agent/group/project 都可以是 peer。
+- **Async reasoning loop**:store -> reason -> query -> inject。
+- **Representations**:低延迟 snapshot 与 session context 同时存在。
+- **Hybrid search**:README 提到 BM25 + vector search。
+- **Integrations**:Claude Code、OpenCode、OpenClaw、Hermes、Cursor-compatible MCP。
+
+## 4. 决策相关性 / Decision relevance
+
+- **对照点**:Honcho 的独特性在于 "who knows what about whom" 的 peer modeling,
+  比普通 user memory 更适合 multi-agent/social agent。
+- **借鉴点**:background reasoning 与 representation endpoint 可作为热路径/冷路径
+  分离参考。
+- **差异点**:marketing/eval claims 需独立复现。
+
+## 5. 适用 / 不适用场景
+
+- **适用**:教育、陪伴、社区、多 agent 协作等需要长期建模参与者关系的产品;希望
+  self-host 或托管 API 二选一的开发者。
+- **不适用**:只需要简单 session summary;需要 permissive license 的商业内嵌库。
+
+## 6. 注意事项 / 风险
+
+- **许可**:AGPL-3.0 对闭源产品内嵌有影响。
+- **benchmark 自报**:"Pareto Frontier" 等 eval/性能定位来自 Honcho 官方材料。
+- **隐私边界**:peer-to-peer representation 需要清晰的 consent、scope 和 deletion 策略。
+
+## 7. 进一步阅读
+
+- archive: [`archives/honcho-overview.md`](archives/honcho-overview.md)
+- GitHub:https://github.com/plastic-labs/honcho
+- Docs:https://docs.honcho.dev/
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/hy-memory.md
+++ b/products/hy-memory.md
@@ -1,0 +1,95 @@
+---
+title: Hy-Memory
+type: product
+source: https://hy-memory.com/
+date_first_seen: 2026-05
+domain: agent-memory-plugin
+business_model: OpenClaw plugin / Hunyuan ecosystem
+license: MIT (official site claim; source repository not resolved at fetch time)
+memory_modules:
+  - ingest-adapter
+  - semantic-dedup
+  - retriever-reranker
+  - dream-consolidator
+status: seed
+last_revised: 2026-05-31
+archive: archives/hy-memory-overview.md
+---
+
+# Hy-Memory
+
+## 1. 一句话定位
+
+Hy-Memory 是腾讯混元方向推出的 OpenClaw 共享记忆插件,主张把用户偏好、事实、
+persona 与意图沉淀成可被多个 agent 共享的长期 memory core。
+
+## 2. 是什么 / 做什么
+
+官方站把 Hy-Memory 定位为基于腾讯混元高维认知记忆演化框架的 OpenClaw
+shared memory plugin。它不是普通 chat history,而是把 raw traces、atomic
+facts、identity profile、mind & intent 等层级合成一个 6-layer memory
+kernel。
+
+站点给出的安装入口是 OpenClaw marketplace:
+
+- `openclaw plugins install openclaw-hy-memory --dangerously-force-unsafe-install`
+- `openclaw hy-memory init`
+- `openclaw gateway restart`
+- `openclaw hy-memory status`
+
+它通过 sidecar Python process 运行,默认向 OpenClaw pre-chat / post-chat
+hook 暴露 auto-recall 与 auto-capture。
+
+## 3. 关键技术选择
+
+- **分层**:L1 raw traces、L2 atomic facts、L3 identity profile、L4-L6 mind
+  & intent
+- **写入**:对话后异步抽取事实与偏好
+- **读取**:对话前自动 recall 并注入相关记录
+- **存储**:示例配置使用 Chroma;每个 `userId` 是隔离的 memory namespace
+- **模型依赖**:官方建议 Hunyuan 3.0 Preview 作为 extraction model,同时使用
+  OpenAI-compatible API 和 BGE-M3 embedding
+
+## 4. 决策相关性 / Decision relevance
+
+- **对照点**:Hy-Memory 把"personalized multi-agent shared memory"作为显式
+  产品目标,与单 agent session memory 不同。
+- **借鉴点**:
+  - pre-chat recall + post-chat async capture 是主流插件化 memory 的典型
+    hook 设计。
+  - `userId` 共享 namespace 对多 agent 记忆复用很直接。
+  - 6-layer cognitive schema 可作为 persona / intent 层建模参考。
+- **差异点**:当前更多是 OpenClaw 插件形态,不是通用 SDK;本仓 kernel 仍需
+  维持 host-agnostic。
+
+## 5. 适用 / 不适用场景
+
+- **适用**:OpenClaw 用户;希望多个 agent 共享个人记忆;接受 Hunyuan/OpenAI
+  compatible extraction pipeline 的长期协作 agent。
+- **不适用**:非 OpenClaw runtime;强合规场景中不能接受 sidecar 执行权限;
+  需要明确可审计 source repo 和 release provenance 的生产部署。
+
+## 6. 注意事项 / 风险
+
+- **代码来源边界**:截至 2026-05-31,官方站提供 GitHub Repository 链接位,
+  但页面解析出的链接落到 GitHub 首页,未解析到具体仓库;因此本笔记只把官网
+  与 OpenClaw 安装路径作为证据。
+- **benchmark 自报**:LongMemEval / PersonaMem 数字来自官方站展示,尚未独立
+  复现。
+- **benchmark ledger**:LongMemEval 与 PersonaMem-v2 rows 见
+  [`../benchmarks/claims/claims.yaml`](../benchmarks/claims/claims.yaml);
+  其中 LongMemEval 记录为 [`../benchmarks/longmemeval.md`](../benchmarks/longmemeval.md),
+  PersonaMem-v2 暂为 candidate。
+- **安全开关**:安装命令需要 `--dangerously-force-unsafe-install`,说明插件会
+  启动外部 Python sidecar,生产接入前必须做权限审计。
+
+## 7. 进一步阅读
+
+- archive: [`archives/hy-memory-overview.md`](archives/hy-memory-overview.md)
+- 官方站:https://hy-memory.com/
+- OpenClaw docs:https://memory.hunyuan.tencent.com/
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/kinic.md
+++ b/products/kinic.md
@@ -1,0 +1,81 @@
+---
+title: Kinic
+type: product
+source: https://www.kinic.io/
+date_first_seen: 2025
+domain: personal-ai-memory
+business_model: consumer app / browser plugin / tokenized datastore
+license: proprietary
+memory_modules:
+  - ingest-adapter
+  - retriever-reranker
+  - security-privacy
+status: seed
+last_revised: 2026-05-31
+archive: archives/kinic-overview.md
+---
+
+# Kinic
+
+## 1. 一句话定位
+
+Kinic 是一个个人 AI memory / personal vector database 产品,强调用户拥有和
+控制自己的 bookmarks、emails、notes、documents,再把这些数据交给 AI agent
+检索。
+
+## 2. 是什么 / 做什么
+
+Kinic 通过浏览器插件收集用户资料,包括 bookmarks、emails、notes 等,形成可
+搜索的个人 memory。官网把它描述为"cryptographically secure, searchable
+memory for AI"。
+
+产品叙事里有两个重点:
+
+- 用户自有 datastore,可更新/删除,用 biometric login 管理 key
+- Kinic vector DB 运行在 Internet Computer,强调 tamper-proof 与 zero-knowledge
+  privacy preserving technology
+
+它也提出"AI Memory Economy":专家或创作者可以出租 / 分享自己的 AI memory
+store。
+
+## 3. 关键技术选择
+
+- **存储**:个人 canister smart contract / Kinic vector DB
+- **采集**:browser extension 一键写入
+- **隐私**:cryptographic ownership、zero-knowledge、biometric key 管理
+- **检索**:trusted AI-powered queries / vector database
+
+## 4. 决策相关性 / Decision relevance
+
+- **对照点**:Kinic 把 memory ownership 与可验证 datastore 结合,代表了
+  web3 / verifiable AI memory 路线。
+- **借鉴点**:
+  - "memory store 可共享 / 可出租"提示 memory kernel 需要清晰的授权与
+    provenance 边界。
+  - browser plugin 作为 ingest adapter 很适合个人 memory bootstrapping。
+  - tamper-proof datastore 是审计叙事的一个极端版本。
+- **差异点**:blockchain/token 设计不是本仓 kernel 的默认方向,只能作为
+  ownership / portability 对照。
+
+## 5. 适用 / 不适用场景
+
+- **适用**:个人 PKM、creator memory store、想要可验证数据所有权的用户。
+- **不适用**:企业内部 agent memory;需要传统数据库和合规采购链路的团队;
+  不接受 token / blockchain 基础设施的用户。
+
+## 6. 注意事项 / 风险
+
+- **技术栈偏窄**:Internet Computer 与 token 机制会限制主流企业采用。
+- **产品成熟度**:官网显示插件已可用,完整 app 仍需继续跟踪。
+- **合规复杂度**:把个人资料放进链上相关基础设施,需要单独评估隐私和删除权。
+
+## 7. 进一步阅读
+
+- archive: [`archives/kinic-overview.md`](archives/kinic-overview.md)
+- 官方:https://www.kinic.io/
+- Blog:https://www.kinic.io/blog/the-ai-memory-economy
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/mem0.md
+++ b/products/mem0.md
@@ -87,6 +87,12 @@ Mem0 自报的 benchmark(LoCoMo 类基准对比上一代 baseline):
 | BEAM (1M) | 64.1 | 6,719 |
 | BEAM (10M) | 48.6 | 6,914 |
 
+> Benchmark records: [`LoCoMo`](../benchmarks/locomo.md),
+> [`LongMemEval`](../benchmarks/longmemeval.md),
+> [`BEAM`](../benchmarks/beam.md). These rows are vendor self-reports in
+> [`../benchmarks/claims/claims.yaml`](../benchmarks/claims/claims.yaml), not
+> independent reproductions.
+
 ### 对 memory kernel 的启发
 
 - **agent fact 与 user fact 等权**这个选择,直接挑战了 kernel 现在的默认

--- a/products/memoryos.md
+++ b/products/memoryos.md
@@ -1,0 +1,90 @@
+---
+title: MemoryOS
+type: product
+source: https://github.com/BAI-LAB/MemoryOS
+date_first_seen: 2025-05
+domain: research-agent-memory
+business_model: OSS / research
+license: Apache 2.0
+memory_modules:
+  - ingest-adapter
+  - semantic-dedup
+  - retriever-reranker
+  - dream-consolidator
+  - evaluator-benchmark
+status: seed
+last_revised: 2026-05-31
+archive: archives/memoryos-overview.md
+---
+
+# MemoryOS
+
+## 1. 一句话定位
+
+MemoryOS 是 BAI-LAB 开源的 personalized AI agent memory operating system,
+把 OS memory management 的分层思想迁移到 agent long-term memory。
+
+## 2. 是什么 / 做什么
+
+MemoryOS 面向 personalized AI agents,目标是让长期交互更连贯、个性化和
+context-aware。它采用 short-term / mid-term / long-term 的层级存储架构,
+并围绕 Storage、Updating、Retrieval、Generation 四个核心模块组织。
+
+仓库提供:
+
+- Python library / examples
+- MemoryOS-MCP server
+- ChromaDB 版本
+- Playground / evaluation artifacts
+
+截至 2026-05-31 查询,GitHub metadata 约 1.4k stars / 137 forks,Apache 2.0,
+最新 release `V1.2`(2025-07-18),仓库在 2026 年仍有更新。
+
+## 3. 关键技术选择
+
+- **分层**:short-term、mid-term、long-term persona/knowledge memory
+- **模块**:storage、updating、retrieval、generation
+- **MCP**:`add_memory`、`retrieve_memory`、`get_user_profile`
+- **模型**:支持 OpenAI-compatible API、Qwen/BGE embedding 等
+- **评测**:LoCoMo 相关自报改进
+
+## 4. 决策相关性 / Decision relevance
+
+- **对照点**:MemoryOS 是 research-to-OSS 的 memory kernel 样本,比商业
+  memory API 更接近本仓的架构讨论。
+- **借鉴点**:
+  - short/mid/long-term 分层适合作为 taxonomy 中 persistence 与 curation
+    轴的实例。
+  - MCP server 暴露 `add/retrieve/profile` 三类工具,是 agent client 集成的
+    最小面。
+  - OS analogy 可用于解释 memory capacity、promotion、eviction。
+- **差异点**:MemoryOS 更强调 personalized dialogue agent;本仓 kernel 还要覆盖
+  工具 agent、代码 agent 和企业业务状态。
+
+## 5. 适用 / 不适用场景
+
+- **适用**:研究 personalized agent memory;需要 MCP 形式接入长期记忆;希望
+  复现 LoCoMo 相关结果。
+- **不适用**:生产级企业 SLA;非对话型 agent 的复杂 provenance / audit 需求;
+  需要成熟商业云服务。
+
+## 6. 注意事项 / 风险
+
+- **研究项目成熟度**:虽有 releases 与 MCP,仍需验证长期维护节奏。
+- **benchmark 自报**:论文和 README 数字应以可复现实验为准。
+- **benchmark ledger**:LoCoMo row 见
+  [`../benchmarks/claims/claims.yaml`](../benchmarks/claims/claims.yaml);
+  normalized record 见 [`../benchmarks/locomo.md`](../benchmarks/locomo.md)。
+- **OpenAI-compatible 依赖**:本地部署仍可能需要外部 LLM / embedding provider。
+
+## 7. 进一步阅读
+
+- archive: [`archives/memoryos-overview.md`](archives/memoryos-overview.md)
+- GitHub:https://github.com/BAI-LAB/MemoryOS
+- Paper:https://arxiv.org/abs/2506.06326
+- Docs:https://bai-lab.github.io/MemoryOS/docs
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/memos.md
+++ b/products/memos.md
@@ -1,0 +1,70 @@
+---
+title: MemOS (MemTensor)
+type: product
+source: https://github.com/MemTensor/MemOS
+date_first_seen: 2026-06
+domain: memory-os
+business_model: OSS + docs/community
+license: Apache 2.0
+memory_modules:
+  - ingest-adapter
+  - semantic-dedup
+  - retriever-reranker
+  - dream-consolidator
+status: seed
+last_revised: 2026-06-11
+archive: archives/memos-overview.md
+---
+
+# MemOS
+
+## 1. 一句话定位
+
+MemTensor MemOS 是面向 LLM 和 AI agents 的 self-evolving memory OS,强调 ultra-
+persistent memory、hybrid retrieval、跨任务 skill reuse 和 token savings。
+
+## 2. 是什么 / 做什么
+
+MemOS 把 memory 作为操作系统式资源管理问题:agent 产生的交互、知识和技能需要
+被抽取、组织、检索和复用,而不是只保存在 chat history 或 vector chunks 中。
+
+本仓将 **MemTensor MemOS** 与已有 [`memoryos.md`](memoryos.md) 区分:后者是
+BAI-LAB MemoryOS / personal agent 的三层记忆系统;MemOS 是另一个产品/OSS 路线。
+
+## 3. 关键技术选择
+
+- **Memory OS framing**:以 OS/资源管理视角组织长期记忆。
+- **Hybrid retrieval**:公开仓库标题和文档强调混合检索。
+- **Cross-task skill reuse**:把可迁移经验/技能作为长期记忆产物。
+- **Self-evolving memory**:强调随任务迭代自动沉淀。
+
+## 4. 决策相关性 / Decision relevance
+
+- **对照点**:与 EverOS、MemoryOS、TencentDB Agent Memory 一起形成 "memory OS"
+  分支,但各自抽象层不同。
+- **借鉴点**:skill reuse 和 token savings 的产品叙事说明市场不再满足于偏好/事实
+  记忆,开始追求任务经验迁移。
+- **差异点**:需要后续阅读代码与 paper 才能确认 schema 和 consolidation 机制。
+
+## 5. 适用 / 不适用场景
+
+- **适用**:研究 self-evolving agent memory;对比 OS-style memory 产品;
+  构建需要跨任务经验复用的 agent。
+- **不适用**:只需要轻量 user preference store;需要稳定托管 SLA 的企业采购。
+
+## 6. 注意事项 / 风险
+
+- **命名风险**:MemOS、MemoryOS、EverMemOS 很容易混淆,引用时必须写全前缀。
+- **benchmark 自报**:仓库标题中的 token saving 数字按 vendor/self-reported 处理。
+- **成熟度**:当前先作为 seed note,后续应补代码路径和 release health。
+
+## 7. 进一步阅读
+
+- archive: [`archives/memos-overview.md`](archives/memos-overview.md)
+- GitHub:https://github.com/MemTensor/MemOS
+- Docs:https://memos.openmem.net/
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/memx.md
+++ b/products/memx.md
@@ -1,0 +1,88 @@
+---
+title: MemX
+type: product
+source: https://memx.me/
+date_first_seen: 2026-03
+domain: local-first-memory
+business_model: OSS
+license: Apache 2.0 (GitHub metadata); site claims MIT at fetch time
+memory_modules:
+  - ingest-adapter
+  - retriever-reranker
+  - security-privacy
+status: seed
+last_revised: 2026-05-31
+archive: archives/memx-overview.md
+---
+
+# MemX
+
+## 1. 一句话定位
+
+MemX 是一个 Rust 编写的 local-first long-term memory system,主张"整个记忆就是
+本机一个文件",面向重视隐私、可复制和低复杂度的个人 AI assistant。
+
+## 2. 是什么 / 做什么
+
+官网给出的体验是命令行式 add/search:
+
+- `memx add "..."`
+- `memx search "..."`
+
+核心卖点:
+
+- 单文件 libSQL 存储
+- 无账号、无同步服务器、无云
+- 低置信查询返回空结果,避免硬塞错误 memory
+- vector + keyword hybrid retrieval,使用 RRF fusion
+- rerank 时考虑 semantic similarity、recency、retrieval frequency、
+  explicit importance
+- 检索结果可解释,统计写回数据库
+
+截至 2026-05-31 查询,GitHub `memxlab/memx` metadata 只有约 2 stars,Apache
+2.0;官网则写 v0.1.0 / open source / MIT。成熟度很低,但作为 local-first
+memory 设计样本有观察价值。
+
+## 3. 关键技术选择
+
+- **存储**:single libSQL file
+- **检索**:vector + keyword parallel recall, RRF fusion
+- **拒答门槛**:低于阈值返回 empty result
+- **ranking**:相似度、recency decay、使用频率、显式重要性
+- **embedding**:支持任意 OpenAI-compatible API,包括 Ollama / LM Studio
+
+## 4. 决策相关性 / Decision relevance
+
+- **对照点**:MemX 是"极简、本地、可复制"路线,与 Supermemory/Zep 这类云
+  context platform 正好相反。
+- **借鉴点**:
+  - refusal gate 是 memory retrieval 里经常缺失但很实用的安全阀。
+  - 单文件 memory.db 很适合个人 agent 迁移和备份。
+  - RRF + explicit importance + recency 是简单但可解释的 baseline。
+- **差异点**:它更像 early-stage CLI/database,不是完整 agent memory platform。
+
+## 5. 适用 / 不适用场景
+
+- **适用**:个人本地 assistant;需要可拷贝 memory file;研究低复杂度 recall
+  baseline。
+- **不适用**:多人协作、企业治理、跨设备同步、复杂 provenance 和审计。
+
+## 6. 注意事项 / 风险
+
+- **license 不一致**:官网写 MIT,GitHub metadata 显示 Apache 2.0,需以仓库
+  `LICENSE` 为准。
+- **成熟度低**:星标和生态很小,只应作为观察项或 baseline,不要当作成熟框架。
+- **benchmark 小**:官网 benchmark 样本很小,不可与 LoCoMo / LongMemEval 直接
+  比较。
+
+## 7. 进一步阅读
+
+- archive: [`archives/memx-overview.md`](archives/memx-overview.md)
+- 官方:https://memx.me/
+- GitHub:https://github.com/memxlab/memx
+- Paper:https://arxiv.org/abs/2603.16171
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/microsoft-foundry-memory.md
+++ b/products/microsoft-foundry-memory.md
@@ -1,0 +1,67 @@
+---
+title: Microsoft Foundry Agent Service Memory
+type: product
+source: https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/what-is-memory
+date_first_seen: 2026-06
+domain: platform-managed-memory
+business_model: Azure / Microsoft Foundry managed service
+license: Proprietary cloud service
+memory_modules:
+  - ingest-adapter
+  - semantic-dedup
+  - dream-consolidator
+  - retriever-reranker
+  - policy-privacy
+status: seed
+last_revised: 2026-06-11
+archive: archives/microsoft-foundry-memory-overview.md
+---
+
+# Microsoft Foundry Agent Service Memory
+
+## 1. 一句话定位
+
+Microsoft Foundry Agent Service Memory 是 Azure Foundry agents 的托管 memory
+store,通过 scope、TTL、CRUD 和 memory tools 支持 user profile、chat summaries 与
+procedural memory。
+
+## 2. 是什么 / 做什么
+
+Microsoft Learn 的 memory 文档把记忆描述为 public preview capability。开发者可以
+让 agent remember/forget,也可以直接管理 memory items。公开概念包括 item store、
+scope、default TTL、user profile memory、chat summaries 和 procedural memory。
+
+## 3. 关键技术选择
+
+- **Scoped store**:每次请求/工具调用显式带 scope。
+- **Item lifecycle**:记忆项支持 CRUD、默认 TTL 和 forget。
+- **Memory types**:profile、summary、procedure 被作为不同用途的 memory。
+- **Agent tools**:通过工具让 agent 直接操作记忆。
+
+## 4. 决策相关性 / Decision relevance
+
+- **对照点**:Microsoft 路线比纯自动抽取更强调 developer-visible item lifecycle。
+- **借鉴点**:scope + TTL + CRUD 是 managed memory 最低治理基线。
+- **差异点**:底层提取/merge/conflict 机制仍是平台实现细节。
+
+## 5. 适用 / 不适用场景
+
+- **适用**:Azure Foundry 上的客服、销售、企业流程 agent;需要 Azure 账号、权限和
+  生命周期控制的团队。
+- **不适用**:本地优先、文件优先、跨平台 agent memory。
+
+## 6. 注意事项 / 风险
+
+- **可用性标签**:官方文档标注 preview/public preview,不能按 GA 稳定能力处理。
+- **平台绑定**:与 Azure Foundry Agent Service 强绑定。
+- **claim 边界**:本笔记只记录 Microsoft 官方概念,不外推内部算法。
+
+## 7. 进一步阅读
+
+- archive: [`archives/microsoft-foundry-memory-overview.md`](archives/microsoft-foundry-memory-overview.md)
+- Docs:https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/what-is-memory
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/openviking.md
+++ b/products/openviking.md
@@ -1,0 +1,68 @@
+---
+title: OpenViking
+type: product
+source: https://volcengine-openviking.mintlify.app/
+date_first_seen: 2026-06
+domain: context-database
+business_model: OSS / Volcengine ecosystem
+license: Apache 2.0
+memory_modules:
+  - parser-chunker
+  - retriever-reranker
+  - dream-consolidator
+status: seed
+last_revised: 2026-06-11
+archive: archives/openviking-overview.md
+---
+
+# OpenViking
+
+## 1. 一句话定位
+
+OpenViking 是火山引擎开源的 AI Agent context database,用 filesystem paradigm 统一
+memory、resources 和 skills,并通过 L0/L1/L2 层级加载降低长期任务上下文成本。
+
+## 2. 是什么 / 做什么
+
+官方文档把 OpenViking 定位为 "The Context Database for AI Agents"。它不是纯
+memory layer,而是 context substrate:memory、resources、skills 都以 `viking://`
+文件系统式 URI 管理,支持 hierarchical loading、semantic retrieval、session
+management 和 MCP/OpenClaw/Claude Desktop 等集成。
+
+## 3. 关键技术选择
+
+- **Filesystem paradigm**:用目录、URI、`ls/find/grep` 等心智模型管理上下文。
+- **L0/L1/L2 context**:abstract、overview、full detail 按需加载。
+- **Directory recursive retrieval**:从 intent analysis 到 directory positioning 再递归检索。
+- **Self-evolving memory**:sessions 自动抽取 profile、preferences、entities、
+  events、cases、patterns 六类 memory。
+
+## 4. 决策相关性 / Decision relevance
+
+- **对照点**:OpenViking 把 memory 放进更广义的 context DB,是本仓需要区分的相邻
+  但核心相关路线。
+- **借鉴点**:层级上下文加载和可视化 retrieval trajectory 很适合解决 context opacity。
+- **差异点**:它不只是 memory;归类时应写成 context database with first-class memory。
+
+## 5. 适用 / 不适用场景
+
+- **适用**:OpenClaw/coding agent 长任务;需要统一 memory/resources/skills 的 agent;
+  追求上下文层级加载的本地/开源工作流。
+- **不适用**:只需要用户偏好存储;不希望引入新的 context filesystem 抽象的轻量应用。
+
+## 6. 注意事项 / 风险
+
+- **benchmark 自报**:OpenClaw completion/token 数字来自官方文档,按 vendor-claimed 处理。
+- **边界**:不可把它简化成 vector DB 或普通 RAG。
+- **生态依赖**:OpenClaw 集成是亮点,但跨 runtime 的成熟度仍需验证。
+
+## 7. 进一步阅读
+
+- archive: [`archives/openviking-overview.md`](archives/openviking-overview.md)
+- Docs:https://volcengine-openviking.mintlify.app/
+- GitHub:https://github.com/volcengine/OpenViking
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/oracle-ai-agent-memory.md
+++ b/products/oracle-ai-agent-memory.md
@@ -1,0 +1,67 @@
+---
+title: Oracle AI Agent Memory
+type: product
+source: https://docs.oracle.com/en/database/oracle/agent-memory/26.4/agmea/about.html
+date_first_seen: 2026-06
+domain: enterprise-db-memory
+business_model: Oracle AI Database / enterprise platform
+license: Proprietary database feature / SDK docs
+memory_modules:
+  - ingest-adapter
+  - retriever-reranker
+  - policy-privacy
+status: seed
+last_revised: 2026-06-11
+archive: archives/oracle-ai-agent-memory-overview.md
+---
+
+# Oracle AI Agent Memory
+
+## 1. 一句话定位
+
+Oracle AI Agent Memory 是基于 Oracle AI Database 的企业 agent 持久记忆层,把
+working memory 与 long-term memory 放进统一的数据库治理边界。
+
+## 2. 是什么 / 做什么
+
+Oracle 文档称 Agent Memory 为 enterprise AI agents 的 persistent memory layer。
+它包含 short-term memory(thread context cards、conversation summaries)和 long-term
+memory(`add` / `search` workflows),用于保存用户偏好、规则和跨会话 facts。
+
+## 3. 关键技术选择
+
+- **Converged database substrate**:把 vector、graph、JSON、transactional 等能力
+  统一到 Oracle AI Database。
+- **Short-term memory**:thread context cards 与 summaries 维持当前任务状态。
+- **Long-term memory**:`add` 和 `search` workflow 管理偏好、规则和 facts。
+- **MCP integration**:文档提到可通过 MCP Server 与 Oracle Private Agent Factory
+  或外部框架集成。
+
+## 4. 决策相关性 / Decision relevance
+
+- **对照点**:Oracle 代表 "enterprise database becomes memory substrate" 路线。
+- **借鉴点**:把 memory scoping、authentication、authorization 明确交给集成方和
+  数据库治理层,适合企业级 memory 讨论。
+- **差异点**:它是数据库/平台能力,不是独立开源 memory SDK。
+
+## 5. 适用 / 不适用场景
+
+- **适用**:Oracle Database 既有客户;强合规、强审计、企业数据边界内的 agent。
+- **不适用**:轻量开源 agent;个人 local-first memory;需要快速跨云迁移的产品。
+
+## 6. 注意事项 / 风险
+
+- **实现依赖**:价值建立在 Oracle AI Database 生态之上。
+- **安全责任**:官方文档强调 integrating application 负责 end-user auth、authorization
+  和正确 memory scoping。
+- **成熟度**:需要继续跟踪 26.x 文档与 SDK 变化。
+
+## 7. 进一步阅读
+
+- archive: [`archives/oracle-ai-agent-memory-overview.md`](archives/oracle-ai-agent-memory-overview.md)
+- Docs:https://docs.oracle.com/en/database/oracle/agent-memory/26.4/agmea/about.html
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/personal-ai.md
+++ b/products/personal-ai.md
@@ -1,0 +1,79 @@
+---
+title: Personal AI
+type: product
+source: https://www.personal.ai/products
+date_first_seen: 2023-04
+domain: personal-ai-memory
+business_model: SaaS / platform
+license: proprietary
+memory_modules:
+  - ingest-adapter
+  - semantic-dedup
+  - retriever-reranker
+  - audit-ui
+status: seed
+last_revised: 2026-05-31
+archive: archives/personal-ai-overview.md
+---
+
+# Personal AI
+
+## 1. 一句话定位
+
+Personal AI 是一个以"persistent, evolving memory"为底座的个人 AI 平台,同时
+提供终端 assistant、persona builder 和 Memory Core 基础设施。
+
+## 2. 是什么 / 做什么
+
+产品页把平台拆成三层:
+
+- **My AI**:面向普通用户的长期关系 assistant,记住对话并学习偏好
+- **Persona Studio**:无代码配置和部署 AI persona,定义 personality、knowledge
+  domains、memory behavior 和 guardrails
+- **Memory Core**:面向开发者的统一 context/memory service,负责 encode、
+  stabilize、recall、evolve persistent memory
+
+它是 C 端个人 AI 与 B 端 memory infrastructure 混合形态,不是单纯开源框架。
+
+## 3. 关键技术选择
+
+- **记忆形态**:长期、持续演化的个人 memory
+- **产品分层**:consumer app / persona builder / infrastructure
+- **控制面**:guardrails 与 memory behavior 在 Persona Studio 中配置
+- **开发者入口**:developer docs 与 Memory Core
+
+## 4. 决策相关性 / Decision relevance
+
+- **对照点**:Personal AI 表明"memory creates identity"是个人 AI 产品的核心
+  叙事,不仅是 agent SDK 功能。
+- **借鉴点**:
+  - 把 memory behavior 变成 persona builder 的显式配置项,值得 host app
+    的 admin UI 参考。
+  - Memory Core 作为 infrastructure 层,说明 personal AI 公司也在把 C 端
+    能力向开发者平台拆分。
+- **差异点**:schema、更新逻辑和底层模型未公开,不适合作为 kernel 技术
+  细节来源。
+
+## 5. 适用 / 不适用场景
+
+- **适用**:个人 assistant、creator persona、企业定制 AI persona。
+- **不适用**:需要开源代码、本地部署或可审计 memory diff 的 agent kernel。
+
+## 6. 注意事项 / 风险
+
+- **黑盒**:Memory Core 具体 schema、检索、consolidation 未公开。
+- **隐私与合规**:个人长期 memory 是高敏数据,需要单独看隐私、导出、删除
+  与训练使用政策。
+- **产品边界变化**:Personal AI 同时做 C 端与平台,比较时要区分 My AI、
+  Persona Studio 和 Memory Core。
+
+## 7. 进一步阅读
+
+- archive: [`archives/personal-ai-overview.md`](archives/personal-ai-overview.md)
+- 官方产品页:https://www.personal.ai/products
+- Developer docs:https://docs.personal.ai/
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/powermem.md
+++ b/products/powermem.md
@@ -1,0 +1,70 @@
+---
+title: PowerMem
+type: product
+source: https://github.com/oceanbase/powermem
+date_first_seen: 2026-06
+domain: memory-api-server
+business_model: OSS / OceanBase ecosystem
+license: Apache 2.0
+memory_modules:
+  - ingest-adapter
+  - semantic-dedup
+  - retriever-reranker
+  - dream-consolidator
+status: seed
+last_revised: 2026-06-11
+archive: archives/powermem-overview.md
+---
+
+# PowerMem
+
+## 1. 一句话定位
+
+PowerMem 是 OceanBase 生态的 persistent, self-evolving AI memory plugin,面向
+coding agents、MCP clients、SDK/API servers 和多后端本地/云存储。
+
+## 2. 是什么 / 做什么
+
+仓库 README 把 PowerMem 描述为结合 vector、full-text、graph retrieval、LLM-driven
+memory extraction、Ebbinghaus-style time decay、Experience + Skill distillation、
+multi-agent isolation、user profiles 和 multimodal signals 的 agent memory 系统。
+
+## 3. 关键技术选择
+
+- **Experience + Skill distillation**:用两层结构把经历沉淀成可复用技能。
+- **4-way hybrid retrieval**:README 提到 hybrid retrieval,并提供 LOCOMO/AppWorld
+  benchmark 复现目录。
+- **多接口**:Python SDK、CLI、HTTP API、MCP server、dashboard、IDE/agent plugins。
+- **多后端**:OceanBase/seekdb/Postgres/SQLite 等配置路径。
+
+## 4. 决策相关性 / Decision relevance
+
+- **对照点**:PowerMem 与 EverOS 一样把 skill/procedural memory 放到产品核心,但
+  更偏工程插件/API server。
+- **借鉴点**:CLI + MCP + HTTP + dashboard 的多入口组合适合观察 memory server 的
+  开发者体验。
+- **差异点**:benchmark 和性能 claim 需要从 `benchmark/` 独立复现后才能当实证。
+
+## 5. 适用 / 不适用场景
+
+- **适用**:需要给 Claude Code、Codex、Cursor、OpenClaw 等 IDE/agent 加长期记忆;
+  希望本地/服务器多部署形态共存的团队。
+- **不适用**:只需要用户级偏好 store;不希望引入 LLM 自动 distillation 的强审计产品。
+
+## 6. 注意事项 / 风险
+
+- **benchmark 自报**:LOCOMO/AppWorld 数字和改善幅度来自官方 README,本仓标为
+  vendor-claimed,待独立复现。
+- **生态复杂度**:多后端和多插件提高灵活性,也增加运维/版本验证成本。
+- **数据治理**:需要实测 delete/export/audit 行为。
+
+## 7. 进一步阅读
+
+- archive: [`archives/powermem-overview.md`](archives/powermem-overview.md)
+- GitHub:https://github.com/oceanbase/powermem
+- Site:https://www.powermem.ai/
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/redis-agent-memory-server.md
+++ b/products/redis-agent-memory-server.md
@@ -1,0 +1,69 @@
+---
+title: Redis Agent Memory Server
+type: product
+source: https://redis.github.io/agent-memory-server/
+date_first_seen: 2026-06
+domain: memory-api-server
+business_model: OSS / Redis ecosystem
+license: Apache 2.0
+memory_modules:
+  - ingest-adapter
+  - semantic-dedup
+  - retriever-reranker
+  - policy-privacy
+status: seed
+last_revised: 2026-06-11
+archive: archives/redis-agent-memory-server-overview.md
+---
+
+# Redis Agent Memory Server
+
+## 1. 一句话定位
+
+Redis Agent Memory Server 是 Redis 生态的生产向 agent memory API/MCP server,以
+working memory + long-term memory 双层结构管理跨会话上下文。
+
+## 2. 是什么 / 做什么
+
+官方文档将它描述为 production-ready memory system for AI agents。它保存
+conversation history、user preferences 与 facts,支持 semantic、keyword、hybrid
+search,并通过 REST API、MCP server 和 Python client 暴露。
+
+## 3. 关键技术选择
+
+- **Two-tier memory**:working memory 负责 session-scoped state 和自动摘要;
+  long-term memory 保存持久偏好和 facts。
+- **Hybrid search**:semantic、keyword、hybrid search 与 topics/entities/time filters。
+- **Smart memory management**:automatic extraction、contextual grounding、
+  deduplication、memory editing。
+- **Ops surface**:authentication、multi-tenancy、background processing、多后端向量库。
+
+## 4. 决策相关性 / Decision relevance
+
+- **对照点**:Redis 把 memory server 包装为可运维 API,区别于纯库或纯 SaaS。
+- **借鉴点**:working/long-term split 与 REST+MCP 双接口是很实用的部署形态。
+- **差异点**:默认与 Redis 生态绑定,人类可读 artifact 不是主路径。
+
+## 5. 适用 / 不适用场景
+
+- **适用**:需要可部署 memory service 的团队;希望用 MCP/REST 快速接入 agent 的
+  Redis 用户。
+- **不适用**:要求所有记忆以 Markdown/git 形式审计;只做短会话 prototype 的项目。
+
+## 6. 注意事项 / 风险
+
+- **产品边界**:它是 agent memory server,不是通用 Redis vector search 的简单包装。
+- **成本与治理**:multi-tenancy、auth、delete/export 实际成熟度需部署验证。
+- **claim 边界**:production-ready 等表述来自官方文档。
+
+## 7. 进一步阅读
+
+- archive: [`archives/redis-agent-memory-server-overview.md`](archives/redis-agent-memory-server-overview.md)
+- Docs:https://redis.github.io/agent-memory-server/
+- MCP:https://redis.github.io/agent-memory-server/mcp/
+- GitHub:https://github.com/redis/agent-memory-server
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/supermemory.md
+++ b/products/supermemory.md
@@ -1,0 +1,92 @@
+---
+title: Supermemory
+type: product
+source: https://supermemory.ai/
+date_first_seen: 2026-05
+domain: context-cloud
+business_model: OSS+SaaS / API / personal app
+license: MIT (open-source repo); commercial cloud terms for hosted service
+memory_modules:
+  - ingest-adapter
+  - parser-chunker
+  - semantic-dedup
+  - retriever-reranker
+  - dream-consolidator
+status: seed
+last_revised: 2026-05-31
+archive: archives/supermemory-overview.md
+---
+
+# Supermemory
+
+## 1. 一句话定位
+
+Supermemory 把自己定位为 "context cloud for agents":同时卖 memory、RAG、
+profiles、connectors、extractors 和 personal app,试图覆盖 agent 的完整上下文
+栈。
+
+## 2. 是什么 / 做什么
+
+产品页把 Supermemory 拆成一组上下文 primitives:
+
+- Memory & continual learning
+- SuperRAG retrieval
+- Filesystem mount
+- User profiles
+- Connectors(Slack、Notion、Drive、Gmail、GitHub、S3 等)
+- Extractors(PDF、网页、图片、音频、文件)
+- Qualitative analysis
+
+它强调"memory, RAG, and profiles live in the same queryable graph",不是孤立
+的 vector chunk。面向开发者有 API/SDK,面向最终用户有 Personal Supermemory
+和浏览器 / coding-agent 插件。
+
+GitHub `supermemoryai/supermemory` 截至 2026-05-31 约 22.9k stars,MIT
+license,仍活跃更新。
+
+## 3. 关键技术选择
+
+- **统一图结构**:memory、RAG、profile 共用可查询 graph
+- **connectors**:多源同步,偏实时更新
+- **deployment**:hosted、self-host、BYOC、air-gapped/on-prem 都在产品页中
+  出现
+- **latency claims**:产品页声称 sub-300ms recall
+- **MCP / plugins**:产品目录明确列出 MCP 与插件形态
+
+## 4. 决策相关性 / Decision relevance
+
+- **对照点**:Supermemory 是 memory-as-context-infrastructure 的商业化样本,
+  比单一 SDK 更像"上下文云"。
+- **借鉴点**:
+  - 把 connectors、profiles、RAG 和 memory 放进同一产品叙事,说明市场正在
+    从"记忆库"转向"完整 context stack"。
+  - filesystem mount 是 agent 可直接消费的接口形态,值得 `ingest-adapter`
+    和 host integration 参考。
+  - personal app + developer API 双入口值得关注。
+- **差异点**:Supermemory 目前更偏全栈产品,本仓 kernel 应避免把 connectors
+  和 UI 直接塞进 core。
+
+## 5. 适用 / 不适用场景
+
+- **适用**:需要快速接入多源上下文的 AI assistant;希望 memory/RAG/profile
+  一体化的 SaaS 团队;需要 on-prem 或 BYOC 的企业。
+- **不适用**:只想研究底层 memory schema 的学术实验;必须完全排除商业
+  control plane 的本地单机工作流。
+
+## 6. 注意事项 / 风险
+
+- **benchmark 自报**:SOTA 与 latency claim 主要来自产品页,需独立复现。
+- **scope 膨胀**:产品覆盖 memory、RAG、connectors、analysis,比较时应拆开
+  看,不要把它与单一 agent memory SDK 直接等价。
+- **企业能力验证**:SOC2/GDPR/on-prem 由产品页声明,采购前仍需正式合规材料。
+
+## 7. 进一步阅读
+
+- archive: [`archives/supermemory-overview.md`](archives/supermemory-overview.md)
+- 官方:https://supermemory.ai/
+- GitHub:https://github.com/supermemoryai/supermemory
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/tencentdb-agent-memory.md
+++ b/products/tencentdb-agent-memory.md
@@ -1,0 +1,99 @@
+---
+title: TencentDB Agent Memory
+type: product
+source: https://github.com/Tencent/TencentDB-Agent-Memory
+date_first_seen: 2026-04
+domain: agent-memory
+business_model: OSS + Tencent Cloud service
+license: Other / repo license file (GitHub metadata); Tencent Cloud service proprietary
+memory_modules:
+  - ingest-adapter
+  - parser-chunker
+  - semantic-dedup
+  - retriever-reranker
+  - dream-consolidator
+  - audit-ui
+status: seed
+last_revised: 2026-05-31
+archive: archives/tencentdb-agent-memory-overview.md
+---
+
+# TencentDB Agent Memory
+
+## 1. 一句话定位
+
+TencentDB Agent Memory 是腾讯云数据库团队推出的 agent 记忆底座:云上产品
+强调企业级记忆管理,开源仓库强调本地可运行的 L0-L3 分层长期记忆与短期
+context offloading。
+
+## 2. 是什么 / 做什么
+
+官方产品页把它描述为"Agent 记忆服务",面向跨会话、长周期、多任务 agent,
+提供自动写入、分层沉淀、按需召回、治理增强和全局资源管理。底层云产品基于
+Tencent Cloud VectorDB。
+
+开源仓库 `Tencent/TencentDB-Agent-Memory` 把重点放在本地可 inspect 的
+记忆流水线:
+
+- **L0 Conversation**:原始会话与引用
+- **L1 Atom**:抽取后的原子记忆
+- **L2 Scenario**:面向场景的 Markdown block
+- **L3 Persona**:可追溯到 scenario 的用户画像
+- **Context offloading**:用 Mermaid task canvas 压缩短期任务状态
+
+截至 2026-05-31 查询,GitHub metadata 约 4.4k stars / 370 forks,最新 release
+为 `v0.3.6`(2026-05-28),仓库仍在活跃更新。
+
+## 3. 关键技术选择
+
+- **存储**:本地默认 SQLite + sqlite-vec;路线图同时支持 Tencent Cloud VectorDB
+- **召回**:keyword / embedding / hybrid,RRF 融合
+- **分层记忆**:conversation -> atom -> scenario -> persona
+- **短期上下文**:Mermaid canvas 保留任务状态,原始 payload 通过 `result_ref`
+  / `node_id` 追溯
+- **接入**:OpenClaw plugin、Hermes Gateway adapter、agent tools
+  `tdai_memory_search` / `tdai_conversation_search`
+
+## 4. 决策相关性 / Decision relevance
+
+- **对照点**:它把"可调试记忆"作为核心卖点,不像纯 vector DB 只返回相似度列表。
+- **借鉴点**:
+  - 分层 artifact 全部可读(L2 Markdown、L3 persona.md、Mermaid canvas),
+    对 `audit-ui` 和 provenance 设计有直接参考价值。
+  - short-term offloading 与 long-term persona 形成闭环,适合对比
+    `dream-consolidator` / `memorydiff-generator` 的边界。
+  - hybrid recall 的可配置项可作为 retriever-reranker 的产品化参考。
+- **差异点**:腾讯方案默认更 opinionated,直接规定 memory pyramid;本仓的
+  kernel 目标仍偏 host-neutral schema + diff。
+
+## 5. 适用 / 不适用场景
+
+- **适用**:OpenClaw/Hermes 生态;需要本地可审计 memory artifacts 的 agent;
+  长任务中上下文膨胀明显、需要 offload 的工具 agent。
+- **不适用**:只需要轻量 SDK 的 SaaS prototype;不想接受 L0-L3 固定结构的
+  host app;需要成熟商业 SLA 但无法使用腾讯云的海外部署。
+
+## 6. 注意事项 / 风险
+
+- **license metadata 不统一**:GitHub API 显示 `Other`;仓库页面底部显示
+  license 链接,引用前应以仓库 `LICENSE` 文件为准。
+- **benchmark 自报**:产品页声称 PersonaMem 与 token 降低数据,目前按官方
+  自测处理,不当作独立复现。
+- **benchmark ledger**:PersonaMem-v2 row 见
+  [`../benchmarks/claims/claims.yaml`](../benchmarks/claims/claims.yaml);
+  benchmark note 暂在 [`../benchmarks/index.md`](../benchmarks/index.md) 以
+  candidate 收录。
+- **云产品与 OSS 边界**:腾讯云 Agent Memory 与开源本地实现不是同一交付
+  形态,文档引用时需要分清。
+
+## 7. 进一步阅读
+
+- archive: [`archives/tencentdb-agent-memory-overview.md`](archives/tencentdb-agent-memory-overview.md)
+- 腾讯云产品页:https://cloud.tencent.com/product/agm
+- GitHub:https://github.com/Tencent/TencentDB-Agent-Memory
+- Release:https://github.com/Tencent/TencentDB-Agent-Memory/releases/tag/v0.3.6
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/zep.md
+++ b/products/zep.md
@@ -52,6 +52,10 @@ healthcare 等行业的预置 entity schema 模板。
 - **性能**:产品页声称 P95 < 200ms,LoCoMo 单次检索 80.32%
 - **合规**:SOC 2 Type II / HIPAA(hosted 版)
 
+> Benchmark record: [`../benchmarks/locomo.md`](../benchmarks/locomo.md);
+> event ledger row: `zep-locomo-2026` in
+> [`../benchmarks/claims/claims.yaml`](../benchmarks/claims/claims.yaml)。
+
 ## 4. 决策相关性 / Decision relevance
 
 - **对照点**:Zep 占据和 memory kernel 几乎相同的生态位 — host-agnostic 的记忆层。它


### PR DESCRIPTION
## Summary

- Add `benchmarks/` as a first-class knowledge layer alongside papers and products, including initial benchmark notes, a claims ledger, and the benchmark landscape overview.
- Expand product memory coverage with additional product notes, archives, architecture landscape docs, and product classification standards.
- Wire the new benchmark/product evidence surfaces into README and docs indexes while keeping vendor claims, paper-origin reuse, critiques, and independent evaluations separated.

## Validation

- `git diff --check`
- changed-file relative link checks
- table pipe consistency checks
- benchmark claims ledger schema validation
- README product/archive count checks

## Notes

- This PR does not run real benchmark evaluations or independently reproduce vendor-reported scores.
- Existing unrelated broken paper links were observed in `papers/index.md` and left unchanged.