### PR TITLE
[codex] Reframe README around the evidence model

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # awesome-agent-memory
 
-**Long-term memory for LLM agents — a decision-driven reading list, 989-paper index, and living survey covering memory architectures, retrieval, consolidation, and forgetting.**
+**Decision-grade evidence base for long-term memory in LLM agents: papers, product notes, benchmark protocols, architecture maps, and a research-to-ADR workflow.**
 
 [中文](README_cn.md) · **English**
 
@@ -16,137 +16,219 @@
 
 </div>
 
-
 ---
 
-## Table of contents
+## Table Of Contents
 
-1. [At a glance](#at-a-glance)
-2. [Repository map](#repository-map)
-3. [Read first](#read-first)
-4. [Repository layout](#repository-layout)
-5. [License / archival policy](#license--archival-policy)
-6. [Origin / maintenance](#origin--maintenance)
+1. [What This Repository Is](#what-this-repository-is)
+2. [At A Glance](#at-a-glance)
+3. [How To Use It](#how-to-use-it)
+4. [Evidence Model](#evidence-model)
+5. [Repository Map](#repository-map)
+6. [Repository Layout](#repository-layout)
+7. [Scope Boundaries](#scope-boundaries)
+8. [License And Archival Policy](#license-and-archival-policy)
+9. [Origin And Maintenance](#origin-and-maintenance)
+10. [Contributing](#contributing)
 
-## At a glance
+## What This Repository Is
 
-| Area | Count | Entry point | What it is for |
+`awesome-agent-memory` is not only an awesome list. It is a structured evidence
+base for deciding how long-term memory should be designed, evaluated, and
+operated in LLM agent systems.
+
+The repository separates five evidence layers:
+
+| Layer | What it owns | Main entry point |
+|---|---|---|
+| Papers | Scholarly claims, methods, and local reading notes | [`papers/index.md`](papers/index.md) |
+| Products | Public behavior of memory products and memory-enabled platforms | [`docs/products-landscape.md`](docs/products-landscape.md) |
+| Benchmarks | Evaluation protocols, usage events, vendor claims, and critique records | [`docs/benchmarks-landscape.md`](docs/benchmarks-landscape.md) |
+| Synthesis | Taxonomy, living survey, architecture patterns, source maps, and signal logs | [`docs/README.md`](docs/README.md) |
+| Decision workflow | How evidence becomes ImpactReports, experiments, and ADR inputs | [`docs/research-radar.md`](docs/research-radar.md) |
+
+The core maintenance rule is simple: keep direct evidence, maintainer inference,
+vendor self-claims, affiliated evaluations, and independent reproductions in
+separate buckets.
+
+## At A Glance
+
+| Area | Current coverage | Entry point | Use it when you need to |
 |---|---:|---|---|
-| Paper index | 989 papers | [`papers/index.md`](papers/index.md) | Searchable entry point for agent-memory papers. |
-| Paper stubs | 988 stubs | [`papers/stubs/`](papers/stubs/) | Lightweight coverage records for papers not yet fully read. |
-| Local PDFs | 534 files | [`papers/pdfs/`](papers/pdfs/) | Archived PDFs for stable reading and audit. |
-| Full / seed notes | 7 full + 2 seed | [`papers/`](papers/) | Human-read paper notes and notes in progress. |
-| Memory product notes | 34 notes | [`products/`](products/) | Notes on existing memory infrastructure and agent-memory products. |
-| Page archives | 33 snapshots | [`products/archives/`](products/archives/) | Markdown snapshots for memory-product page auditability. |
-| Benchmark catalog | 12 seed entries | [`benchmarks/index.md`](benchmarks/index.md) | First-class benchmark records and usage-claim ledger. |
-| Survey docs | 1 living survey + 6 meta-survey records | [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) · [`docs/meta-surveys.md`](docs/meta-surveys.md) | Maintainer synthesis and survey tracking. |
+| Paper index | 989 papers | [`papers/index.md`](papers/index.md) | Search agent-memory papers and discovery trails. |
+| Paper stubs | 988 stubs | [`papers/stubs/`](papers/stubs/) | Track papers that are covered but not yet fully read. |
+| Local PDFs | 534 files | [`papers/pdfs/`](papers/pdfs/) | Re-read sources and audit paper notes. |
+| Full / seed paper notes | 7 full + 2 seed | [`papers/`](papers/) | Use human-read notes for architectural decisions. |
+| Memory product notes | 34 notes | [`products/`](products/) | Compare memory layers, memory SDKs, managed memory, and memory-enabled agents. |
+| Product page archives | 33 snapshots | [`products/archives/`](products/archives/) | Audit product claims after source pages change. |
+| Benchmark catalog | 12 catalog entries | [`benchmarks/index.md`](benchmarks/index.md) | Understand memory benchmarks and where claims come from. |
+| Claims ledger | Structured YAML ledger | [`benchmarks/claims/claims.yaml`](benchmarks/claims/claims.yaml) | Separate vendor claims, paper evaluations, critiques, and reproductions. |
+| Survey and taxonomy | 1 living survey + 6 meta-survey records | [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) · [`docs/meta-surveys.md`](docs/meta-surveys.md) | Build a field-level view before choosing an implementation. |
+| Impact reports | Template only for now | [`impact-reports/README.md`](impact-reports/README.md) | Promote strong evidence into kernel-design recommendations. |
 
-## Repository map
+## How To Use It
+
+Start with the path that matches your question:
+
+| Goal | Read these first |
+|---|---|
+| Get the field overview | [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md), then [`docs/taxonomy.md`](docs/taxonomy.md) |
+| Find relevant papers | [`papers/index.md`](papers/index.md), then full notes under [`papers/`](papers/) |
+| Compare memory products | [`docs/products-landscape.md`](docs/products-landscape.md), [`docs/product-memory-architectures.md`](docs/product-memory-architectures.md), [`docs/product-architecture-diagrams.md`](docs/product-architecture-diagrams.md) |
+| Check why a product was included or rejected | [`docs/product-discovery-log.md`](docs/product-discovery-log.md) |
+| Evaluate benchmark claims | [`docs/benchmarks-landscape.md`](docs/benchmarks-landscape.md), [`benchmarks/index.md`](benchmarks/index.md), [`benchmarks/claims/claims.yaml`](benchmarks/claims/claims.yaml) |
+| Track new releases and source channels | [`docs/signals.md`](docs/signals.md), [`docs/information-sources.md`](docs/information-sources.md) |
+| Turn research into a memory-kernel decision | [`docs/research-radar.md`](docs/research-radar.md), then [`impact-reports/README.md`](impact-reports/README.md) |
+| See Ymem-specific bindings | [`docs/ymem-binding/README.md`](docs/ymem-binding/README.md) |
+
+## Evidence Model
+
+The repository is organized so claims can be traced back to their source type.
+
+| Evidence class | Where it belongs | How to read it |
+|---|---|---|
+| Primary paper evidence | Full notes in [`papers/`](papers/) and canonical links in [`papers/index.md`](papers/index.md) | Can support method and benchmark-protocol claims when the note is full. |
+| Paper stubs | [`papers/stubs/`](papers/stubs/) | Discovery coverage only; upgrade before using in an ImpactReport. |
+| Product behavior | Product notes in [`products/`](products/) and archives in [`products/archives/`](products/archives/) | Supports "the vendor says/offers X", not independent performance conclusions. |
+| Vendor benchmark claims | [`benchmarks/claims/claims.yaml`](benchmarks/claims/claims.yaml) | Must stay labeled as vendor or affiliated evidence unless independently reproduced. |
+| Independent reproductions | [`benchmarks/claims/claims.yaml`](benchmarks/claims/claims.yaml) | Require enough third-party setup detail to compare against the original claim. |
+| Maintainer synthesis | [`docs/`](docs/) | Useful for prioritization and design judgment; should not be confused with direct evidence. |
+
+## Repository Map
 
 ```mermaid
 flowchart LR
-  R["README"] --> D["Docs map<br/>survey + taxonomy"]
-  R --> P["Papers<br/>index + stubs + PDFs"]
-  R --> PL["Memory products<br/>notes + page archives"]
-  R --> B["Benchmarks<br/>protocols + claims ledger"]
-  D --> IR["Impact reports<br/>evaluation template"]
-  P --> IR
-  PL --> IR
+  R["README"] --> D["docs/<br/>survey, taxonomy, sources, signals"]
+  R --> P["papers/<br/>index, full notes, stubs, PDFs"]
+  R --> PR["products/<br/>notes and page archives"]
+  R --> B["benchmarks/<br/>protocol notes and claims ledger"]
+  D --> A["architecture maps<br/>product patterns and diagrams"]
+  P --> IR["impact-reports/<br/>decision template"]
+  PR --> IR
   B --> IR
-  IR --> KD["Kernel decisions<br/>sandbox + ADR"]
-  D -. "optional" .-> YB["Ymem binding"]
+  IR --> ADR["kernel decisions<br/>experiments and ADRs outside this repo"]
+  D -. "optional project binding" .-> Y["docs/ymem-binding/"]
 ```
 
-## Read first
+## Repository Layout
 
-If this is your first visit, use these entry points in order:
+### Concept And Synthesis Docs
 
-1. [`docs/README.md`](docs/README.md) — map of the documentation set.
-2. [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) — the living survey and current maintainer synthesis.
-3. [`docs/taxonomy.md`](docs/taxonomy.md) — the shared vocabulary for forms, functions, dynamics, persistence, and curation.
-4. [`papers/index.md`](papers/index.md) — the 989-paper index, organized for discovery and follow-up reading.
-5. [`docs/benchmarks-landscape.md`](docs/benchmarks-landscape.md) — benchmark usage, evidence class, and cross-source statistics.
-6. [`docs/products-landscape.md`](docs/products-landscape.md) — memory product notes grouped by domain and audience.
-7. [`docs/product-memory-architectures.md`](docs/product-memory-architectures.md) — cross-product architecture patterns and diagrams.
-
-## Repository layout
-
-### Concept files (top level)
-
-All concept docs now live under [`docs/`](docs/). Start with
-[`docs/README.md`](docs/README.md) if you want the shortest map.
-
-| File | Purpose |
+| Path | Purpose |
 |---|---|
-| [`docs/README.md`](docs/README.md) | Documentation map: what to read first and where each concept lives. |
-| [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) | A living literature review by the maintainer. |
-| [`docs/meta-surveys.md`](docs/meta-surveys.md) | Index of **external** meta-surveys (2025-12 ~ 2026-05). |
-| [`docs/taxonomy.md`](docs/taxonomy.md) | Generic agent-memory taxonomy: cross-walk of 3 external frameworks. |
-| [`docs/research-radar.md`](docs/research-radar.md) | Generic Radar schema for ResearchItem and ImpactReport notes. |
-| [`docs/information-sources.md`](docs/information-sources.md) | 10-category source catalog with a dedicated zh-CN section. |
+| [`docs/README.md`](docs/README.md) | Documentation map and recommended reading order. |
+| [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) | Living survey of memory architectures, retrieval, consolidation, forgetting, and evaluation. |
+| [`docs/taxonomy.md`](docs/taxonomy.md) | Shared vocabulary for classifying agent-memory systems and memory-kernel responsibilities. |
+| [`docs/meta-surveys.md`](docs/meta-surveys.md) | External meta-survey index from late 2025 through 2026 H1. |
+| [`docs/research-radar.md`](docs/research-radar.md) | Workflow for turning papers, products, and benchmark evidence into ImpactReports and ADR inputs. |
+| [`docs/information-sources.md`](docs/information-sources.md) | Source catalog for papers, products, communities, and zh-CN information channels. |
 | [`docs/related-work.md`](docs/related-work.md) | Discovery-input attribution and scrape provenance. |
-| [`docs/products-landscape.md`](docs/products-landscape.md) | Memory products by **domain × audience**. |
-| [`docs/product-discovery-log.md`](docs/product-discovery-log.md) | Multi-agent product discovery log with Tier A / Tier B / reject decisions. |
-| [`docs/product-memory-architectures.md`](docs/product-memory-architectures.md) | Cross-product memory architecture patterns and comparison diagrams. |
-| [`docs/product-architecture-diagrams.md`](docs/product-architecture-diagrams.md) | Per-product Mermaid architecture diagrams for public product patterns. |
-| [`docs/benchmarks-landscape.md`](docs/benchmarks-landscape.md) | Benchmark landscape by capability, usage type, and evidence independence. |
-| [`docs/signals.md`](docs/signals.md) | Reverse-chrono 2026 H1 release / memory product / blog log. |
+| [`docs/signals.md`](docs/signals.md) | Reverse-chronological release, comparison, and blog signal log. |
 
-### Per-item notes
+### Products And Architectures
 
-| Path | Contents |
+| Path | Purpose |
 |---|---|
-| [`papers/`](papers/) | 7 full paper notes, 2 seed notes, and master [`index.md`](papers/index.md). |
-| [`papers/stubs/`](papers/stubs/) | 988 auto-generated stubs for papers not yet fully read. |
-| [`papers/pdfs/`](papers/pdfs/) | 534 archived PDFs (~1.8 GB). See archival policy. |
-| [`papers/_scrape/`](papers/_scrape/) | Reproducibility artifacts: scrape script + dedup JSON. |
-| [`products/`](products/) | 34 memory product notes (Mem0, Letta, Zep, Graphiti, EverOS, Redis Agent Memory Server, …). |
-| [`products/archives/`](products/archives/) | 33 Markdown snapshots of canonical memory product pages. |
-| [`benchmarks/`](benchmarks/) | 12 benchmark seed entries and first-class protocol notes. |
-| [`benchmarks/claims/`](benchmarks/claims/) | Event ledger for benchmark usage, vendor claims, critiques, and reproductions. |
-| [`benchmarks/archives/`](benchmarks/archives/) | Optional source-page snapshots for benchmark pages, repos, or dataset cards. |
-| [`docs/ymem-binding/`](docs/ymem-binding/) | Project-specific bindings from the maintainer's [Ymem](https://github.com/Snseam/Ymem) kernel; safe to ignore if you don't use Ymem. |
+| [`products/`](products/) | 34 memory product notes, including Mem0, Letta, Zep, Graphiti, EverOS, MemOS, Redis Agent Memory Server, Supermemory, TencentDB Agent Memory, and platform-managed memory offerings. |
+| [`products/archives/`](products/archives/) | 33 markdown snapshots of canonical memory product pages. |
+| [`docs/products-landscape.md`](docs/products-landscape.md) | Product landscape by domain and audience. |
+| [`docs/product-discovery-log.md`](docs/product-discovery-log.md) | Multi-agent product discovery log with Tier A, Tier B, reject, and alias decisions. |
+| [`docs/product-memory-architectures.md`](docs/product-memory-architectures.md) | Cross-product architecture patterns: memory OS, graph/temporal memory, MCP/local-first memory, managed cloud memory, and personal memory. |
+| [`docs/product-architecture-diagrams.md`](docs/product-architecture-diagrams.md) | Per-product Mermaid diagrams based on public product patterns. |
 
-## License / archival policy
+### Papers, Benchmarks, And Decision Workflow
+
+| Path | Purpose |
+|---|---|
+| [`papers/`](papers/) | 7 full paper notes, 2 seed notes, and the master [`index.md`](papers/index.md). |
+| [`papers/stubs/`](papers/stubs/) | 988 generated stubs for papers not yet fully read. |
+| [`papers/pdfs/`](papers/pdfs/) | 534 archived PDFs, about 1.8 GB. See the archival policy below. |
+| [`papers/_scrape/`](papers/_scrape/) | Reproducibility artifacts: scrape script and dedup JSON. |
+| [`benchmarks/`](benchmarks/) | Benchmark catalog, protocol notes, and the note template. |
+| [`benchmarks/claims/`](benchmarks/claims/) | Usage-event ledger for benchmark mentions, vendor claims, critiques, and reproductions. |
+| [`benchmarks/archives/`](benchmarks/archives/) | Optional source-page snapshots for benchmark pages, repositories, or dataset cards. |
+| [`docs/benchmarks-landscape.md`](docs/benchmarks-landscape.md) | Benchmark landscape by capability, usage type, and evidence independence. |
+| [`impact-reports/README.md`](impact-reports/README.md) | Template for promoting strong evidence into architecture recommendations. |
+
+### Governance And Project Binding
+
+| Path | Purpose |
+|---|---|
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | Contribution rules for papers, products, benchmarks, and evidence ledgers. |
+| [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) | Community conduct policy. |
+| [`SECURITY.md`](SECURITY.md) | Security reporting guidance. |
+| [`CITATION.cff`](CITATION.cff) | Citation metadata. |
+| [`docs/ymem-binding/`](docs/ymem-binding/) | Project-specific bindings for the maintainer's [Ymem](https://github.com/Snseam/Ymem) kernel. Safe to skip if you only need the generic evidence base. |
+
+## Scope Boundaries
+
+Included:
+
+- long-term and multi-session memory for LLM agents;
+- memory writing, retrieval, consolidation, forgetting, personalization,
+  provenance, governance, and auditability;
+- products that expose memory as a first-class capability;
+- benchmarks used to evaluate memory behavior, personalization, temporal
+  reasoning, forgetting, or memory-layer trade-offs.
+
+Excluded or kept only as adjacent context:
+
+- pure vector databases with no memory lifecycle;
+- plain RAG middleware that does not model update, consolidation, or forgetting;
+- general agent frameworks where memory is not a first-class surface;
+- long-context inference or prompt-cache systems by themselves;
+- vendor performance claims presented as independent evidence.
+
+## License And Archival Policy
 
 Notes and survey content are released under the [Apache License 2.0](LICENSE).
-Quoted excerpts from external papers and articles remain the property of
-their respective authors and are used under fair use / fair dealing for
-commentary and research purposes.
+Quoted excerpts from external papers and articles remain the property of their
+authors and are used for commentary and research.
 
-**Locally archived PDFs** (`papers/pdfs/`) come from sources that explicitly
-permit redistribution — arXiv perpetual non-exclusive license, CC-BY at ACL
-Anthology, open OpenReview submissions, etc. If you find a PDF here whose
-source restricts redistribution, please open an issue; we will remove it.
-The canonical URL in the corresponding note's `urls` field remains the
+Locally archived PDFs in [`papers/pdfs/`](papers/pdfs/) come from sources that
+permit redistribution, such as arXiv, ACL Anthology, and open OpenReview
+submissions. If a PDF source restricts redistribution, open an issue and it
+will be removed. The canonical URL in the corresponding note remains the
 authoritative source.
 
-**Memory product page snapshots** (`products/archives/`) are research backups,
-captured so that this repo's reasoning stays auditable when source pages
-change or disappear. They are **not** re-published material; commercial
-citation should always use the original URL in the snapshot's `source_url`
-header.
+Product and benchmark page snapshots are audit backups. They are not
+republished commercial material. Cite the original URL from the snapshot header
+for external or commercial use.
 
-## Origin / maintenance
+## Origin And Maintenance
 
-This repo was started by the
-[**Ymem**](https://github.com/Snseam/Ymem) project, but the top-level
-documentation is intended to stay useful for any agent-memory kernel. Ymem
-specific bindings — module names, maintainer stance, and internal benchmark
-choices — live in [`docs/ymem-binding/`](docs/ymem-binding/) so the public
-entry points remain project-neutral.
+This repo was started by the [Ymem](https://github.com/Snseam/Ymem) project,
+but the public entry points are intended to remain useful for any agent-memory
+kernel. Ymem-specific module names, maintainer stance, and internal benchmark
+choices live under [`docs/ymem-binding/`](docs/ymem-binding/).
 
-The paper index also uses a small set of public awesome-list repositories as
-discovery inputs. Source attribution and scrape artifacts live in
-[`docs/related-work.md`](docs/related-work.md) and
-[`papers/_scrape/`](papers/_scrape/). These inputs are used for discovery only;
-notes, survey synthesis, and maintainer judgments are maintained here.
+The paper index also uses public awesome-list repositories as discovery inputs.
+Attribution and scrape artifacts live in [`docs/related-work.md`](docs/related-work.md)
+and [`papers/_scrape/`](papers/_scrape/). Those inputs are discovery sources;
+notes, synthesis, and maintainer judgments are maintained here.
+
+## Contributing
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) and
+[`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md). In short:
+
+- New paper: add or upgrade a note under [`papers/`](papers/), and use a full
+  note before citing it in an ImpactReport.
+- New product: add a note under [`products/`](products/), archive the source
+  page when appropriate, and update the product landscape if it is core.
+- New benchmark: add or update a benchmark note, then record usage events in
+  [`benchmarks/claims/claims.yaml`](benchmarks/claims/claims.yaml).
+- New product or benchmark claim: label the source as vendor, affiliated,
+  critique, or independent reproduction.
+- New information source: update [`docs/information-sources.md`](docs/information-sources.md)
+  or [`docs/related-work.md`](docs/related-work.md).
 
 ---
 
-> *Notes are authored by the maintainer. Some stubs and first drafts were
-> accelerated with LLM tooling; every full note is grounded in the actual
-> PDF or memory product page that was read, not in unverified secondary summaries.*
+> Notes are authored by the maintainer. Some stubs and first drafts were
+> accelerated with LLM tooling; full notes should be grounded in the actual PDF,
+> product page, benchmark source, or archived snapshot rather than unverified
+> secondary summaries.
 
 <div align="center">
 
@@ -154,7 +236,7 @@ notes, survey synthesis, and maintainer judgments are maintained here.
 **[Docs map](docs/README.md)** ·
 **[Papers index](papers/index.md)** ·
 **[Benchmarks](benchmarks/index.md)** ·
-**[Memory products landscape](docs/products-landscape.md)** ·
+**[Memory products](docs/products-landscape.md)** ·
 **[Product architectures](docs/product-memory-architectures.md)** ·
 **[Signals](docs/signals.md)** ·
 **[中文版](README_cn.md)**

--- a/README_cn.md
+++ b/README_cn.md
@@ -2,7 +2,7 @@
 
 # awesome-agent-memory
 
-**面向 LLM agent 长程记忆的研究入口 —— 决策驱动的阅读清单、989 篇论文索引、活综述,涵盖记忆架构、检索、整合与遗忘。**
+**面向 LLM agent 长程记忆的决策级证据库：论文、产品笔记、benchmark 协议、架构图谱，以及从研究到 ADR 的工作流。**
 
 **中文** · [English](README.md)
 
@@ -20,135 +20,200 @@
 
 ## 目录
 
-1. [一眼总览](#一眼总览)
-2. [仓库地图](#仓库地图)
-3. [先读这里](#先读这里)
-4. [仓库结构](#仓库结构)
-5. [License 与存档策略](#license-与存档策略)
-6. [发起方与维护](#发起方与维护)
-7. [贡献](#贡献)
+1. [这个仓库是什么](#这个仓库是什么)
+2. [一眼总览](#一眼总览)
+3. [怎么使用](#怎么使用)
+4. [证据模型](#证据模型)
+5. [仓库地图](#仓库地图)
+6. [仓库结构](#仓库结构)
+7. [范围边界](#范围边界)
+8. [License 与存档策略](#license-与存档策略)
+9. [发起方与维护](#发起方与维护)
+10. [贡献](#贡献)
+
+## 这个仓库是什么
+
+`awesome-agent-memory` 不只是一个 awesome list。它是一个结构化证据库，用来
+判断 LLM agent 的长程记忆应该如何设计、评估和运营。
+
+仓库把证据拆成五层：
+
+| 层级 | 负责什么 | 主入口 |
+|---|---|---|
+| 论文 | 学术主张、方法和本地阅读笔记 | [`papers/index.md`](papers/index.md) |
+| 产品 | 记忆产品和内建 memory 平台的公开能力 | [`docs/products-landscape.md`](docs/products-landscape.md) |
+| Benchmark | 评测协议、使用事件、厂商 claims 和方法批评 | [`docs/benchmarks-landscape.md`](docs/benchmarks-landscape.md) |
+| 综合文档 | taxonomy、活综述、架构模式、信息源和信号日志 | [`docs/README.md`](docs/README.md) |
+| 决策工作流 | 证据如何进入 ImpactReport、实验和 ADR 输入 | [`docs/research-radar.md`](docs/research-radar.md) |
+
+核心维护原则是：直接证据、维护者推断、厂商自报、关联方评测和独立复现必须分开
+记录，不能混成一个“排行榜”。
 
 ## 一眼总览
 
-| 板块 | 数量 | 入口 | 用途 |
+| 板块 | 当前覆盖 | 入口 | 适合用来 |
 |---|---:|---|---|
-| 论文索引 | 989 篇论文 | [`papers/index.md`](papers/index.md) | 检索 agent memory 论文的主入口。 |
-| 论文 stub | 988 个 stub | [`papers/stubs/`](papers/stubs/) | 尚未 full 阅读论文的轻量覆盖记录。 |
-| 本地 PDF | 534 个文件 | [`papers/pdfs/`](papers/pdfs/) | 稳定阅读和审计用的 PDF 存档。 |
-| full / seed 笔记 | 7 个 full + 2 个 seed | [`papers/`](papers/) | 已人工阅读或正在推进的论文笔记。 |
-| 记忆产品笔记 | 34 个笔记 | [`products/`](products/) | 市面上已有的记忆基础设施和 agent-memory 产品记录。 |
-| 页面快照 | 33 个快照 | [`products/archives/`](products/archives/) | 用于审计的记忆产品页面 markdown 快照。 |
-| Benchmark 目录 | 12 个 seed 条目 | [`benchmarks/index.md`](benchmarks/index.md) | 与论文、产品并列的评测协议和使用 claims ledger。 |
-| 综述文档 | 1 份活综述 + 6 条 meta-survey 记录 | [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) · [`docs/meta-surveys.md`](docs/meta-surveys.md) | 维护者综合判断与综述追踪。 |
+| 论文索引 | 989 篇论文 | [`papers/index.md`](papers/index.md) | 搜索 agent-memory 论文和发现线索。 |
+| 论文 stub | 988 个 stub | [`papers/stubs/`](papers/stubs/) | 跟踪已覆盖但尚未 full 阅读的论文。 |
+| 本地 PDF | 534 个文件 | [`papers/pdfs/`](papers/pdfs/) | 复读来源和审计论文笔记。 |
+| full / seed 论文笔记 | 7 个 full + 2 个 seed | [`papers/`](papers/) | 为架构决策引用人工阅读笔记。 |
+| 记忆产品笔记 | 34 个笔记 | [`products/`](products/) | 对比 memory layer、memory SDK、managed memory 和带记忆的 agent 产品。 |
+| 产品页面快照 | 33 个快照 | [`products/archives/`](products/archives/) | 在源页面变化后审计产品 claims。 |
+| Benchmark 目录 | 12 个 catalog 条目 | [`benchmarks/index.md`](benchmarks/index.md) | 理解 memory benchmark 及其 claims 来源。 |
+| Claims ledger | 结构化 YAML ledger | [`benchmarks/claims/claims.yaml`](benchmarks/claims/claims.yaml) | 区分厂商自报、论文评测、方法批评和独立复现。 |
+| 综述与 taxonomy | 1 份活综述 + 6 条 meta-survey 记录 | [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) · [`docs/meta-surveys.md`](docs/meta-surveys.md) | 在选型或设计前建立领域视角。 |
+| Impact reports | 目前只有模板 | [`impact-reports/README.md`](impact-reports/README.md) | 把强证据提升为 memory-kernel 架构建议。 |
+
+## 怎么使用
+
+按你的问题选择路径：
+
+| 目标 | 先读这些 |
+|---|---|
+| 快速理解领域 | [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md)，再读 [`docs/taxonomy.md`](docs/taxonomy.md) |
+| 找相关论文 | [`papers/index.md`](papers/index.md)，再看 [`papers/`](papers/) 下的 full note |
+| 比较记忆产品 | [`docs/products-landscape.md`](docs/products-landscape.md)、[`docs/product-memory-architectures.md`](docs/product-memory-architectures.md)、[`docs/product-architecture-diagrams.md`](docs/product-architecture-diagrams.md) |
+| 查看产品为什么入库或被拒绝 | [`docs/product-discovery-log.md`](docs/product-discovery-log.md) |
+| 评估 benchmark claims | [`docs/benchmarks-landscape.md`](docs/benchmarks-landscape.md)、[`benchmarks/index.md`](benchmarks/index.md)、[`benchmarks/claims/claims.yaml`](benchmarks/claims/claims.yaml) |
+| 跟踪新发布和信息源 | [`docs/signals.md`](docs/signals.md)、[`docs/information-sources.md`](docs/information-sources.md) |
+| 把研究转成 kernel 决策 | [`docs/research-radar.md`](docs/research-radar.md)，再用 [`impact-reports/README.md`](impact-reports/README.md) |
+| 查看 Ymem 特定绑定 | [`docs/ymem-binding/README.md`](docs/ymem-binding/README.md) |
+
+## 证据模型
+
+仓库按来源类型组织 claims，方便追溯：
+
+| 证据类型 | 存放位置 | 读取方式 |
+|---|---|---|
+| 一手论文证据 | [`papers/`](papers/) 的 full note 和 [`papers/index.md`](papers/index.md) 的 canonical link | full note 可支持方法和 benchmark 协议判断。 |
+| 论文 stub | [`papers/stubs/`](papers/stubs/) | 只代表发现覆盖；进入 ImpactReport 前必须升级。 |
+| 产品公开能力 | [`products/`](products/) 的产品笔记和 [`products/archives/`](products/archives/) 的快照 | 支持“厂商宣称/提供 X”，不等于独立性能结论。 |
+| 厂商 benchmark claims | [`benchmarks/claims/claims.yaml`](benchmarks/claims/claims.yaml) | 除非有独立复现，否则必须继续标注为 vendor 或 affiliated evidence。 |
+| 独立复现 | [`benchmarks/claims/claims.yaml`](benchmarks/claims/claims.yaml) | 需要第三方实验设置足够清楚，才能和原始 claim 对比。 |
+| 维护者综合判断 | [`docs/`](docs/) | 可用于优先级和设计判断，但不能当作直接证据。 |
 
 ## 仓库地图
 
 ```mermaid
 flowchart LR
-  R["README"] --> D["文档地图<br/>综述 + taxonomy"]
-  R --> P["论文<br/>索引 + stubs + PDFs"]
-  R --> PL["记忆产品<br/>笔记 + 页面快照"]
-  R --> B["Benchmark<br/>协议 + claims ledger"]
-  D --> IR["Impact reports<br/>评估模板"]
-  P --> IR
-  PL --> IR
+  R["README"] --> D["docs/<br/>综述、taxonomy、信息源、signals"]
+  R --> P["papers/<br/>索引、full notes、stubs、PDFs"]
+  R --> PR["products/<br/>产品笔记和页面快照"]
+  R --> B["benchmarks/<br/>协议笔记和 claims ledger"]
+  D --> A["架构图谱<br/>产品模式和逐产品图"]
+  P --> IR["impact-reports/<br/>决策模板"]
+  PR --> IR
   B --> IR
-  IR --> KD["Kernel 决策<br/>沙盒 + ADR"]
-  D -. "可选" .-> YB["Ymem binding"]
+  IR --> ADR["kernel 决策<br/>实验和 ADR 在外部仓库完成"]
+  D -. "可选项目绑定" .-> Y["docs/ymem-binding/"]
 ```
-
-## 先读这里
-
-第一次打开本仓,建议按这个顺序读:
-
-1. [`docs/README.md`](docs/README.md) —— 文档地图,快速判断每份文档负责什么。
-2. [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) —— 活综述与当前维护者综合判断。
-3. [`docs/taxonomy.md`](docs/taxonomy.md) —— forms / functions / dynamics / persistence / curation 的共享词表。
-4. [`papers/index.md`](papers/index.md) —— 989 篇论文索引,用于发现线索和后续阅读。
-5. [`docs/benchmarks-landscape.md`](docs/benchmarks-landscape.md) —— benchmark 使用、证据等级和跨来源统计。
-6. [`docs/products-landscape.md`](docs/products-landscape.md) —— 按领域和服务对象整理的记忆产品全景。
-7. [`docs/product-memory-architectures.md`](docs/product-memory-architectures.md) —— 跨产品 memory 架构模式与图谱。
 
 ## 仓库结构
 
-### 顶层概念文档
+### 概念与综合文档
 
-所有概念文档现已收纳到 [`docs/`](docs/) 子目录。如果只想先看地图,从
-[`docs/README.md`](docs/README.md) 开始。
-
-| 文件 | 用途 |
+| 路径 | 用途 |
 |---|---|
-| [`docs/README.md`](docs/README.md) | 文档地图:先读什么、每份概念文档放在哪里。 |
-| [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) | 维护者的活综述。 |
-| [`docs/meta-surveys.md`](docs/meta-surveys.md) | **外部** meta-survey 索引(2025-12 ~ 2026-05)。 |
-| [`docs/taxonomy.md`](docs/taxonomy.md) | 通用 agent memory taxonomy:三套外部分类轴对照。 |
-| [`docs/research-radar.md`](docs/research-radar.md) | ResearchItem 与 ImpactReport 笔记的通用 Radar schema。 |
-| [`docs/information-sources.md`](docs/information-sources.md) | 10 类信息源 catalog,含 zh-CN 独立节。 |
-| [`docs/related-work.md`](docs/related-work.md) | 发现线索归因与抓取来源记录。 |
-| [`docs/products-landscape.md`](docs/products-landscape.md) | 记忆产品按**领域 × 服务对象**全景。 |
-| [`docs/product-discovery-log.md`](docs/product-discovery-log.md) | 多子 agent 产品搜索日志,记录 Tier A / Tier B / 拒绝理由。 |
-| [`docs/product-memory-architectures.md`](docs/product-memory-architectures.md) | 跨产品 memory 架构模式与对比图谱。 |
-| [`docs/product-architecture-diagrams.md`](docs/product-architecture-diagrams.md) | 基于公开资料的逐产品 Mermaid 架构图。 |
-| [`docs/benchmarks-landscape.md`](docs/benchmarks-landscape.md) | 按能力、使用方式和独立性拆分的 benchmark 全景。 |
-| [`docs/signals.md`](docs/signals.md) | 2026 H1 反时序日志(release / memory product / blog)。 |
+| [`docs/README.md`](docs/README.md) | 文档地图和推荐阅读顺序。 |
+| [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) | 记忆架构、检索、整合、遗忘和评估的活综述。 |
+| [`docs/taxonomy.md`](docs/taxonomy.md) | 分类 agent-memory 系统和 memory-kernel 职责的共享词表。 |
+| [`docs/meta-surveys.md`](docs/meta-surveys.md) | 2025 年末到 2026 H1 的外部 meta-survey 索引。 |
+| [`docs/research-radar.md`](docs/research-radar.md) | 把论文、产品、benchmark 证据转成 ImpactReport 和 ADR 输入的工作流。 |
+| [`docs/information-sources.md`](docs/information-sources.md) | 论文、产品、社区和中文信息源 catalog。 |
+| [`docs/related-work.md`](docs/related-work.md) | 发现线索归因和抓取来源记录。 |
+| [`docs/signals.md`](docs/signals.md) | release、对比文章和博客信号的反时序日志。 |
 
-### 逐条笔记
+### 产品与架构图谱
 
-| 路径 | 内容 |
+| 路径 | 用途 |
 |---|---|
-| [`papers/`](papers/) | 7 个 full 论文笔记、2 个 seed 笔记 + 主索引 [`index.md`](papers/index.md)。 |
-| [`papers/stubs/`](papers/stubs/) | 988 个尚未 full 阅读论文的自动生成 stub。 |
-| [`papers/pdfs/`](papers/pdfs/) | 534 个本地 PDF(~1.8 GB)。详见存档策略。 |
-| [`papers/_scrape/`](papers/_scrape/) | 可复现产物:抓取脚本 + dedup JSON。 |
-| [`products/`](products/) | 34 个记忆产品笔记。 |
-| [`products/archives/`](products/archives/) | 33 个记忆产品页面的 markdown 快照。 |
-| [`benchmarks/`](benchmarks/) | 12 个 benchmark seed 条目和一等评测协议笔记。 |
-| [`benchmarks/claims/`](benchmarks/claims/) | benchmark 使用、厂商自报、批评和复现的事件 ledger。 |
-| [`benchmarks/archives/`](benchmarks/archives/) | benchmark 页面、repo、dataset card 的可选审计快照。 |
-| [`docs/ymem-binding/`](docs/ymem-binding/) | 维护者所在的 [Ymem](https://github.com/Snseam/Ymem) 项目特定绑定;如果你不维护 Ymem,可以跳过。 |
+| [`products/`](products/) | 34 个记忆产品笔记，包括 Mem0、Letta、Zep、Graphiti、EverOS、MemOS、Redis Agent Memory Server、Supermemory、TencentDB Agent Memory 和平台 managed memory 等。 |
+| [`products/archives/`](products/archives/) | 33 个记忆产品 canonical 页面 markdown 快照。 |
+| [`docs/products-landscape.md`](docs/products-landscape.md) | 按领域和服务对象整理的产品全景。 |
+| [`docs/product-discovery-log.md`](docs/product-discovery-log.md) | 多子 agent 产品搜索日志，记录 Tier A、Tier B、拒绝和 alias 决策。 |
+| [`docs/product-memory-architectures.md`](docs/product-memory-architectures.md) | 跨产品架构模式：Memory OS、graph/temporal memory、MCP/local-first memory、云厂商 managed memory 和个人记忆。 |
+| [`docs/product-architecture-diagrams.md`](docs/product-architecture-diagrams.md) | 基于公开产品模式的逐产品 Mermaid 架构图。 |
+
+### 论文、Benchmark 与决策工作流
+
+| 路径 | 用途 |
+|---|---|
+| [`papers/`](papers/) | 7 个 full 论文笔记、2 个 seed 笔记和主索引 [`index.md`](papers/index.md)。 |
+| [`papers/stubs/`](papers/stubs/) | 988 个尚未 full 阅读论文的生成 stub。 |
+| [`papers/pdfs/`](papers/pdfs/) | 534 个本地 PDF，约 1.8 GB。详见下方存档策略。 |
+| [`papers/_scrape/`](papers/_scrape/) | 可复现产物：抓取脚本和 dedup JSON。 |
+| [`benchmarks/`](benchmarks/) | benchmark catalog、协议笔记和笔记模板。 |
+| [`benchmarks/claims/`](benchmarks/claims/) | benchmark 提及、厂商自报、方法批评和复现的 usage-event ledger。 |
+| [`benchmarks/archives/`](benchmarks/archives/) | benchmark 页面、repo 或 dataset card 的可选审计快照。 |
+| [`docs/benchmarks-landscape.md`](docs/benchmarks-landscape.md) | 按能力、使用方式和证据独立性整理的 benchmark 全景。 |
+| [`impact-reports/README.md`](impact-reports/README.md) | 把强证据提升为架构建议的模板。 |
+
+### 治理与项目绑定
+
+| 路径 | 用途 |
+|---|---|
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | 论文、产品、benchmark 和 evidence ledger 的贡献规则。 |
+| [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) | 社区行为准则。 |
+| [`SECURITY.md`](SECURITY.md) | 安全问题报告方式。 |
+| [`CITATION.cff`](CITATION.cff) | 引用元数据。 |
+| [`docs/ymem-binding/`](docs/ymem-binding/) | 维护者的 [Ymem](https://github.com/Snseam/Ymem) kernel 项目绑定；如果只需要通用证据库，可以跳过。 |
+
+## 范围边界
+
+纳入范围：
+
+- LLM agent 的长程、多会话记忆；
+- 记忆写入、检索、整合、遗忘、个性化、溯源、治理和审计；
+- 把 memory 作为一等能力公开暴露的产品；
+- 用于评估记忆行为、个性化、时间推理、遗忘或 memory-layer 成本/质量权衡的 benchmark。
+
+排除或仅作为相邻背景：
+
+- 没有 memory lifecycle 的纯 vector DB；
+- 不处理更新、整合或遗忘的普通 RAG 中间件；
+- memory 不是一等接口的通用 agent 框架；
+- 单独的 long-context inference 或 prompt cache；
+- 被包装成独立证据的厂商性能 claims。
 
 ## License 与存档策略
 
-笔记与综述内容以 [Apache 2.0](LICENSE) 协议发布。
-**引用自外部论文与文章的摘录**仍归原作者所有,本仓在 fair use / fair dealing
-框架下出于研究评议目的使用。
+笔记和综述内容以 [Apache 2.0](LICENSE) 协议发布。外部论文和文章的引用片段
+仍归原作者所有，本仓仅用于研究评议和注释。
 
-**本地存档 PDF**(`papers/pdfs/`)均来自允许 redistribute 的来源 ——
-arXiv perpetual non-exclusive license、ACL Anthology 的 CC-BY、OpenReview
-开放投稿等。若发现本仓某 PDF 的源协议禁止 redistribute,请开 issue,
-我们会撤下;对应笔记 `urls` 字段中的 canonical URL 仍是权威来源。
+[`papers/pdfs/`](papers/pdfs/) 中的本地 PDF 来自允许 redistribute 的来源，
+例如 arXiv、ACL Anthology 和开放 OpenReview 投稿。若发现某 PDF 的源协议禁止
+redistribute，请开 issue，仓库会移除；对应笔记中的 canonical URL 仍是权威来源。
 
-**记忆产品页面快照**(`products/archives/`)是研究备份,用以让本仓的推理在源
-页面变更或消失后仍可审计。它们**不是**重新发布材料;商用引用请以快照 header
-中的 `source_url` 为准。
+产品和 benchmark 页面快照是审计备份，不是商业材料的再发布。外部或商用引用应使用
+快照 header 中的原始 URL。
 
 ## 发起方与维护
 
-本仓由 [**Ymem**](https://github.com/Snseam/Ymem)(一个 agent memory
-kernel)项目发起,但顶层文档应当对任何 agent-memory kernel 都有用。
-**Ymem 特定绑定** —— 模块名、维护者立场、内部 benchmark 选择 —— 收纳到
-[`docs/ymem-binding/`](docs/ymem-binding/) 子目录,以确保公开入口保持项目中性。
+本仓由 [Ymem](https://github.com/Snseam/Ymem) 项目发起，但公开入口应当对任何
+agent-memory kernel 都有用。Ymem 特定的模块名、维护者立场和内部 benchmark 选择
+收纳在 [`docs/ymem-binding/`](docs/ymem-binding/)。
 
-论文索引整理时也参考了若干公开 awesome-list 仓库作为发现线索;具体来源、
-抓取记录与归因见 [`docs/related-work.md`](docs/related-work.md) 和
-[`papers/_scrape/`](papers/_scrape/)。这些来源仅作为发现入口;条目说明、
-综述判断和维护口径由本仓独立整理。
+论文索引也使用若干公开 awesome-list 仓库作为发现入口。归因和抓取产物见
+[`docs/related-work.md`](docs/related-work.md) 与 [`papers/_scrape/`](papers/_scrape/)。
+这些来源只用于发现；笔记、综合判断和维护口径由本仓维护。
 
 ## 贡献
 
-参见 [`CONTRIBUTING.md`](CONTRIBUTING.md) 与 [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)。简言之:
+参见 [`CONTRIBUTING.md`](CONTRIBUTING.md) 和
+[`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)。简言之：
 
-- **新论文** → 先在 `papers/` 加 stub(或升级已有 stub 到 full),然后看是否
-  值得写 ImpactReport。
-- **新记忆产品** → 在 `products/` 加笔记并存档页面到 `products/archives/`,再
-  决定是否需要进入 [`docs/products-landscape.md`](docs/products-landscape.md)。
-- **新 benchmark** → 在 `benchmarks/` 加协议笔记,并在
-  [`benchmarks/claims/claims.yaml`](benchmarks/claims/claims.yaml) 记录来源和使用事件。
-- **新信息源** → 加进 [`docs/information-sources.md`](docs/information-sources.md)
-  对应的类目。
-- **新发现来源** → 加进 [`docs/related-work.md`](docs/related-work.md) 并记录来源范围。
+- 新论文：在 [`papers/`](papers/) 下新增或升级笔记；进入 ImpactReport 前需要 full note。
+- 新产品：在 [`products/`](products/) 下新增笔记，必要时存档源页面；核心产品还要更新产品全景。
+- 新 benchmark：新增或更新 benchmark note，并在
+  [`benchmarks/claims/claims.yaml`](benchmarks/claims/claims.yaml) 记录使用事件。
+- 新产品或 benchmark claim：标清来源是厂商自报、关联方评测、方法批评还是独立复现。
+- 新信息源：更新 [`docs/information-sources.md`](docs/information-sources.md)
+  或 [`docs/related-work.md`](docs/related-work.md)。
 
 ---
+
+> 本仓内容由维护者撰写；部分 stub 和初稿使用 LLM 工具加速。full note 应基于实际
+> PDF、产品页面、benchmark 来源或已归档快照，而不是未经验证的二手摘要。
 
 <div align="center">
 
@@ -162,6 +227,3 @@ kernel)项目发起,但顶层文档应当对任何 agent-memory kernel 都有用
 **[English](README.md)**
 
 </div>
-
-> *本仓内容由仓库维护者人工撰写,部分 stub 与初稿借助 LLM 工具加速生成;每条
-> full 笔记都基于实际的 PDF / 记忆产品页面 grounded,不引用未经验证的二手摘要。*


### PR DESCRIPTION
## Summary
- Rework the English and Chinese READMEs around the repository's current evidence model instead of a simple directory listing.
- Add clearer paths for papers, products, benchmarks, synthesis docs, and the research-to-ADR workflow.
- Document evidence boundaries so vendor claims, affiliated evaluations, independent reproductions, and maintainer synthesis stay separate.

## Validation
- `git diff --check`
- README local link check
- README count check for products, archives, paper stubs, PDFs, and paper notes
- README table pipe-shape scan
- Mermaid fence count check

## Notes
- This PR only updates `README.md` and `README_cn.md`.
- External URL crawling was not run.