### PR TITLE
[codex] Refresh memory radar for 2026-06 sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 # awesome-agent-memory
 
-**Long-term memory for LLM agents — a decision-driven reading list, 989-paper index, and living survey covering memory architectures, retrieval, consolidation, and forgetting.**
+**Long-term memory for LLM agents — a decision-driven reading list, 989 scraped-paper index, current-source radar, and living survey covering memory architectures, retrieval, consolidation, and forgetting.**
 
 [中文](README_cn.md) · **English**
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Papers](https://img.shields.io/badge/papers-989-brightgreen.svg)](papers/index.md)
 [![PDFs](https://img.shields.io/badge/local_PDFs-534-orange.svg)](papers/pdfs/)
-[![Memory products](https://img.shields.io/badge/memory%20products-34-purple.svg)](products/)
-[![Benchmarks](https://img.shields.io/badge/benchmarks-12-blueviolet.svg)](benchmarks/)
+[![Memory products](https://img.shields.io/badge/memory%20products-38-purple.svg)](products/)
+[![Benchmarks](https://img.shields.io/badge/benchmarks-13-blueviolet.svg)](benchmarks/)
 [![Surveys](https://img.shields.io/badge/meta_surveys-6-yellow.svg)](docs/meta-surveys.md)
 [![Updated](https://img.shields.io/badge/updated-2026--06-lightgrey.svg)](docs/signals.md)
 
@@ -32,13 +32,13 @@
 
 | Area | Count | Entry point | What it is for |
 |---|---:|---|---|
-| Paper index | 989 papers | [`papers/index.md`](papers/index.md) | Searchable entry point for agent-memory papers. |
+| Paper index | 989 scraped papers + 2026-06 manual radar additions | [`papers/index.md`](papers/index.md) | Searchable entry point for agent-memory papers; the 989 count is the 2026-05 scrape baseline. |
 | Paper stubs | 988 stubs | [`papers/stubs/`](papers/stubs/) | Lightweight coverage records for papers not yet fully read. |
 | Local PDFs | 534 files | [`papers/pdfs/`](papers/pdfs/) | Archived PDFs for stable reading and audit. |
-| Full / seed notes | 7 full + 2 seed | [`papers/`](papers/) | Human-read paper notes and notes in progress. |
-| Memory product notes | 34 notes | [`products/`](products/) | Notes on existing memory infrastructure and agent-memory products. |
-| Page archives | 33 snapshots | [`products/archives/`](products/archives/) | Markdown snapshots for memory-product page auditability. |
-| Benchmark catalog | 12 seed entries | [`benchmarks/index.md`](benchmarks/index.md) | First-class benchmark records and usage-claim ledger. |
+| Full / seed notes | 7 full + 7 seed | [`papers/`](papers/) | Human-read paper notes and notes in progress. |
+| Memory product notes | 38 notes | [`products/`](products/) | Notes on existing memory infrastructure and agent-memory products. |
+| Page archives | 37 snapshots | [`products/archives/`](products/archives/) | Markdown snapshots for memory-product page auditability. |
+| Benchmark catalog | 13 catalog rows | [`benchmarks/index.md`](benchmarks/index.md) | First-class benchmark records plus stub-backed candidate rows and a usage-claim ledger. |
 | Survey docs | 1 living survey + 6 meta-survey records | [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) · [`docs/meta-surveys.md`](docs/meta-surveys.md) | Maintainer synthesis and survey tracking. |
 
 ## Repository map
@@ -63,11 +63,12 @@ If this is your first visit, use these entry points in order:
 
 1. [`docs/README.md`](docs/README.md) — map of the documentation set.
 2. [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) — the living survey and current maintainer synthesis.
-3. [`docs/taxonomy.md`](docs/taxonomy.md) — the shared vocabulary for forms, functions, dynamics, persistence, and curation.
-4. [`papers/index.md`](papers/index.md) — the 989-paper index, organized for discovery and follow-up reading.
-5. [`docs/benchmarks-landscape.md`](docs/benchmarks-landscape.md) — benchmark usage, evidence class, and cross-source statistics.
-6. [`docs/products-landscape.md`](docs/products-landscape.md) — memory product notes grouped by domain and audience.
-7. [`docs/product-memory-architectures.md`](docs/product-memory-architectures.md) — cross-product architecture patterns and diagrams.
+3. [`docs/memory-radar-2026-06.md`](docs/memory-radar-2026-06.md) — latest current-source refresh across papers, products, GitHub projects, and reviewer decisions.
+4. [`docs/taxonomy.md`](docs/taxonomy.md) — the shared vocabulary for forms, functions, dynamics, persistence, and curation.
+5. [`papers/index.md`](papers/index.md) — the paper index, organized for scrape-baseline discovery and manual radar additions.
+6. [`docs/benchmarks-landscape.md`](docs/benchmarks-landscape.md) — benchmark usage, evidence class, and cross-source statistics.
+7. [`docs/products-landscape.md`](docs/products-landscape.md) — memory product notes grouped by domain and audience.
+8. [`docs/product-memory-architectures.md`](docs/product-memory-architectures.md) — cross-product architecture patterns and diagrams.
 
 ## Repository layout
 
@@ -83,6 +84,7 @@ All concept docs now live under [`docs/`](docs/). Start with
 | [`docs/meta-surveys.md`](docs/meta-surveys.md) | Index of **external** meta-surveys (2025-12 ~ 2026-05). |
 | [`docs/taxonomy.md`](docs/taxonomy.md) | Generic agent-memory taxonomy: cross-walk of 3 external frameworks. |
 | [`docs/research-radar.md`](docs/research-radar.md) | Generic Radar schema for ResearchItem and ImpactReport notes. |
+| [`docs/memory-radar-2026-06.md`](docs/memory-radar-2026-06.md) | 2026-06 current-source refresh across papers, products, GitHub projects, and reviewer decisions. |
 | [`docs/information-sources.md`](docs/information-sources.md) | 10-category source catalog with a dedicated zh-CN section. |
 | [`docs/related-work.md`](docs/related-work.md) | Discovery-input attribution and scrape provenance. |
 | [`docs/products-landscape.md`](docs/products-landscape.md) | Memory products by **domain × audience**. |
@@ -96,13 +98,13 @@ All concept docs now live under [`docs/`](docs/). Start with
 
 | Path | Contents |
 |---|---|
-| [`papers/`](papers/) | 7 full paper notes, 2 seed notes, and master [`index.md`](papers/index.md). |
+| [`papers/`](papers/) | 7 full paper notes, 7 seed notes, and master [`index.md`](papers/index.md). |
 | [`papers/stubs/`](papers/stubs/) | 988 auto-generated stubs for papers not yet fully read. |
 | [`papers/pdfs/`](papers/pdfs/) | 534 archived PDFs (~1.8 GB). See archival policy. |
 | [`papers/_scrape/`](papers/_scrape/) | Reproducibility artifacts: scrape script + dedup JSON. |
-| [`products/`](products/) | 34 memory product notes (Mem0, Letta, Zep, Graphiti, EverOS, Redis Agent Memory Server, …). |
-| [`products/archives/`](products/archives/) | 33 Markdown snapshots of canonical memory product pages. |
-| [`benchmarks/`](benchmarks/) | 12 benchmark seed entries and first-class protocol notes. |
+| [`products/`](products/) | 38 memory product notes (Mem0, Letta, Zep, Graphiti, EverOS, Redis Agent Memory Server, agentmemory, memsearch, …). |
+| [`products/archives/`](products/archives/) | 37 Markdown snapshots of canonical memory product pages. |
+| [`benchmarks/`](benchmarks/) | 13 benchmark catalog rows, including protocol notes and stub-backed candidate rows. |
 | [`benchmarks/claims/`](benchmarks/claims/) | Event ledger for benchmark usage, vendor claims, critiques, and reproductions. |
 | [`benchmarks/archives/`](benchmarks/archives/) | Optional source-page snapshots for benchmark pages, repos, or dataset cards. |
 | [`docs/ymem-binding/`](docs/ymem-binding/) | Project-specific bindings from the maintainer's [Ymem](https://github.com/Snseam/Ymem) kernel; safe to ignore if you don't use Ymem. |

--- a/README_cn.md
+++ b/README_cn.md
@@ -2,15 +2,15 @@
 
 # awesome-agent-memory
 
-**面向 LLM agent 长程记忆的研究入口 —— 决策驱动的阅读清单、989 篇论文索引、活综述,涵盖记忆架构、检索、整合与遗忘。**
+**面向 LLM agent 长程记忆的研究入口 —— 决策驱动的阅读清单、989 篇抓取论文索引、当前来源 radar、活综述,涵盖记忆架构、检索、整合与遗忘。**
 
 **中文** · [English](README.md)
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Papers](https://img.shields.io/badge/papers-989-brightgreen.svg)](papers/index.md)
 [![PDFs](https://img.shields.io/badge/local_PDFs-534-orange.svg)](papers/pdfs/)
-[![记忆产品](https://img.shields.io/badge/memory%20products-34-purple.svg)](products/)
-[![Benchmarks](https://img.shields.io/badge/benchmarks-12-blueviolet.svg)](benchmarks/)
+[![记忆产品](https://img.shields.io/badge/memory%20products-38-purple.svg)](products/)
+[![Benchmarks](https://img.shields.io/badge/benchmarks-13-blueviolet.svg)](benchmarks/)
 [![Surveys](https://img.shields.io/badge/meta_surveys-6-yellow.svg)](docs/meta-surveys.md)
 [![Updated](https://img.shields.io/badge/updated-2026--06-lightgrey.svg)](docs/signals.md)
 
@@ -32,13 +32,13 @@
 
 | 板块 | 数量 | 入口 | 用途 |
 |---|---:|---|---|
-| 论文索引 | 989 篇论文 | [`papers/index.md`](papers/index.md) | 检索 agent memory 论文的主入口。 |
+| 论文索引 | 989 篇抓取论文 + 2026-06 手工 radar 新增 | [`papers/index.md`](papers/index.md) | 检索 agent memory 论文的主入口;989 是 2026-05 抓取基线。 |
 | 论文 stub | 988 个 stub | [`papers/stubs/`](papers/stubs/) | 尚未 full 阅读论文的轻量覆盖记录。 |
 | 本地 PDF | 534 个文件 | [`papers/pdfs/`](papers/pdfs/) | 稳定阅读和审计用的 PDF 存档。 |
-| full / seed 笔记 | 7 个 full + 2 个 seed | [`papers/`](papers/) | 已人工阅读或正在推进的论文笔记。 |
-| 记忆产品笔记 | 34 个笔记 | [`products/`](products/) | 市面上已有的记忆基础设施和 agent-memory 产品记录。 |
-| 页面快照 | 33 个快照 | [`products/archives/`](products/archives/) | 用于审计的记忆产品页面 markdown 快照。 |
-| Benchmark 目录 | 12 个 seed 条目 | [`benchmarks/index.md`](benchmarks/index.md) | 与论文、产品并列的评测协议和使用 claims ledger。 |
+| full / seed 笔记 | 7 个 full + 7 个 seed | [`papers/`](papers/) | 已人工阅读或正在推进的论文笔记。 |
+| 记忆产品笔记 | 38 个笔记 | [`products/`](products/) | 市面上已有的记忆基础设施和 agent-memory 产品记录。 |
+| 页面快照 | 37 个快照 | [`products/archives/`](products/archives/) | 用于审计的记忆产品页面 markdown 快照。 |
+| Benchmark 目录 | 13 个 catalog 行 | [`benchmarks/index.md`](benchmarks/index.md) | 与论文、产品并列的评测协议、stub-backed 候选行和使用 claims ledger。 |
 | 综述文档 | 1 份活综述 + 6 条 meta-survey 记录 | [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) · [`docs/meta-surveys.md`](docs/meta-surveys.md) | 维护者综合判断与综述追踪。 |
 
 ## 仓库地图
@@ -63,11 +63,12 @@ flowchart LR
 
 1. [`docs/README.md`](docs/README.md) —— 文档地图,快速判断每份文档负责什么。
 2. [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) —— 活综述与当前维护者综合判断。
-3. [`docs/taxonomy.md`](docs/taxonomy.md) —— forms / functions / dynamics / persistence / curation 的共享词表。
-4. [`papers/index.md`](papers/index.md) —— 989 篇论文索引,用于发现线索和后续阅读。
-5. [`docs/benchmarks-landscape.md`](docs/benchmarks-landscape.md) —— benchmark 使用、证据等级和跨来源统计。
-6. [`docs/products-landscape.md`](docs/products-landscape.md) —— 按领域和服务对象整理的记忆产品全景。
-7. [`docs/product-memory-architectures.md`](docs/product-memory-architectures.md) —— 跨产品 memory 架构模式与图谱。
+3. [`docs/memory-radar-2026-06.md`](docs/memory-radar-2026-06.md) —— 最新当前来源刷新,覆盖论文、产品、GitHub 项目和 reviewer 分流结论。
+4. [`docs/taxonomy.md`](docs/taxonomy.md) —— forms / functions / dynamics / persistence / curation 的共享词表。
+5. [`papers/index.md`](papers/index.md) —— 论文索引,同时承接抓取基线和手工 radar 新增。
+6. [`docs/benchmarks-landscape.md`](docs/benchmarks-landscape.md) —— benchmark 使用、证据等级和跨来源统计。
+7. [`docs/products-landscape.md`](docs/products-landscape.md) —— 按领域和服务对象整理的记忆产品全景。
+8. [`docs/product-memory-architectures.md`](docs/product-memory-architectures.md) —— 跨产品 memory 架构模式与图谱。
 
 ## 仓库结构
 
@@ -83,6 +84,7 @@ flowchart LR
 | [`docs/meta-surveys.md`](docs/meta-surveys.md) | **外部** meta-survey 索引(2025-12 ~ 2026-05)。 |
 | [`docs/taxonomy.md`](docs/taxonomy.md) | 通用 agent memory taxonomy:三套外部分类轴对照。 |
 | [`docs/research-radar.md`](docs/research-radar.md) | ResearchItem 与 ImpactReport 笔记的通用 Radar schema。 |
+| [`docs/memory-radar-2026-06.md`](docs/memory-radar-2026-06.md) | 2026-06 当前来源刷新,覆盖论文、产品、GitHub 项目和 reviewer 分流结论。 |
 | [`docs/information-sources.md`](docs/information-sources.md) | 10 类信息源 catalog,含 zh-CN 独立节。 |
 | [`docs/related-work.md`](docs/related-work.md) | 发现线索归因与抓取来源记录。 |
 | [`docs/products-landscape.md`](docs/products-landscape.md) | 记忆产品按**领域 × 服务对象**全景。 |
@@ -96,13 +98,13 @@ flowchart LR
 
 | 路径 | 内容 |
 |---|---|
-| [`papers/`](papers/) | 7 个 full 论文笔记、2 个 seed 笔记 + 主索引 [`index.md`](papers/index.md)。 |
+| [`papers/`](papers/) | 7 个 full 论文笔记、7 个 seed 笔记 + 主索引 [`index.md`](papers/index.md)。 |
 | [`papers/stubs/`](papers/stubs/) | 988 个尚未 full 阅读论文的自动生成 stub。 |
 | [`papers/pdfs/`](papers/pdfs/) | 534 个本地 PDF(~1.8 GB)。详见存档策略。 |
 | [`papers/_scrape/`](papers/_scrape/) | 可复现产物:抓取脚本 + dedup JSON。 |
-| [`products/`](products/) | 34 个记忆产品笔记。 |
-| [`products/archives/`](products/archives/) | 33 个记忆产品页面的 markdown 快照。 |
-| [`benchmarks/`](benchmarks/) | 12 个 benchmark seed 条目和一等评测协议笔记。 |
+| [`products/`](products/) | 38 个记忆产品笔记。 |
+| [`products/archives/`](products/archives/) | 37 个记忆产品页面的 markdown 快照。 |
+| [`benchmarks/`](benchmarks/) | 13 个 benchmark catalog 行,包含协议笔记和 stub-backed 候选行。 |
 | [`benchmarks/claims/`](benchmarks/claims/) | benchmark 使用、厂商自报、批评和复现的事件 ledger。 |
 | [`benchmarks/archives/`](benchmarks/archives/) | benchmark 页面、repo、dataset card 的可选审计快照。 |
 | [`docs/ymem-binding/`](docs/ymem-binding/) | 维护者所在的 [Ymem](https://github.com/Snseam/Ymem) 项目特定绑定;如果你不维护 Ymem,可以跳过。 |

--- a/benchmarks/claims/claims.yaml
+++ b/benchmarks/claims/claims.yaml
@@ -75,6 +75,25 @@ events:
     evidence_refs:
       - papers/memoryagentbench.md
     extract_confidence: medium
+  - event_id: gatemem-origin-2026
+    benchmark_id: gatemem
+    source_kind: paper
+    source_id: benchmarks/gatemem.md
+    source_date: 2026-06
+    actor: GateMem authors
+    actor_type: paper_authors
+    usage_type: originates_benchmark
+    claim_direction: methodological_only
+    compared_systems: []
+    reported_metrics: []
+    experimental_setup: "Shared-memory agent benchmark for utility, access control, and active forgetting; local note is seed quality."
+    reproduction_status: not_reproduced
+    evidence_level: primary_pdf
+    independence_class: survey_only
+    comparability_notes: "Origin protocol only; normalized metrics, leaderboard scores, dataset license, and reported results are not yet mapped."
+    evidence_refs:
+      - benchmarks/gatemem.md
+    extract_confidence: medium
   - event_id: mem0-paper-locomo-2025
     benchmark_id: locomo
     source_kind: paper

--- a/benchmarks/gatemem.md
+++ b/benchmarks/gatemem.md
@@ -1,0 +1,107 @@
+---
+title: GateMem — memory governance in multi-principal shared-memory agents
+benchmark_id: gatemem
+name: GateMem
+aliases:
+  - GATEMEM
+status: seed
+origin_type: paper_origin
+origin_source: https://arxiv.org/abs/2606.18829
+first_public_date: 2026-06
+domain: shared_memory_governance
+modality: text
+task_grain: multi_principal_long_horizon_episode
+capability_axes:
+  - utility
+  - access_control
+  - active_forgetting
+dataset_size: 91 episodes / 2,218 hidden checkpoints
+data_nature: synthetic_long_form_multi_party_episodes
+metrics:
+  - task_utility
+  - leakage
+  - deletion_compliance
+  - memory_governance_score
+judge_type: structured_judging
+code_available: yes
+data_available: yes
+license: MIT code; dataset license check
+known_limitations:
+  - seed note; protocol, leaderboard, and dataset license require full read
+canonical_sources:
+  - https://arxiv.org/abs/2606.18829
+  - https://rzhub.github.io/GateMem/project.html
+  - https://github.com/rzhub/GateMem
+  - https://huggingface.co/datasets/Ray368/GateMem
+  - https://rzhub.github.io/GateMem/
+confidence: medium
+memory_modules:
+  - evaluator-benchmark
+  - policy-privacy
+  - retriever-reranker
+last_revised: 2026-06-24
+---
+
+# GateMem
+
+## What It Measures
+
+GateMem evaluates shared-memory agents where multiple principals write into and
+query a common memory pool. It jointly tests:
+
+- legitimate long-horizon utility after state updates;
+- access control across contextual authorization boundaries;
+- active forgetting after explicit deletion requests.
+
+## Dataset / Scale
+
+The arXiv abstract and project page describe medical, office, education, and
+household domains, with 91 long-form multi-party episodes and 2,218 hidden
+checkpoints. The code repository and Hugging Face dataset are public; dataset
+license and split details still need a full read.
+
+## Protocol
+
+GateMem is important because it rejects the single-user private-memory assumption
+that dominates older memory benchmarks. It treats memory quality as governance:
+an agent must remember enough to help the requester, avoid leaking memories to
+the wrong requester, and honor deletion.
+
+## Metrics and Judging
+
+The seed sources name utility, access-control violation, active-forgetting
+failure, and a combined Memory Governance Score. Judge implementation details
+are not yet mapped in this repo.
+
+## Baselines and Reported Results
+
+Only the paper-origin benchmark event is logged in `claims/claims.yaml`.
+Normalized metrics, baselines, reported scores, and leaderboard submissions
+still require a full read.
+
+## Validity / Contamination / License Caveats
+
+- Code and dataset are public; dataset license and full data card details require
+  verification.
+- Multi-principal policy setups may be hard to compare across systems unless
+  scope, role, and deletion semantics are normalized.
+
+## Comparability Notes
+
+Compare GateMem with MemoryAgentBench selective forgetting and LongMemEval
+abstention/update axes, but do not average its access-control results with
+single-user recall benchmarks.
+
+## Related Papers
+
+- Paper:https://arxiv.org/abs/2606.18829
+- Project page:https://rzhub.github.io/GateMem/project.html
+- Code:https://github.com/rzhub/GateMem
+- Dataset:https://huggingface.co/datasets/Ray368/GateMem
+- Leaderboard:https://rzhub.github.io/GateMem/
+
+## Impact Use
+
+- `policy-privacy`:first-class benchmark candidate for scoped recall and access control.
+- `evaluator-benchmark`:candidate for Ymem shared-memory governance tests.
+- Ready for ImpactReport:no, upgrade from seed after full read.

--- a/benchmarks/index.md
+++ b/benchmarks/index.md
@@ -1,6 +1,6 @@
 ---
 title: Benchmark catalog — agent-memory evaluation protocols
-date: 2026-06-11
+date: 2026-06-24
 status: seed
 language: zh-CN
 ---
@@ -32,6 +32,7 @@ official repository, dataset card, or independent reproduction.
 | LoCoMo | seed | paper-origin | very long-term conversational memory | retrieval / temporal / causal | [`locomo.md`](locomo.md) | yes |
 | ConvoMem | full | paper-origin | conversational memory scaling | multi-evidence / preference / abstention | [`convomem.md`](convomem.md) | yes |
 | MemoryAgentBench | seed | paper-origin | incremental multi-turn agent memory | retrieval / learning / long-range / forgetting | [`memoryagentbench.md`](memoryagentbench.md) | yes |
+| GateMem | seed | paper-origin | multi-principal shared memory governance | utility / access control / active forgetting | [`gatemem.md`](gatemem.md) | backlog |
 | BEAM | candidate | paper-origin | million-token memory scale | long-scale recall / temporal degradation | [`beam.md`](beam.md) | yes |
 | RealMem | candidate | paper-origin | real-world memory-driven interaction | multi-source / real-world interaction | [`../papers/stubs/realmem-benchmarking-llms-in-real-world-memory-driven.md`](../papers/stubs/realmem-benchmarking-llms-in-real-world-memory-driven.md) | backlog |
 | CloneMem | candidate | paper-origin | AI clone memory | identity continuity / personalization | [`../papers/stubs/clonemem-benchmarking-long-term-memory-for-ai-clones.md`](../papers/stubs/clonemem-benchmarking-long-term-memory-for-ai-clones.md) | backlog |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Documentation map
 
 This directory contains the concept layer for awesome-agent-memory. Use it to
-decide what to read before opening the 989-paper index or the product notes.
+decide what to read before opening the paper index or the product notes.
 
 ## Read first
 
@@ -12,13 +12,15 @@ decide what to read before opening the 989-paper index or the product notes.
 3. [`research-radar.md`](research-radar.md) — workflow for turning papers,
    products, and benchmark evidence into ResearchItems, ImpactReports,
    experiments, and ADRs.
-4. [`benchmarks-landscape.md`](benchmarks-landscape.md) — benchmark map by
+4. [`memory-radar-2026-06.md`](memory-radar-2026-06.md) — latest current-source
+   refresh across papers, products, GitHub projects, and reviewer decisions.
+5. [`benchmarks-landscape.md`](benchmarks-landscape.md) — benchmark map by
    capability, usage type, and evidence independence.
-5. [`products-landscape.md`](products-landscape.md) — product map by domain and
+6. [`products-landscape.md`](products-landscape.md) — product map by domain and
    audience.
-6. [`product-architecture-diagrams.md`](product-architecture-diagrams.md) —
+7. [`product-architecture-diagrams.md`](product-architecture-diagrams.md) —
    architecture diagrams for the current memory product notes.
-7. [`product-memory-architectures.md`](product-memory-architectures.md) —
+8. [`product-memory-architectures.md`](product-memory-architectures.md) —
    cross-product memory architecture patterns and comparison tables.
 
 ## Concept docs
@@ -39,6 +41,7 @@ decide what to read before opening the 989-paper index or the product notes.
 | File | Purpose |
 |---|---|
 | [`research-radar.md`](research-radar.md) | Generic Radar loop: paper/product/benchmark -> ResearchItem or BenchmarkItem -> ImpactReport -> sandbox -> ADR. |
+| [`memory-radar-2026-06.md`](memory-radar-2026-06.md) | 2026-06 current-source refresh with must-add, update-existing, watchlist, and reject decisions. |
 | [`information-sources.md`](information-sources.md) | Source catalog for papers, products, communities, and zh-CN information channels. |
 | [`related-work.md`](related-work.md) | Positioning against sibling agent-memory awesome-lists. |
 

--- a/docs/benchmarks-landscape.md
+++ b/docs/benchmarks-landscape.md
@@ -1,6 +1,6 @@
 ---
 title: Benchmarks landscape — agent memory evaluation by capability and evidence
-date: 2026-06-11
+date: 2026-06-24
 status: seed
 language: zh-CN
 ---
@@ -23,6 +23,7 @@ language: zh-CN
 | 长程对话记忆 | [`LoCoMo`](../benchmarks/locomo.md) | factual recall / temporal / causal / multi-session | seed,产品横评最常见 |
 | 对话记忆规模曲线 | [`ConvoMem`](../benchmarks/convomem.md) | long-context vs block extraction vs RAG crossover | full,同时批评 LongMemEval/LoCoMo |
 | agent 记忆能力维度 | [`MemoryAgentBench`](../benchmarks/memoryagentbench.md) | retrieval / test-time learning / long-range / forgetting | seed,适合定义能力轴 |
+| shared-memory governance | [`GateMem`](../benchmarks/gatemem.md) | utility / access control / active forgetting | seed,6 月新增治理 benchmark |
 | 百万 token 规模 | [`BEAM`](../benchmarks/beam.md) | 1M/10M 长尺度记忆退化 | candidate,目前主要来自 Mem0 自报 |
 | 真实交互 / persona | RealMem / CloneMem / KnowMe-Bench / PersonaMem-v2 | real-world memory, identity continuity, companion personalization | candidate,先列入 backlog |
 | agent 任务 / 多 agent | LoCoBench-Agent / MemoryArena / MemBench | coding agent, shared memory conflict, write/manage 评测 | candidate,需升级 source note |
@@ -40,6 +41,7 @@ language: zh-CN
 | ConvoMem | 2 | origin + baseline comparison |
 | BEAM | 2 | Mem0 BEAM 1M / 10M vendor claims |
 | MemoryAgentBench | 2 | origin + survey mention |
+| GateMem | 1 | origin paper logged; metrics/results not yet normalized |
 | PersonaMem-v2 | 2 | Hy-Memory + TencentDB Agent Memory self-claims |
 | MemBench | 1 | survey mention |
 | MemoryArena | 1 | survey mention |
@@ -113,7 +115,9 @@ language: zh-CN
    PersonaMem-style claims.
 4. Promote MemoryArena and MemBench if multi-agent conflict or write/manage
    evaluation becomes a kernel priority.
-5. Add independent reproduction rows only when the source gives enough setup
+5. Upgrade GateMem if shared-memory governance or enterprise scoped recall becomes
+   a kernel priority.
+6. Add independent reproduction rows only when the source gives enough setup
    detail to distinguish reruns from marketing summaries.
 
 ## E. Maintenance Contract

--- a/docs/memory-radar-2026-06.md
+++ b/docs/memory-radar-2026-06.md
@@ -1,0 +1,89 @@
+---
+title: 2026-06 Memory Radar refresh
+date: 2026-06-24
+status: current-source-refresh
+language: zh-CN
+---
+
+# 2026-06 Memory Radar refresh
+
+本页记录 2026-06-24 的并行 radar 刷新结果。主 agent 负责整合,子 agent 分别检索
+论文/会议、官方产品文档、GitHub 项目和仓库落点;验证与评审阶段按来源质量、记忆
+系统相关性、Ymem/AgentMemory 决策价值和重复风险分流。
+
+## 执行模型
+
+| Lane | 角色 | 输出 |
+|---|---|---|
+| papers/conferences | `researcher` | arXiv / OpenReview / ACL Anthology 2026 候选 |
+| products/platforms | `researcher` | 官方产品文档、release notes、preview/beta 状态 |
+| GitHub/OSS | `researcher` + GitHub API spot-check | 活跃 repo、license、stars、更新时间、README claim |
+| repo-map | `explore` | 现有条目、重复风险、落地文件 |
+| source/relevance review | `verifier` / `critic` | must-add / update-existing / watchlist / reject |
+
+## Must-add / update-existing
+
+### Papers and benchmarks
+
+| Action | Item | Why it matters | Local anchor |
+|---|---|---|---|
+| must-add | Agent Memory: Characterization and System Implications of Stateful Long-Horizon Workloads | 把 agent memory 从算法主题推进到 systems workload:taxonomy、write/read/generation profiling、fleet-scale 管理建议 | [`../papers/agent-memory-systems-characterization.md`](../papers/agent-memory-systems-characterization.md) |
+| must-add | RaMem | 把 retrieval 之后的"证据是否仍适用"显式化,提出 context collapse 和 validity-aware retrieval | [`../papers/ramem.md`](../papers/ramem.md) |
+| must-add | AdaMem | 把 memory write policy 学成 role-specific policy,直接对应 personalization memory bloat 与 selective retention | [`../papers/adamem-learning-what-to-remember.md`](../papers/adamem-learning-what-to-remember.md) |
+| must-add | GateMem | 从单用户 recall 转向多主体 shared-memory governance:utility、access control、active forgetting 同测 | [`../benchmarks/gatemem.md`](../benchmarks/gatemem.md) |
+| must-add | LightMem | SLM 驱动 retrieval/write/consolidation,强调 bounded online cost 与离线 consolidation | [`../papers/lightmem-agent-memory.md`](../papers/lightmem-agent-memory.md) |
+| update-existing | MemoryAgentBench | ICLR 2026 接收后继续作为能力 taxonomy anchor:retrieval、test-time learning、long-range、selective forgetting | [`../papers/memoryagentbench.md`](../papers/memoryagentbench.md) |
+| update-existing | MemGen | ICLR 2026 Poster;已有 stub,本轮只补 venue/status 信号 | [`../papers/stubs/memgen-weaving-generative-latent-memory-for-self-evolving.md`](../papers/stubs/memgen-weaving-generative-latent-memory-for-self-evolving.md) |
+| update-existing / disambiguate | AtomMem | 2026-06 `AtomMem: ... via Atomic Facts` 与 2026-01 `AtomMem : ... Atomic Memory Operation` 不是同一条 | [`../papers/atommem-atomic-facts.md`](../papers/atommem-atomic-facts.md) |
+
+### Products
+
+| Action | Product | Why it matters | Local anchor |
+|---|---|---|---|
+| update-existing | AWS Bedrock AgentCore Memory | 2026-03 streaming notifications、2026-05 metadata filtering 使 LTM record lifecycle 更接近 evented memory infra | [`../products/aws-agentcore-memory.md`](../products/aws-agentcore-memory.md) |
+| update-existing | Google Agent Platform Memory Bank | 2026-06-23 docs 明确 scoped identity、TTL、revisions、IAM conditions 和 event ingestion | [`../products/google-memory-bank.md`](../products/google-memory-bank.md) |
+| update-existing | Microsoft Foundry Agent Service Memory | Build 2026 后 user/session/procedural memory 与 item CRUD/search 进入 public preview 路线 | [`../products/microsoft-foundry-memory.md`](../products/microsoft-foundry-memory.md) |
+| update-existing | Cloudflare Agent Memory | 2026-06 docs 仍标 beta,但公开了 remember/recall、profile/namespace、fact/event/instruction/task memory 类型 | [`../products/cloudflare-agent-memory.md`](../products/cloudflare-agent-memory.md) |
+| update-existing | OpenAI ChatGPT Memory / Dreaming | 2026-06 memory dreaming 与 release notes 显示 memory summary/source/staleness 方向升级 | [`../products/openai-memory.md`](../products/openai-memory.md) |
+| update-existing | Claude Code / Claude app memory | Claude Code v2.1.59+ auto memory 与 `CLAUDE.md`/`MEMORY.md` 文档化;chat-app memory 仍作相邻信号 | [`../products/claude-dreams.md`](../products/claude-dreams.md) |
+| must-add | agentmemory | 高活跃 coding-agent persistent memory server,覆盖 Claude Code/Codex/Cursor/OpenClaw/MCP | [`../products/agentmemory.md`](../products/agentmemory.md) |
+| must-add | Memori | agent-native memory infrastructure,从 agent execution/conversation 生成 structured persistent state | [`../products/memori.md`](../products/memori.md) |
+| must-add | memU | workspace runtime -> agent memory,把 conversations/docs/code/media/tool traces 编译为 durable memory layers | [`../products/memu.md`](../products/memu.md) |
+| must-add | memsearch | Markdown + Milvus 的 cross-agent coding memory layer,有 Zilliz 官方 repo/docs 支撑 | [`../products/memsearch.md`](../products/memsearch.md) |
+
+## Watchlist / reject
+
+| Decision | Item | Reason |
+|---|---|---|
+| watchlist | EvoArena / EvoMem | 很适合 tracking memory evolution,但本轮先进入 radar watchlist,等代码/benchmark 证据补齐后再建 benchmark note |
+| watchlist | SubtleMemory | fine-grained relational discrimination 对 evaluator 有价值,但需先读数据协议 |
+| watchlist | Control-Plane Placement Shapes Forgetting / ForgetEval | 对 forgetting architecture 有压强,但需验证 benchmark 是否可公开复现 |
+| watchlist | memforks | "Git for AI agent memory" 信号清晰,但 2026-06 新项目、license 不明确、stars/生态弱于 Tier A |
+| watchlist | remnic | scoped memory/provenance/correction/MCP/HTTP 方向相关,但当前信号量低,先保留 discovery |
+| reject as core | pure vector DB / generic RAG / catalog-only MCP memory entries | 只提供存储/检索或目录信号,未处理 memory lifecycle |
+| reject as core | ordinary chat history / generic agent frameworks | 缺少独立 memory 产品边界或可审计 lifecycle |
+
+## Evidence gaps / next verification
+
+| Item | Gap | Why not blocking |
+|---|---|---|
+| GateMem | 代码、dataset、leaderboard 已公开,但 dataset license、split details、reported scores 还需 full read 后再升级 | 本轮只登记 paper-origin benchmark event,不登记 score claim |
+| LightMem | ACL 页面与 arXiv 支撑 seed note,但 PDF/code/license 与 LoCoMo 设置还需精读 | 本轮 `evidence_level` 仅为 medium,不作为 full note |
+| AWS AgentCore Memory streaming | What’s New 页面只概述 created/modified,delete event 由 developer guide 支撑 | 产品笔记已同时引用 announcement 与 record-streaming guide |
+| GitHub Tier A projects | stars/update/license 仅作 discovery signal;custom license 项需要后续复核 | 产品笔记只写产品定位、activity 和 caveat,不写质量结论 |
+| ACL / ICLR 2026 venues | 页面已上线,但会议日期晚于 2026-06-24 | 只写为 accepted/poster/source status,不推断现场发布后的变化 |
+
+## Trend synthesis
+
+- **Memory lifecycle is now first-class**:write control、retention/deletion、active forgetting、procedural memory 和 control-plane placement 成为论文/产品共同主题。
+- **Evaluation moved from recall to governance**:MemoryAgentBench、GateMem、SubtleMemory、ForgetEval 等把选择性遗忘、访问控制、关系辨析和动态演化纳入测试。
+- **Systems cost is becoming a research object**:Agent Memory characterization 和 LightMem 都把 construction/retrieval/generation cost、bounded online latency 放进核心 claim。
+- **Cloud platforms are converging on managed memory stores**:AWS/Google/Microsoft/Cloudflare 都在把 scope、TTL、CRUD/search、eventing、profiles/namespaces 做成 agent platform primitive。
+- **Coding-agent memory is becoming a product category**:agentmemory、memsearch、memU、Basic Memory、ByteRover、PowerMem、Honcho 等都围绕 Claude Code/Codex/Cursor/OpenClaw/MCP 打通项目记忆。
+
+## Review notes
+
+- 收录项均要求 primary source:论文用 arXiv/OpenReview/ACL Anthology,产品用官方 docs/blog/GitHub repo。
+- GitHub stars 只作 discovery signal;产品笔记必须写明 license、activity date 和 maturity caveat。
+- Vendor benchmark / performance claim 不升级为 independent evidence;只可写为 vendor-claimed。
+- `AtomMem` 必须带 arXiv ID disambiguation:2601.08323 是 January atomic-operation paper,2606.19847 是 June atomic-facts memory system。

--- a/docs/product-architecture-diagrams.md
+++ b/docs/product-architecture-diagrams.md
@@ -1,15 +1,17 @@
 ---
 title: Memory product architecture diagrams
-date: 2026-06-11
+date: 2026-06-24
 status: working-note
 language: zh-CN
 ---
 
 # Memory 产品架构图
 
-范围:本页覆盖当前 `products/` 下的 34 个产品/模式笔记。图是基于公开页面、
-GitHub README、论文摘要与本仓快照的**架构归纳**;闭源 SaaS 与厂商内建记忆没有
-底层实现披露时,图只表达可观察产品边界和合理推断,不当作内部实现事实。
+范围:本页的证据索引覆盖当前 `products/` 下的 38 个产品/模式笔记;逐产品
+Mermaid 图当前覆盖 34 个产品/模式。2026-06-24 新增的 agentmemory、Memori、memU、
+memsearch 只进入证据索引和 pending-diagram 队列,尚无逐产品 Mermaid 图。图是基于
+公开页面、GitHub README、论文摘要与本仓快照的**架构归纳**;闭源 SaaS 与厂商内建
+记忆没有底层实现披露时,图只表达可观察产品边界和合理推断,不当作内部实现事实。
 
 跨产品架构模式的总览与对比表见
 [`product-memory-architectures.md`](product-memory-architectures.md);本页保留
@@ -823,6 +825,10 @@ flowchart LR
 | Basic Memory | [`../products/basic-memory.md`](../products/basic-memory.md) | <https://docs.basicmemory.com/> |
 | ByteRover | [`../products/byterover.md`](../products/byterover.md) | <https://www.byterover.dev/> |
 | Honcho | [`../products/honcho.md`](../products/honcho.md) | <https://github.com/plastic-labs/honcho> |
+| agentmemory (pending diagram) | [`../products/agentmemory.md`](../products/agentmemory.md) | <https://github.com/rohitg00/agentmemory> |
+| Memori (pending diagram) | [`../products/memori.md`](../products/memori.md) | <https://github.com/MemoriLabs/Memori> |
+| memU (pending diagram) | [`../products/memu.md`](../products/memu.md) | <https://github.com/NevaMind-AI/memU> |
+| memsearch (pending diagram) | [`../products/memsearch.md`](../products/memsearch.md) | <https://github.com/zilliztech/memsearch> |
 | OpenViking | [`../products/openviking.md`](../products/openviking.md) | <https://volcengine-openviking.mintlify.app/> |
 | Hy-Memory | [`../products/hy-memory.md`](../products/hy-memory.md) | <https://hy-memory.com/> |
 | MemoryOS | [`../products/memoryos.md`](../products/memoryos.md) | <https://github.com/BAI-LAB/MemoryOS> |

--- a/docs/product-discovery-log.md
+++ b/docs/product-discovery-log.md
@@ -1,13 +1,13 @@
 ---
 title: Product discovery log — agent memory products
-date: 2026-06-11
+date: 2026-06-24
 status: working-log
 language: zh-CN
 ---
 
 # Product discovery log
 
-本日志记录 2026-06-11 的多子 agent 产品搜索、证据审查和最终入库决定。它不是
+本日志记录 2026-06-11 与 2026-06-24 的多子 agent 产品搜索、证据审查和最终入库决定。它不是
 产品介绍页,而是解释**为什么某个候选被深度入库、只进入轻量索引、或被拒绝**。
 
 ## 1. 执行模型
@@ -60,6 +60,10 @@ language: zh-CN
 | Basic Memory | https://docs.basicmemory.com/ | https://github.com/basicmachines-co/basic-memory | local-first memory | docs + repo | Tier A | Markdown source of truth, knowledge graph, MCP-native, cloud/local | PKM crossover and AGPL | MCP, OSS |
 | ByteRover (Cipher) | https://www.byterover.dev/ | https://github.com/campfirein/byterover-cli | coding-agent memory | site + repo + docs | Tier A | portable memory layer for autonomous coding agents, CLI/MCP/context tree | ELv2/source-available; maturity needs follow-up | MCP, OSS |
 | Honcho | https://github.com/plastic-labs/honcho | https://docs.honcho.dev/ | memory infrastructure | repo + docs | Tier A | peer-centric memory, async reasoning, representations, MCP/SDK/self-host | eval claims vendor-side, AGPL | OSS, MCP |
+| agentmemory | https://github.com/rohitg00/agentmemory | https://agent-memory.dev | coding-agent memory | repo + GitHub API spot-check | Tier A | persistent memory for Claude Code/Codex/Cursor/OpenClaw/MCP; Apache-2.0; active 2026-06 | benchmark claims need independent review | OSS, GitHub |
+| Memori | https://github.com/MemoriLabs/Memori | https://memorilabs.ai | agent-native memory infrastructure | repo + product site | Tier A | LLM-agnostic layer for agent execution/conversation -> structured persistent state | license API returned NOASSERTION | OSS, GitHub |
+| memU | https://github.com/NevaMind-AI/memU | https://memu.pro | workspace-to-agent memory | repo + product site | Tier A | workspace runtime compiles conversations/docs/code/media/tool traces into memory | license API returned NOASSERTION; fast-changing | OSS, GitHub |
+| memsearch | https://github.com/zilliztech/memsearch | https://zilliztech.github.io/memsearch/ | coding-agent memory | repo + docs | Tier A | Markdown + Milvus memory layer for Claude Code/Codex/OpenClaw; MIT; vendor-backed | coding-agent/project memory, not generic governance layer | OSS, GitHub |
 
 ## 5. Tier B / lightweight index
 
@@ -74,7 +78,14 @@ language: zh-CN
 | mem9 | n/a | memory SDK | OSS lane signal | Tier B | memory-focused candidate | source quality incomplete | OSS |
 | Memstate AI | n/a | memory server | MCP lane signal | Tier B | memory-focused candidate | canonical evidence incomplete | MCP |
 | ClawMem | https://github.com/yoloshii/ClawMem | local memory vault | repo | Tier B | on-device coding-agent memory | release/license maturity not reviewed | MCP |
-| agentmemory | https://github.com/rohitg00/agentmemory | coding-agent memory | repo | Tier B | shared memory server signal | reviewers split; kept lightweight until source health check | OSS |
+| memforks | https://github.com/memforks-dev/memforks | versioned memory | repo | Tier B | "Git for AI agent memory" concept | early project, custom/unclear license | OSS |
+| remnic | https://github.com/joshuaswarren/remnic | scoped memory/context | repo | Tier B | provenance, correction, evals, MCP/HTTP surface | small ecosystem signal; implementation depth not reviewed | OSS |
+| nram | https://github.com/nram-ai/nram | self-hosted memory | repo | Tier B | MCP/REST continuity, graph, consolidation signal | extremely new/low activity signal | OSS |
+| Universal Memory Protocol | https://github.com/edihasaj/universal-memory-protocol | protocol proposal | repo | Tier B | interop idea adjacent to MCP/A2A | not established as standard | OSS |
+| memanto | https://github.com/moorcheh-ai/memanto | coding-agent memory | repo | Tier B | local memory agent for Claude Code/Cursor/Codex | needs source/eval review before core note | OSS |
+| LycheeMem | https://github.com/LycheeMem/LycheeMem | long-term memory framework | repo | Tier B | MCP/plugin/Python integration signal | release/activity maturity unclear | OSS |
+| Parcle Memory | https://github.com/Parcle-AI/parcle-memory | per-user agent memory | repo | Tier B | conversations/files with cited answers | product/API boundary and self-host story need review | OSS |
+| Neo4j Agent Memory | https://github.com/neo4j-labs/agent-memory | graph-native agent memory | repo | Tier B | graph-backed memory/context graph | labs project; API stability unclear | OSS |
 | SimpleMem | n/a | coding-agent memory | OSS lane signal | Tier B | memory candidate | evidence/maturity weaker than Tier A set | OSS |
 | SuperLocalMemory | arXiv | research architecture | paper | Tier B | local-first architecture pressure | not productized enough | Academic |
 | Decagon / Sierra | vendor sites | customer-service memory | product signals | Tier B | embedded user/customer memory in vertical agents | not standalone memory infrastructure | Adjacent |
@@ -120,12 +131,17 @@ language: zh-CN
 | Basic Memory | [`../products/basic-memory.md`](../products/basic-memory.md) | [`../products/archives/basic-memory-overview.md`](../products/archives/basic-memory-overview.md) | docs + repo; AGPL/local-first |
 | ByteRover | [`../products/byterover.md`](../products/byterover.md) | [`../products/archives/byterover-overview.md`](../products/archives/byterover-overview.md) | site + repo/docs; alias Cipher |
 | Honcho | [`../products/honcho.md`](../products/honcho.md) | [`../products/archives/honcho-overview.md`](../products/archives/honcho-overview.md) | repo + docs; vendor eval claims labeled |
+| agentmemory | [`../products/agentmemory.md`](../products/agentmemory.md) | [`../products/archives/agentmemory-overview.md`](../products/archives/agentmemory-overview.md) | GitHub repo/API; benchmark claims not independently verified |
+| Memori | [`../products/memori.md`](../products/memori.md) | [`../products/archives/memori-overview.md`](../products/archives/memori-overview.md) | GitHub repo + homepage; license unresolved |
+| memU | [`../products/memu.md`](../products/memu.md) | [`../products/archives/memu-overview.md`](../products/archives/memu-overview.md) | GitHub repo + homepage; license unresolved |
+| memsearch | [`../products/memsearch.md`](../products/memsearch.md) | [`../products/archives/memsearch-overview.md`](../products/archives/memsearch-overview.md) | GitHub repo + docs; MIT; Zilliz/Milvus substrate |
 
 ## 9. Coordinator notes
 
 - EverMind/EverOS/EverMemOS 已深度入库为 Tier A,满足本轮 spot-check 要求。
 - Google/Microsoft/Alibaba 在 reviewer 间有分歧,最终以官方 developer docs 为准纳入
   Tier A,但保留 preview/cloud black-box 风险。
-- MIRIX、Pieces LTM、MemMachine、mem9、Memstate、ClawMem、agentmemory、SimpleMem
-  等不删除,但先作为 Tier B 轻量索引,等待源码/许可/release health 补证。
+- MIRIX、Pieces LTM、MemMachine、mem9、Memstate、ClawMem、SimpleMem、memforks、
+  remnic、nram、memanto、LycheeMem、Parcle Memory、Neo4j Agent Memory 等不删除,
+  但先作为 Tier B 轻量索引,等待源码/许可/release health 补证。
 - 所有 vendor benchmark 或性能 claim 都按 vendor-claimed / 自报处理,不写成独立实证。

--- a/docs/product-memory-architectures.md
+++ b/docs/product-memory-architectures.md
@@ -1,6 +1,6 @@
 ---
 title: Product memory architectures — cross-product patterns
-date: 2026-06-11
+date: 2026-06-24
 status: working-note
 language: zh-CN
 ---
@@ -144,7 +144,7 @@ flowchart TB
 | Field | Synthesis |
 |---|---|
 | architecture pattern | sidecar memory substrate: IDE/agent hooks capture work, MCP exposes recall/write/delete/export tools, local files or DB store state |
-| products mapped | Basic Memory、ByteRover、Redis Agent Memory Server、PowerMem、Honcho、Supermemory MCP、Pieces LTM、ClawMem、agentmemory |
+| products mapped | Basic Memory、ByteRover、Redis Agent Memory Server、PowerMem、Honcho、Supermemory MCP、Pieces LTM、ClawMem、agentmemory、memsearch、memU、Memori |
 | common data flow | IDE/session hooks -> extraction -> Markdown/context tree/local DB -> hybrid index -> MCP recall -> session briefing/context injection |
 | memory types | project decisions、file history、debug episodes、preferences、skills、timeline、audit trail |
 | retrieval/consolidation strategy | vector + BM25 + graph/timeline;session stop 或 compaction 前做总结,重复模式提升为 skills |

--- a/docs/products-landscape.md
+++ b/docs/products-landscape.md
@@ -1,6 +1,6 @@
 ---
 title: Products landscape — agent memory by domain × audience
-date: 2026-06-11
+date: 2026-06-24
 status: working-spec
 language: zh-CN
 ---
@@ -88,6 +88,10 @@ language: zh-CN
 | Basic Memory | [`../products/basic-memory.md`](../products/basic-memory.md) | OSS+SaaS | 个人开发者 / 团队 / Markdown 用户 | local-first Markdown memory + knowledge graph + MCP |
 | ByteRover(原 Cipher) | [`../products/byterover.md`](../products/byterover.md) | Source-available | coding agent 用户 / 团队 | autonomous coding agents 的 portable memory layer |
 | Honcho | [`../products/honcho.md`](../products/honcho.md) | OSS+SaaS | agent builder / multi-agent 产品 | peer-centric stateful agent memory infrastructure |
+| agentmemory | [`../products/agentmemory.md`](../products/agentmemory.md) | OSS | coding agent 用户 | multi-client persistent memory for Claude Code / Codex / Cursor / OpenClaw |
+| Memori | [`../products/memori.md`](../products/memori.md) | OSS / productizing | agent builder / production agent 团队 | agent execution + conversation -> structured persistent state |
+| memU | [`../products/memu.md`](../products/memu.md) | OSS / productizing | workspace agent / OpenClaw / MCP 用户 | workspace context -> durable agent memory layers |
+| memsearch | [`../products/memsearch.md`](../products/memsearch.md) | OSS | coding agent 用户 / Zilliz-Milvus 生态 | Markdown + Milvus 的 cross-agent coding memory |
 | OpenViking | [`../products/openviking.md`](../products/openviking.md) | OSS | coding agent 用户 / OpenClaw 用户 / agent builder | context database:filesystem 管理 memory、resources、skills |
 | MemoryOS | [`../products/memoryos.md`](../products/memoryos.md) | OSS / Research | 研究者 / 个人开发者 | personalized agent 的 memory operating system |
 | A-MEM | [`../products/a-mem.md`](../products/a-mem.md) | OSS / Research | 研究者 | Zettelkasten 式 agentic memory organization |
@@ -136,6 +140,9 @@ language: zh-CN
 | PowerMem | OSS | Claude Code / Codex / Cursor / OpenClaw 用户 | CLI/HTTP/MCP/插件共用后端 memory |
 | Redis Agent Memory Server | OSS | 任意 MCP/REST agent | Redis-backed memory server,支持 working/long-term memory |
 | Honcho | OSS+SaaS | Claude Code / OpenCode / OpenClaw / Hermes 用户 | peer-centric memory + MCP/SDK |
+| agentmemory | OSS | Claude Code / Codex / Cursor / OpenClaw / MCP 用户 | coding-agent persistent memory server |
+| memU | OSS / productizing | workspace agents / OpenClaw / MCP 用户 | workspace runtime 编译多模态 context 为 memory |
+| memsearch | OSS | Claude Code / Codex / OpenCode / OpenClaw 用户 | Markdown + Milvus semantic memory |
 | OpenViking | OSS | OpenClaw / OpenCode / Claude Desktop 用户 | context DB + MCP,统一 memory/resources/skills |
 
 ### A5. 个人知识管理(PKM)与记忆增强
@@ -215,13 +222,14 @@ memory kernel 通常的关系是:**复用**它们做底层 vector store,**不取
 Letta self-host / Mem0 self-host / Zep self-host / Graphiti / Cognee /
 Obsidian + 插件 / LangMem / Hindsight / TencentDB Agent Memory /
 EverOS / MemOS / Redis Agent Memory Server / PowerMem / Basic Memory /
-ByteRover / Honcho / OpenViking / MemoryOS / A-MEM / MemX /
+ByteRover / Honcho / agentmemory / Memori / memU / memsearch /
+OpenViking / MemoryOS / A-MEM / MemX /
 Supermemory self-host。
 
 ### B2. 中小团队 / SaaS startup
 Mem0 cloud / Zep cloud / Supermemory API / Hindsight cloud / Basic Memory
-Cloud / Honcho API / Redis Agent Memory Server / OpenAI Assistants /
-Pinecone / Cursor for Teams。
+Cloud / Honcho API / Redis Agent Memory Server / agentmemory / Memori / memU /
+memsearch / OpenAI Assistants / Pinecone / Cursor for Teams。
 
 ### B3. 大企业
 Glean / Mem0 Enterprise / Notion / Slack AI / Anthropic for Enterprise /

--- a/docs/research-radar.md
+++ b/docs/research-radar.md
@@ -1,7 +1,7 @@
 ---
 title: Research Radar — agent memory knowledge → kernel decisions workflow
 date: 2026-05-08
-revised: 2026-05-19
+revised: 2026-06-24
 status: working-spec
 language: zh-CN
 ---
@@ -36,6 +36,10 @@ ImpactReport 和实验提案。kernel 主线的变更走 ADR 流程,由 Radar �
 
 详见 [`information-sources.md`](information-sources.md) —— 10 个类别的完整
 catalog,中文社区单独成节。该文档是 Radar 信息面的 single source of truth。
+
+当前来源刷新记录见 [`memory-radar-2026-06.md`](memory-radar-2026-06.md)。它保留
+并行子 agent 搜索、主 agent 整合、source/relevance review 后的 must-add /
+update-existing / watchlist / reject 决策,避免把快照判断散落到单条笔记里。
 
 ## 3. ResearchItem schema
 

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -1,6 +1,6 @@
 ---
 title: Signals — agent memory news, releases, comparisons (reverse chrono)
-date: 2026-06-11
+date: 2026-06-24
 status: living-log
 language: zh-CN
 ---
@@ -12,13 +12,19 @@ language: zh-CN
 
 类型 enum:`release` `comparison` `blog` `paper` `talk` `incident` `funding` `product`
 
-Radar 动作 enum:`stub` `deep-note` `impact-report` `archive-only`
-(`archive-only` 表示有趣但不进入 ResearchItem 流程)
+Radar 动作 enum:`stub` `seed-note` `deep-note` `impact-report` `archive-only`
+(`deep-note` 表示已落地产品/聚合笔记,不等同于 frontmatter `status: full`;
+`archive-only` 表示有趣但不进入 ResearchItem 流程)
 
 ## 2026 Q2
 
 | 日期 | 来源 | 类型 | 一句话 | Radar 动作 |
 |---|---|---|---|---|
+| 2026-06-24 | [2026-06 Memory Radar refresh](memory-radar-2026-06.md) | paper/product | 本轮用并行子 agent 搜索 + source/relevance review,把论文、官方产品和 GitHub 项目分成 must-add / update-existing / watchlist / reject | `deep-note` ✅([`memory-radar-2026-06.md`](memory-radar-2026-06.md)) |
+| 2026-06-24 | [Agent Memory](https://arxiv.org/abs/2606.06448) / [RaMem](https://arxiv.org/abs/2606.22844) / [AdaMem](https://arxiv.org/abs/2606.21144) / [LightMem](https://aclanthology.org/2026.acl-long.588/) | paper | 6 月论文把 memory 生命周期推进到 systems profiling、context-valid retrieval、personalized write policy 和 bounded-cost SLM memory | `seed-note` ✅(见 `papers/`) |
+| 2026-06-24 | [GateMem](https://arxiv.org/abs/2606.18829) | paper | shared-memory agent benchmark 开始把 utility、access control、active forgetting 联合评估 | `stub` ✅([`../benchmarks/gatemem.md`](../benchmarks/gatemem.md)) |
+| 2026-06-24 | [`rohitg00/agentmemory`](https://github.com/rohitg00/agentmemory) / [`MemoriLabs/Memori`](https://github.com/MemoriLabs/Memori) / [`NevaMind-AI/memU`](https://github.com/NevaMind-AI/memU) / [`zilliztech/memsearch`](https://github.com/zilliztech/memsearch) | release | coding-agent / workspace-agent memory 继续产品化,但 GitHub stars 只作为 discovery signal | `deep-note` ✅(见 `products/`) |
+| 2026-06-24 | [AWS AgentCore Memory streaming](https://aws.amazon.com/about-aws/whats-new/2026/03/agentcore-memory-streaming-ltm/) / [AWS LTM metadata](https://aws.amazon.com/about-aws/whats-new/2026/05/agentcore-longterm-memory-metadata/) / [Google Memory Bank](https://docs.cloud.google.com/gemini-enterprise-agent-platform/scale/memory-bank) / [Microsoft Foundry Memory](https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/what-is-memory) / [Cloudflare Agent Memory](https://developers.cloudflare.com/agent-memory/) | product | managed memory 平台从"有 LTM"推进到 record streaming、metadata filtering、scope/TTL/revisions、CRUD/search 和 beta/private-beta 治理面 | `deep-note` ✅(更新 `products/`) |
 | 2026-06-11 | [EverOS](https://evermind.ai/everos) / [`EverMind-AI/EverOS`](https://github.com/EverMind-AI/EverOS) | product | EverMind/EverOS/EverMemOS 明确以 Profile/Episodic/Skill、self-evolving skills 和 Markdown export 切入 memory OS | `deep-note` ✅([`../products/everos.md`](../products/everos.md)) |
 | 2026-06-11 | [`MemTensor/MemOS`](https://github.com/MemTensor/MemOS) | release | MemOS 作为独立 self-evolving memory OS 出现,需与已有 MemoryOS/EverMemOS 区分 | `deep-note` ✅([`../products/memos.md`](../products/memos.md)) |
 | 2026-06-11 | [AWS AgentCore Memory](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/memory.html) / [Google Memory Bank](https://docs.cloud.google.com/gemini-enterprise-agent-platform/scale/memory-bank) / [Microsoft Foundry Memory](https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/what-is-memory) | product | hyperscaler agent platforms 同时把 managed long-term memory 做成 scope/TTL/strategy/CRUD 能力 | `deep-note` ✅(见 `products/`) |
@@ -68,8 +74,9 @@ Radar 动作 enum:`stub` `deep-note` `impact-report` `archive-only`
 - **LangMem 与 LangGraph checkpoint 的关系**:LangChain 的 memory 故事 2026
   又重写了一遍,等 LangGraph v1 稳定后建笔记
 - **小型 OSS/MCP memory servers 的证据补齐**:MemMachine、mem9、Memstate、ClawMem、
-  agentmemory、SimpleMem 等先留在 discovery log,等 license/release health 与
-  canonical docs 查清再决定是否 deep-note
+  SimpleMem、memforks、remnic、nram、MemoryCloud、Universal Memory Protocol、
+  memanto、LycheeMem、Parcle Memory、Neo4j Agent Memory 等先留在 discovery log 或
+  radar watchlist,等 license/release health 与 canonical docs 查清再决定是否 deep-note
 
 ## 维护说明
 

--- a/docs/ymem-binding/research-radar.md
+++ b/docs/ymem-binding/research-radar.md
@@ -1,7 +1,7 @@
 ---
 title: Ymem-specific Research Radar binding
 date: 2026-05-08
-revised: 2026-05-19
+revised: 2026-06-24
 status: working-spec
 language: zh-CN
 origin: |
@@ -105,6 +105,8 @@ ADR
 v0 (当前):
 - 手动维护 papers/ 和 products/
 - 不做自动 radar,不做自动 ingest
+- 2026-06 开始把并行子 agent current-source refresh 作为人工 radar run 的标准记录
+  形态,见 [`../memory-radar-2026-06.md`](../memory-radar-2026-06.md)
 
 v0.5:
 - 把每周/双周阅读整理成 ResearchItem

--- a/papers/adamem-learning-what-to-remember.md
+++ b/papers/adamem-learning-what-to-remember.md
@@ -1,0 +1,57 @@
+---
+title: AdaMem — Learning What to Remember for Personalized Long-Horizon LLM Agents
+arxiv_id: 2606.21144
+source: arXiv:2606.21144
+date: 2026-06
+domain: memory
+core_claim: |
+  Personalized agents need role-specific write policies. AdaMem learns what to
+  store from week-by-week QA feedback, improving useful memory while reducing
+  memory volume.
+evidence_level: medium
+code_available: check
+license: check
+memory_modules:
+  - ingest-adapter
+  - dream-consolidator
+  - memorydiff-generator
+  - evaluator-benchmark
+status: seed
+last_revised: 2026-06-24
+urls:
+  - https://arxiv.org/abs/2606.21144
+---
+
+# AdaMem(arXiv 2606.21144)
+
+## Problem statement
+
+长期个性化 agent 不是"存得越多越好"。无关琐事会造成 memory bloat,挤占有用偏好、
+承诺、情绪和日程信息,最终降低 QA 准确率。
+
+## Core claim
+
+AdaMem 维护 role-specific Memory Policy,并通过 weekly QA feedback 做 lightweight
+patch-style self-reflection。论文构造 AdaMem-Bench,模拟多周交互和逐周 QA,并报告在
+Mem0 uniform baseline 之上提升 QA,同时减少 memory volume。
+
+## Decision relevance
+
+- `ingest-adapter`:需要显式区分 raw event 与 admission policy,不能默认全量写入。
+- `memorydiff-generator`:policy patch 是一种比单条 memory ADD/UPDATE 更高层的 diff。
+- `dream-consolidator`:可以把失败 QA 作为反事实反馈,驱动后续写入策略调整。
+- `evaluator-benchmark`:需要覆盖 week-by-week personalization,而不是只测单次 recall。
+
+## Caveats
+
+本地笔记是 seed 质量。AdaMem-Bench 的数据生成、反馈强度和 baseline 设置仍需精读后确认。
+reported gains 只作为 paper-origin claim。
+
+## Sources
+
+- arXiv:https://arxiv.org/abs/2606.21144
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/papers/agent-memory-systems-characterization.md
+++ b/papers/agent-memory-systems-characterization.md
@@ -1,0 +1,60 @@
+---
+title: Agent Memory — Characterization and System Implications of Stateful Long-Horizon Workloads
+arxiv_id: 2606.06448
+source: arXiv:2606.06448
+date: 2026-06
+domain: systems
+core_claim: |
+  Agent memory should be treated as a stateful long-horizon systems workload,
+  not just a retrieval algorithm. The paper profiles construction, retrieval,
+  and generation phases across representative memory systems and derives system
+  recommendations for scheduling, freshness, amortization, and fleet operation.
+evidence_level: medium
+code_available: check
+license: check
+memory_modules:
+  - ingest-adapter
+  - dream-consolidator
+  - retriever-reranker
+  - evaluator-benchmark
+status: seed
+last_revised: 2026-06-24
+urls:
+  - https://arxiv.org/abs/2606.06448
+---
+
+# Agent Memory(arXiv 2606.06448)
+
+## Problem statement
+
+这篇 2026-06-04 arXiv 论文把 agent memory 定义为 stateful long-horizon workload。
+它关注的不是单个 retrieval 模型,而是 memory construction、retrieval 和 generation
+在真实 agent 生命周期里的成本、延迟、freshness 与部署 trade-off。
+
+## Core claim
+
+作者提出一个系统视角 taxonomy,并构建 phase-aware profiling harness,对 10 个代表性
+agent memory system 在两个 benchmark suite 上做画像。核心结论是:memory design 会把
+成本在写路径、读路径和生成路径之间迁移,所以 memory kernel 的架构选择必须同时看
+quality、latency、query volume 和更新频率。
+
+## Decision relevance
+
+- `ingest-adapter`:写入是否 synchronous / asynchronous / batched 会直接改变热路径成本。
+- `dream-consolidator`:consolidation 调度不能只看质量,还要看 amortization 和 freshness。
+- `retriever-reranker`:retrieval cost 必须和 query volume 一起评估,不能孤立看单次延迟。
+- `evaluator-benchmark`:需要把 cost profile 与 quality benchmark 并列记录。
+
+## Caveats
+
+本地笔记是 seed 质量。尚未精读 PDF 与 harness 细节;不能把 paper 中的系统建议当成
+本仓已复现结论。下一步应补齐被测系统列表、benchmark 设置和代码可用性。
+
+## Sources
+
+- arXiv:https://arxiv.org/abs/2606.06448
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/papers/atommem-atomic-facts.md
+++ b/papers/atommem-atomic-facts.md
@@ -1,0 +1,59 @@
+---
+title: AtomMem — Building Simple and Effective Memory System for LLM Agents via Atomic Facts
+arxiv_id: 2606.19847
+source: arXiv:2606.19847
+date: 2026-06
+domain: memory
+core_claim: |
+  Long-term agent memory can be made denser and more stable by extracting
+  high-value atomic facts, organizing them into hierarchical event structures,
+  and maintaining temporal user profiles.
+evidence_level: medium
+code_available: check
+license: check
+memory_modules:
+  - parser-chunker
+  - semantic-dedup
+  - dream-consolidator
+  - retriever-reranker
+status: seed
+last_revised: 2026-06-24
+urls:
+  - https://arxiv.org/abs/2606.19847
+---
+
+# AtomMem atomic facts(arXiv 2606.19847)
+
+## Disambiguation
+
+本条是 2026-06 的 **AtomMem: Building Simple and Effective Memory System for
+LLM Agents via Atomic Facts**。不要与本仓已有 2026-01 stub
+[`stubs/atommem-learnable-dynamic-agentic-memory-with-atomic-memory.md`](stubs/atommem-learnable-dynamic-agentic-memory-with-atomic-memory.md)
+混淆;后者 arXiv ID 是 `2601.08323`,标题是 **Learnable Dynamic Agentic Memory
+with Atomic Memory Operation**。
+
+## Core claim
+
+论文提出 Fact Executor,从 long-form interactions 中选择性抽取 high-value atomic
+facts,再组织成 hierarchical event structures 与 temporal profiles。目标是让长期记忆
+既 compact 又能保持 episodic coherence 和 user attribute evolution。
+
+## Decision relevance
+
+- `parser-chunker`:atomic fact 是比 raw chunk 更适合长期存储的最小单元。
+- `semantic-dedup`:atomic fact 需要 structured metadata,否则容易产生碎片化重复。
+- `dream-consolidator`:hierarchical event structure 是 consolidation 输出的一种候选形态。
+- `retriever-reranker`:retrieval 应同时支持 fact-level 和 event/profile-level 召回。
+
+## Caveats
+
+本地笔记是 seed 质量。下一步应验证数据集、fact extraction 训练方式和是否有 official code。
+
+## Sources
+
+- arXiv:https://arxiv.org/abs/2606.19847
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/papers/index.md
+++ b/papers/index.md
@@ -19,6 +19,18 @@ removed.
 - By year: 2026=388, 2025=309, 2024=129, 2023=72, 2022=6, 2021=4, 2020=3, 2018=2, 2017=1, undated=75
 - By source-count: 6 sources=6, 5 sources=18, 4 sources=32, 3 sources=66, 2 sources=127, 1 sources=740
 
+## 2026-06 manual radar additions
+
+These entries were added by the 2026-06-24 current-source radar refresh. They
+are not part of the 2026-05-19 nine-list scrape statistics above.
+
+- [Agent Memory: Characterization and System Implications of Stateful Long-Horizon Workloads](agent-memory-systems-characterization.md) — 2026-06 — seed — [arxiv](https://arxiv.org/abs/2606.06448)
+- [RaMem: Contextual Reinstatement for Long-term Agentic Memory](ramem.md) — 2026-06 — seed — [arxiv](https://arxiv.org/abs/2606.22844)
+- [AdaMem: Learning What to Remember for Personalized Long-Horizon LLM Agents](adamem-learning-what-to-remember.md) — 2026-06 — seed — [arxiv](https://arxiv.org/abs/2606.21144)
+- [AtomMem: Building Simple and Effective Memory System for LLM Agents via Atomic Facts](atommem-atomic-facts.md) — 2026-06 — seed — [arxiv](https://arxiv.org/abs/2606.19847)
+- [Lightweight LLM Agent Memory with Small Language Models](lightmem-agent-memory.md) — ACL 2026 — seed — [acl](https://aclanthology.org/2026.acl-long.588/) / [arxiv](https://arxiv.org/abs/2604.07798)
+- [GateMem: Benchmarking Memory Governance in Multi-Principal Shared-Memory Agents](../benchmarks/gatemem.md) — 2026-06 — benchmark seed — [arxiv](https://arxiv.org/abs/2606.18829)
+
 **Top by cross-list reference count (>=4 sources):**
 - [MAGMA: A Multi-Graph based Agentic Memory Architecture for AI Agents](stubs/magma-a-multi-graph-based-agentic-memory-architecture-for.md) — 2026 — 6 sources [DEEP,IAAR,Shi,Tele,C3I,Volt]
 - [Mem0: Building production-ready ai agents with scalable long-term memory](stubs/mem0-building-production-ready-ai-agents-with-scalable-long.md) — 2025 — 6 sources [AMW,DEEP,IAAR,Shi,Tele,C3I]
@@ -599,8 +611,8 @@ removed.
 - [User personalization](stubs/user-personalization.md) — 2025 — sources: [DEEP,IAAR] — _deferred-size-cap_ — [arxiv](https://arxiv.org/abs/2508.13250)
 - [WebCoach: Self-Evolving Web Agents with Cross-Session Memory Guidance](stubs/webcoach-self-evolving-web-agents-with-cross-session-memory.md) — 2025 — sources: [AMW,C3I] — _deferred-size-cap_ — [arxiv](https://arxiv.org/abs/2511.12997)
 - [WebWeaver: Structuring Web-Scale Evidence with Dynamic Outlines for Open-Ended Deep Research](stubs/webweaver-structuring-web-scale-evidence-with-dynamic.md) — 2025 — sources: [IAAR,C3I] — _deferred-size-cap_ — [arxiv](https://arxiv.org/abs/2509.13312)
-- [arxiv-2503.08102](arxiv-2503.08102.md) — 2025 — sources: [Tele] — _deferred_ — [arxiv](https://arxiv.org/abs/2503.08102)
-- [arxiv-2512.14142](arxiv-2512.14142.md) — 2025 — sources: [AMW] — _deferred_ — [arxiv](https://arxiv.org/abs/2512.14142)
+- [arxiv-2503.08102](stubs/arxiv-2503.08102.md) — 2025 — sources: [Tele] — _deferred_ — [arxiv](https://arxiv.org/abs/2503.08102)
+- [arxiv-2512.14142](stubs/arxiv-2512.14142.md) — 2025 — sources: [AMW] — _deferred_ — [arxiv](https://arxiv.org/abs/2512.14142)
 - [A Comprehensive Survey of Self-Evolving AI Agents: A New Paradigm Bridging Foundation Models and Lifelong Agentic Systems](stubs/a-comprehensive-survey-of-self-evolving-ai-agents-a-new.md) — 2025 — sources: [C3I] — _deferred_ — [arxiv](https://arxiv.org/abs/2508.07407)
 - [A Survey of Context Engineering for Large Language Models](stubs/a-survey-of-context-engineering-for-large-language-models.md) — 2025 — sources: [C3I] — _deferred_ — [arxiv](https://arxiv.org/abs/2507.13334)
 - [A Survey of Machine Unlearning in Large Language Models: Methods, Challenges and Future Directions](stubs/a-survey-of-machine-unlearning-in-large-language-models.md) — 2025 — sources: [IAAR] — _deferred_ — [arxiv](https://arxiv.org/abs/2503.01854)

--- a/papers/lightmem-agent-memory.md
+++ b/papers/lightmem-agent-memory.md
@@ -1,0 +1,58 @@
+---
+title: Lightweight LLM Agent Memory with Small Language Models
+arxiv_id: 2604.07798
+source: ACL 2026 / arXiv:2604.07798
+date: 2026-04
+domain: memory
+core_claim: |
+  A memory system can reduce online cost by using Small Language Models for
+  retrieval, writing, and offline consolidation, while keeping long-horizon
+  agent memory useful under bounded compute.
+evidence_level: medium
+code_available: check
+license: check
+memory_modules:
+  - ingest-adapter
+  - retriever-reranker
+  - dream-consolidator
+  - evaluator-benchmark
+status: seed
+last_revised: 2026-06-24
+urls:
+  - https://aclanthology.org/2026.acl-long.588/
+  - https://arxiv.org/abs/2604.07798
+---
+
+# LightMem agent memory(ACL 2026)
+
+## Problem statement
+
+很多 agent memory system 在在线路径反复调用大模型,准确率提升但长期交互延迟和成本会
+累积。LightMem 把 memory retrieval、writing 与 long-term consolidation 模块化,并用
+Small Language Models 降低在线成本。
+
+## Core claim
+
+LightMem 使用 STM / MTM / LTM 三层组织,线上固定 retrieval budget,先 vector coarse
+retrieval 再 semantic consistency reranking;离线从交互证据中抽象 reusable knowledge,
+增量整合进 LTM。ACL Anthology 页面与 arXiv 摘要都强调 bounded compute 与低延迟路径。
+
+## Decision relevance
+
+- `retriever-reranker`:固定 retrieval budget + rerank 是生产 memory kernel 的基本约束。
+- `dream-consolidator`:offline consolidation 可以用小模型承担部分整理工作。
+- `evaluator-benchmark`:报告质量时必须同时写 latency/cost,否则无法评估生产可行性。
+
+## Caveats
+
+本地笔记是 seed 质量。需要精读 ACL PDF 才能确认 SLM 选择、LoCoMo 设置和 code/license。
+
+## Sources
+
+- ACL Anthology:https://aclanthology.org/2026.acl-long.588/
+- arXiv:https://arxiv.org/abs/2604.07798
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/papers/memoryagentbench.md
+++ b/papers/memoryagentbench.md
@@ -1,6 +1,6 @@
 ---
 title: MemoryAgentBench — Evaluating Memory in LLM Agents via Incremental Multi-Turn Interactions
-source: ICLR 2026 (https://iclr.cc/virtual/2026/poster/10010781) / OpenReview pdf
+source: ICLR 2026 Poster / OpenReview
 date: 2026
 domain: eval
 memory_modules:
@@ -11,7 +11,10 @@ evidence_level: strong
 code_available: check
 license: check
 status: seed
-last_revised: 2026-05-19
+last_revised: 2026-06-24
+urls:
+  - https://openreview.net/forum?id=DT7JyQC3MR
+  - https://arxiv.org/abs/2507.05257
 ---
 
 # MemoryAgentBench
@@ -61,7 +64,9 @@ selective forgetting
 
 ## Notes
 
-(随精读迭代)
+2026-06 refresh:OpenReview page lists this as ICLR 2026 Poster. The local
+benchmark note remains seed quality until protocol and artifact details are
+normalized.
 
 ---
 

--- a/papers/ramem.md
+++ b/papers/ramem.md
@@ -1,0 +1,62 @@
+---
+title: RaMem — Contextual Reinstatement for Long-term Agentic Memory
+arxiv_id: 2606.22844
+source: arXiv:2606.22844
+date: 2026-06
+domain: memory
+core_claim: |
+  Long-term agent memory fails when compressed fragments lose the conditions
+  that made them valid. RaMem reinstates episodic context around retrieved
+  memories and uses validity-aware retrieval before synthesis.
+evidence_level: medium
+code_available: check
+license: check
+memory_modules:
+  - retriever-reranker
+  - semantic-dedup
+  - dream-consolidator
+  - policy-privacy
+status: seed
+last_revised: 2026-06-24
+urls:
+  - https://arxiv.org/abs/2606.22844
+---
+
+# RaMem(arXiv 2606.22844)
+
+## Problem statement
+
+RaMem 把 retrieval-only memory 的一个核心失效模式命名为 **context collapse**:
+memory fragment 看起来语义相关,但原始事件时间、会话范围、参与者或提及条件已经不
+适用于当前 query。
+
+## Core claim
+
+方法包括四步:
+
+1. evidence anchoring:保留 memory 的原始 episodic conditions。
+2. recall condition induction:从 query 推断当前证据条件。
+3. validity-aware retrieval:优先检索 context-compatible memories。
+4. context-preserved synthesis:让 generator 在结构化 context 下生成答案。
+
+论文报告在 long-term memory benchmarks 上比 strong baselines 有平均 10%+ F1 改进。
+
+## Decision relevance
+
+- `retriever-reranker` 不应只输出相似 memory,还应输出 validity / applicability metadata。
+- `semantic-dedup` 合并 memory 时不能丢掉事件时间、session span 和 participant scope。
+- `dream-consolidator` 需要保留可追溯的 evidence anchor,否则后续 recall 无法判断适用性。
+
+## Caveats
+
+本地笔记是 seed 质量。reported F1 仍是作者实证,未在本仓 claims ledger 中登记为独立
+复现。下一步应检查 benchmark、baseline 和代码可用性。
+
+## Sources
+
+- arXiv:https://arxiv.org/abs/2606.22844
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/papers/stubs/memgen-weaving-generative-latent-memory-for-self-evolving.md
+++ b/papers/stubs/memgen-weaving-generative-latent-memory-for-self-evolving.md
@@ -4,6 +4,7 @@ arxiv_id: "2509.24704"
 date: 2025
 domain: unclassified
 status: stub
+venue: ICLR 2026 Poster
 sources:
   - AgentMemoryWorld
   - DEEP-PolyU
@@ -20,3 +21,6 @@ urls:
 > ResearchItem when this paper becomes a candidate for Ymem evaluation.
 
 2025-10-12 MemGen Weaving Generative Latent Memory for Self-Evolving Agents
+
+2026-06-24 radar refresh:OpenReview lists MemGen as an ICLR 2026 Poster. Keep as
+stub until the paper is upgraded to a seed/full ResearchItem.

--- a/products/agentmemory.md
+++ b/products/agentmemory.md
@@ -1,0 +1,67 @@
+---
+title: agentmemory
+type: product
+source: https://github.com/rohitg00/agentmemory
+date_first_seen: 2026-06
+domain: coding-agent-memory
+business_model: OSS
+license: Apache-2.0
+memory_modules:
+  - ingest-adapter
+  - retriever-reranker
+  - policy-privacy
+status: seed
+last_revised: 2026-06-24
+archive: archives/agentmemory-overview.md
+---
+
+# agentmemory
+
+## 1. 一句话定位
+
+agentmemory 是面向 AI coding agents 的 persistent memory layer,以 MCP/CLI/REST
+形态把 Claude Code、Codex、Cursor、OpenClaw、Hermes 等 agent 的项目上下文和决策
+跨 session 保存与召回。
+
+## 2. 是什么 / 做什么
+
+GitHub repo 描述为 "persistent memory for AI coding agents"。本轮 GitHub API
+spot-check 显示仓库仍活跃:created 2026-02-25,updated 2026-06-24,pushed
+2026-06-22,Apache-2.0 license,TypeScript 主语言,并带有 `codex`、`openclaw`、
+`memory`、`agentmemory` 等 topics。
+
+## 3. 关键技术选择
+
+- **Coding-agent-first**:把 memory 问题定位在开发 agent 的项目上下文、决策和历史。
+- **Multi-client surface**:README/GitHub topics 显示覆盖 Claude Code、Codex、
+  Cursor、OpenClaw、GitHub Copilot CLI 等入口。
+- **MCP/REST/CLI signal**:适合作为 coding-agent memory server 类产品观察样本。
+
+## 4. 决策相关性 / Decision relevance
+
+- **对照点**:coding-agent memory 正在从插件零散能力走向可共享 memory server。
+- **借鉴点**:multi-client namespace、project-scoped recall 和 agent-neutral API
+  对 Ymem host integration 有参考价值。
+- **差异点**:本仓尚未审计其 retrieval quality、staleness handling 与 schema 设计。
+
+## 5. 适用 / 不适用场景
+
+- **适用**:希望多个 coding agents 共享项目记忆的个人开发者和团队。
+- **不适用**:需要经过独立 benchmark 证明的企业 memory kernel;需要完全审计内部算法的场景。
+
+## 6. 注意事项 / 风险
+
+- **成熟度**:虽然 GitHub 活跃度很高,但本笔记只把 stars/activity 当 discovery signal。
+- **证据边界**:benchmark claim 需要独立复核后才能进入 `benchmarks/claims/claims.yaml`。
+- **范围**:它属于 coding-agent memory 产品,不是通用企业 managed memory。
+
+## 7. 进一步阅读
+
+- archive: [`archives/agentmemory-overview.md`](archives/agentmemory-overview.md)
+- GitHub:https://github.com/rohitg00/agentmemory
+- Homepage:https://agent-memory.dev
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/archives/agentmemory-overview.md
+++ b/products/archives/agentmemory-overview.md
@@ -1,0 +1,27 @@
+---
+source_url: https://github.com/rohitg00/agentmemory
+source_homepage: https://agent-memory.dev
+fetched: 2026-06-24
+purpose: research backup; canonical sources are the URLs above
+---
+
+# agentmemory — snapshot
+
+## Positioning
+
+agentmemory presents itself as persistent memory for AI coding agents, with
+multi-client support across Claude Code, Codex, Cursor, OpenClaw, Hermes and MCP
+clients.
+
+## Public Evidence
+
+- GitHub API spot-check:created 2026-02-25,updated 2026-06-24,pushed 2026-06-22.
+- License:Apache-2.0.
+- Primary language:TypeScript.
+- Discovery signal:high GitHub star/fork activity; treated only as activity
+  signal, not quality evidence.
+
+## Evidence Boundary
+
+Included as Tier A coding-agent memory because memory is first-class and the
+repo is active. Benchmark/performance claims require independent verification.

--- a/products/archives/memori-overview.md
+++ b/products/archives/memori-overview.md
@@ -1,0 +1,26 @@
+---
+source_url: https://github.com/MemoriLabs/Memori
+source_homepage: https://memorilabs.ai
+fetched: 2026-06-24
+purpose: research backup; canonical sources are the URLs above
+---
+
+# Memori — snapshot
+
+## Positioning
+
+Memori presents itself as agent-native memory infrastructure:an LLM-agnostic
+layer that turns agent execution and conversations into structured persistent
+state for production systems.
+
+## Public Evidence
+
+- GitHub API spot-check:created 2025-07-24,updated 2026-06-23,pushed 2026-06-15.
+- License:GitHub API returned `NOASSERTION`; manual review required.
+- Primary language:Python.
+- Discovery signal:active repo and product homepage.
+
+## Evidence Boundary
+
+Included because it explicitly targets structured agent memory beyond chat
+history. License and benchmark claims remain unresolved.

--- a/products/archives/memsearch-overview.md
+++ b/products/archives/memsearch-overview.md
@@ -1,0 +1,26 @@
+---
+source_url: https://github.com/zilliztech/memsearch
+source_docs: https://zilliztech.github.io/memsearch/
+fetched: 2026-06-24
+purpose: research backup; canonical sources are the URLs above
+---
+
+# memsearch — snapshot
+
+## Positioning
+
+memsearch is a persistent, unified memory layer for AI coding agents, backed by
+Markdown and Milvus, with explicit Claude Code / Codex / OpenClaw-style agent
+targets.
+
+## Public Evidence
+
+- GitHub API spot-check:created 2026-02-09,updated 2026-06-23,pushed 2026-06-22.
+- License:MIT.
+- Primary language:Python.
+- Official docs describe cross-platform semantic memory for AI coding agents.
+
+## Evidence Boundary
+
+Included because it combines human-readable memory artifacts with vector search
+for coding agents. Claims about retrieval quality remain vendor/source claims.

--- a/products/archives/memu-overview.md
+++ b/products/archives/memu-overview.md
@@ -1,0 +1,25 @@
+---
+source_url: https://github.com/NevaMind-AI/memU
+source_homepage: https://memu.pro
+fetched: 2026-06-24
+purpose: research backup; canonical sources are the URLs above
+---
+
+# memU — snapshot
+
+## Positioning
+
+memU presents itself as a workspace runtime for AI agents, turning conversations,
+documents, code, media, and tool traces into durable agent memory layers.
+
+## Public Evidence
+
+- GitHub API spot-check:created 2025-07-29,updated 2026-06-24,pushed 2026-06-24.
+- License:GitHub API returned `NOASSERTION`; manual review required.
+- Primary language:Python.
+- Topics include agent-memory, MCP, OpenClaw, skills, sandbox, and proactive AI.
+
+## Evidence Boundary
+
+Included as a workspace-to-memory product signal. Internal memory structure,
+license, and performance claims require further review.

--- a/products/aws-agentcore-memory.md
+++ b/products/aws-agentcore-memory.md
@@ -12,7 +12,7 @@ memory_modules:
   - retriever-reranker
   - policy-privacy
 status: seed
-last_revised: 2026-06-11
+last_revised: 2026-06-24
 archive: archives/aws-agentcore-memory-overview.md
 ---
 
@@ -35,6 +35,16 @@ insights、user preferences、facts 和 session summaries,并在未来会话中�
 - **Session events**:通过 `sessionId` 等范围保存会话历史。
 - **Strategies**:长期记忆由 strategy 决定抽取什么;可用内建、覆盖或自管策略。
 - **Managed lifecycle**:云服务负责存储、检索和跨会话召回。
+
+## 3.1 2026-06 refresh
+
+- 2026-03-12 AWS 发布 LTM record streaming:memory record create/update/delete 可
+  通过 Kinesis stream 触发事件,减少 polling。What’s New 页面只概述 created/modified,
+  record-streaming developer guide 进一步列出 delete event type。
+- 2026-05-06 AWS 发布 long-term memory metadata:memory record 可带 structured
+  indexed keys,用于 tag/filter/retrieve。
+- 这使 AgentCore Memory 从"托管 LTM"进一步接近 evented memory lifecycle infra,
+  对 Ymem 的 `memorydiff-generator` 和审计流水线有对照价值。
 
 ## 4. 决策相关性 / Decision relevance
 
@@ -60,6 +70,9 @@ insights、user preferences、facts 和 session summaries,并在未来会话中�
 - archive: [`archives/aws-agentcore-memory-overview.md`](archives/aws-agentcore-memory-overview.md)
 - Docs:https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/memory.html
 - Strategies:https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/memory-strategies.html
+- Streaming announcement:https://aws.amazon.com/about-aws/whats-new/2026/03/agentcore-memory-streaming-ltm/
+- Streaming developer guide:https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/memory-record-streaming.html
+- Metadata:https://aws.amazon.com/about-aws/whats-new/2026/05/agentcore-longterm-memory-metadata/
 
 ---
 

--- a/products/claude-dreams.md
+++ b/products/claude-dreams.md
@@ -10,7 +10,7 @@ evidence_level: medium (production product, no public benchmark numbers)
 code_available: no (proprietary)
 license: proprietary
 status: seed
-last_revised: 2026-05-19
+last_revised: 2026-06-24
 ---
 
 # Claude Dreams
@@ -20,6 +20,20 @@ last_revised: 2026-05-19
 Agent 工作时写 memory 是局部和增量的。长期会积累重复、矛盾、过期条目。Dreams
 作为离线 job,读取 memory store 和过去 sessions,**生成一个新的整理后 memory
 store**。原输入 store 不被直接修改,便于审核和丢弃。
+
+## 2026-06 product note
+
+Anthropic/Claude 侧需要分开看两条线:
+
+- **Claude Code memory**:官方 docs 将 `CLAUDE.md`、repo-local `MEMORY.md` 和 auto
+  memory 文档化,并给出 Claude Code v2.1.59+ 的 auto memory 要求。它是 coding-agent
+  host memory,对本仓产品全景的 Coding & Dev agents 类更直接。
+- **Claude app memory**:release notes 显示 consumer/team app memory 扩展到更多 plan,
+  但它更像 chat-app vendor memory,不等同于 agent memory platform。
+
+本文件继续保留 Dreams/offline consolidation 的 architecture signal;Claude Code memory
+后续可单独拆成产品 note,如果公开 docs 稳定且与 `CLAUDE.md`/`MEMORY.md` 形成清晰
+agent-memory lifecycle。
 
 ## Architectural takeaways
 

--- a/products/cloudflare-agent-memory.md
+++ b/products/cloudflare-agent-memory.md
@@ -11,7 +11,7 @@ memory_modules:
   - retriever-reranker
   - policy-privacy
 status: seed
-last_revised: 2026-06-11
+last_revised: 2026-06-24
 archive: archives/cloudflare-agent-memory-overview.md
 ---
 
@@ -37,6 +37,13 @@ Cloudflare docs 把 agent memory 分成 conversation history 与 context memory:
   Skills 四类公开抽象。
 - **Provider abstraction**:默认可用 SQLite / Durable Object,search provider 可替换。
 - **平台托管**:Agent Memory 是 Cloudflare 平台服务,与 Workers/Agents 生态绑定。
+
+## 3.1 2026-06 refresh
+
+2026-06-02 官方 Agent Memory docs 标注 beta/private beta,并将 API 面拆为
+conversation ingestion、`remember`、`recall`、profiles/namespaces,以及 facts、
+events、instructions、tasks 等 memory 类型。它比早期 Agents session/context
+memory 更接近专门托管的 memory service。
 
 ## 4. 决策相关性 / Decision relevance
 
@@ -65,6 +72,7 @@ Cloudflare docs 把 agent memory 分成 conversation history 与 context memory:
 - archive: [`archives/cloudflare-agent-memory-overview.md`](archives/cloudflare-agent-memory-overview.md)
 - Blog:https://blog.cloudflare.com/introducing-agent-memory/
 - Docs:https://developers.cloudflare.com/agents/concepts/conversation-state-and-memory/
+- Agent Memory docs:https://developers.cloudflare.com/agent-memory/
 
 ---
 

--- a/products/google-memory-bank.md
+++ b/products/google-memory-bank.md
@@ -12,7 +12,7 @@ memory_modules:
   - retriever-reranker
   - policy-privacy
 status: seed
-last_revised: 2026-06-11
+last_revised: 2026-06-24
 archive: archives/google-memory-bank-overview.md
 ---
 
@@ -36,6 +36,13 @@ multimodal inputs、TTL/configuration、revisions 和 IAM conditions。
 - **Async generation**:对话进入后异步生成可检索的 memories。
 - **Governance**:TTL、revision、IAM condition 和 memory poisoning 指南是文档重点。
 - **ADK integration**:面向 Google ADK/Agent Platform 的开发者入口。
+
+## 3.1 2026-06 refresh
+
+2026-06-23 版本的官方 docs 将 Memory Bank 描述为从 user-agent conversations
+动态生成 long-term memories,并强调 scoped identity isolation、event ingestion、
+similarity retrieval、TTL、revisions 与 IAM conditions。相较 2025 Vertex AI Memory
+Bank preview,当前入口已明确归入 Gemini Enterprise Agent Platform。
 
 ## 4. 决策相关性 / Decision relevance
 
@@ -61,6 +68,7 @@ multimodal inputs、TTL/configuration、revisions 和 IAM conditions。
 
 - archive: [`archives/google-memory-bank-overview.md`](archives/google-memory-bank-overview.md)
 - Docs:https://docs.cloud.google.com/gemini-enterprise-agent-platform/scale/memory-bank
+- Setup:https://docs.cloud.google.com/gemini-enterprise-agent-platform/scale/memory-bank/setup
 
 ---
 

--- a/products/memori.md
+++ b/products/memori.md
@@ -1,0 +1,59 @@
+---
+title: Memori
+type: product
+source: https://github.com/MemoriLabs/Memori
+date_first_seen: 2026-06
+domain: agent-native-memory-infrastructure
+business_model: OSS / productizing
+license: NOASSERTION
+memory_modules:
+  - ingest-adapter
+  - dream-consolidator
+  - retriever-reranker
+status: seed
+last_revised: 2026-06-24
+archive: archives/memori-overview.md
+---
+
+# Memori
+
+## 1. 一句话定位
+
+Memori 是 agent-native memory infrastructure,主张把 agent execution 与 conversation
+转成 structured persistent state,服务 production agent systems。
+
+## 2. 是什么 / 做什么
+
+本轮 GitHub API spot-check 显示 `MemoriLabs/Memori` created 2025-07-24,updated
+2026-06-23,pushed 2026-06-15,Python 主语言,homepage 为 `memorilabs.ai`。repo
+description 明确写到 LLM-agnostic memory layer、structured persistent state 和
+production systems。
+
+## 3. 关键技术选择
+
+- **Trace-aware memory**:定位不只存 conversation,也关注 agent execution state。
+- **LLM-agnostic**:公开描述强调跨模型层,不是单一 vendor memory。
+- **Production framing**:更像面向团队/平台的 memory infra,而非单用户插件。
+
+## 4. 决策相关性 / Decision relevance
+
+- **对照点**:把 tool/result/workflow outcome 纳入 memory,补足纯 chat memory 的盲区。
+- **借鉴点**:`ingest-adapter` 应能接 agent trace,而非只接 user/assistant message。
+- **风险点**:GitHub license API 返回 `NOASSERTION`,需要人工确认 license 后再推荐集成。
+
+## 5. 注意事项 / 风险
+
+- **License 未清**:本轮只记录 GitHub API 的 `NOASSERTION`;商业或二次分发需单独审查。
+- **证据边界**:官方站/README claim 不能替代独立 benchmark。
+- **成熟度**:活跃度强,但本仓尚未读源码或运行 demo。
+
+## 6. 进一步阅读
+
+- archive: [`archives/memori-overview.md`](archives/memori-overview.md)
+- GitHub:https://github.com/MemoriLabs/Memori
+- Homepage:https://memorilabs.ai
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/memsearch.md
+++ b/products/memsearch.md
@@ -1,0 +1,59 @@
+---
+title: memsearch
+type: product
+source: https://github.com/zilliztech/memsearch
+date_first_seen: 2026-06
+domain: coding-agent-memory
+business_model: OSS
+license: MIT
+memory_modules:
+  - ingest-adapter
+  - semantic-dedup
+  - retriever-reranker
+status: seed
+last_revised: 2026-06-24
+archive: archives/memsearch-overview.md
+---
+
+# memsearch
+
+## 1. 一句话定位
+
+memsearch 是 Zilliz 开源的 cross-platform semantic memory layer,面向 Claude Code、
+Codex、OpenCode、OpenClaw 等 coding agents,以 Markdown + Milvus/Hybrid Search 保存
+和召回跨 session 项目记忆。
+
+## 2. 是什么 / 做什么
+
+本轮 GitHub API spot-check 显示 `zilliztech/memsearch` created 2026-02-09,updated
+2026-06-23,pushed 2026-06-22,MIT license,Python 主语言,homepage 为
+`zilliztech.github.io/memsearch/`。公开 docs 描述其为 cross-platform semantic
+memory for AI coding agents。
+
+## 3. 关键技术选择
+
+- **Markdown + vector backend**:human-readable artifact 与 Milvus/hybrid search 结合。
+- **Coding-agent plugins**:面向 Claude Code、Codex CLI、OpenCode/OpenClaw 等入口。
+- **Automatic capture / recall**:产品定位强调用户安装后无需手动保存命令。
+
+## 4. 决策相关性 / Decision relevance
+
+- **对照点**:Zilliz/Milvus 路线代表 vector DB 厂商把 agent memory 上移到插件层。
+- **借鉴点**:Markdown source + semantic index 是兼顾可审计与检索性能的折中形态。
+- **差异点**:底层仍强依赖 Milvus/embedding stack,不等同于完整 memory governance layer。
+
+## 5. 注意事项 / 风险
+
+- **范围**:主要是 coding-agent 项目记忆,不是 enterprise user-profile memory。
+- **claim 边界**:本笔记只记录官方 repo/docs 可验证能力,不写独立性能结论。
+
+## 6. 进一步阅读
+
+- archive: [`archives/memsearch-overview.md`](archives/memsearch-overview.md)
+- GitHub:https://github.com/zilliztech/memsearch
+- Docs:https://zilliztech.github.io/memsearch/
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/memu.md
+++ b/products/memu.md
@@ -1,0 +1,61 @@
+---
+title: memU
+type: product
+source: https://github.com/NevaMind-AI/memU
+date_first_seen: 2026-06
+domain: workspace-to-agent-memory
+business_model: OSS / productizing
+license: NOASSERTION
+memory_modules:
+  - parser-chunker
+  - ingest-adapter
+  - dream-consolidator
+  - retriever-reranker
+status: seed
+last_revised: 2026-06-24
+archive: archives/memu-overview.md
+---
+
+# memU
+
+## 1. 一句话定位
+
+memU 是 "workspace to agent memory" 路线的 memory runtime,把 conversations、
+documents、code、images、audio 和 tool traces 编译成 agent 可持续使用的 durable
+memory layers。
+
+## 2. 是什么 / 做什么
+
+本轮 GitHub API spot-check 显示 `NevaMind-AI/memU` created 2025-07-29,updated
+2026-06-24,pushed 2026-06-24,Python 主语言,homepage 为 `memu.pro`。repo topics
+覆盖 `agent-memory`、`mcp`、`openclaw`、`sandbox`、`skills`、`proactive-ai`。
+
+## 3. 关键技术选择
+
+- **Workspace runtime**:输入面不止对话,还包括文件、代码、媒体和工具 traces。
+- **Multimodal / file-oriented signal**:把 workspace 编译为 durable memory,与
+  file/skill memory 方向接近。
+- **Agent ecosystem focus**:README 和 topics 都指向 OpenClaw/MCP/skills 生态。
+
+## 4. 决策相关性 / Decision relevance
+
+- **对照点**:workspace-level memory 比 chat memory 更接近 coding/productivity agent 的真实输入。
+- **借鉴点**:`parser-chunker` 与 `ingest-adapter` 需要处理 heterogeneous workspace evidence。
+- **差异点**:本仓尚未验证其三层 memory 结构、检索质量和 forgetting 行为。
+
+## 5. 注意事项 / 风险
+
+- **License 未清**:GitHub API 返回 `NOASSERTION`;README 徽章与实际 LICENSE 需后续人工核查。
+- **成熟度**:活跃度高但本地未跑 demo。
+- **证据边界**:只收录产品/架构信号,不采纳未复核的性能 claim。
+
+## 6. 进一步阅读
+
+- archive: [`archives/memu-overview.md`](archives/memu-overview.md)
+- GitHub:https://github.com/NevaMind-AI/memU
+- Homepage:https://memu.pro
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/microsoft-foundry-memory.md
+++ b/products/microsoft-foundry-memory.md
@@ -13,7 +13,7 @@ memory_modules:
   - retriever-reranker
   - policy-privacy
 status: seed
-last_revised: 2026-06-11
+last_revised: 2026-06-24
 archive: archives/microsoft-foundry-memory-overview.md
 ---
 
@@ -38,6 +38,13 @@ scope、default TTL、user profile memory、chat summaries 和 procedural memory
 - **Memory types**:profile、summary、procedure 被作为不同用途的 memory。
 - **Agent tools**:通过工具让 agent 直接操作记忆。
 
+## 3.1 2026-06 refresh
+
+Build 2026 后,Microsoft 官方博客和 Learn 文档把 Foundry memory 进一步拆成
+user memory、session memory 和 procedural memory。how-to 文档显示 memory store
+与 memory items 支持 create/update/list/delete/search,且 Python/C#/JavaScript/
+Java/REST 均有接口覆盖。当前仍是 public preview。
+
 ## 4. 决策相关性 / Decision relevance
 
 - **对照点**:Microsoft 路线比纯自动抽取更强调 developer-visible item lifecycle。
@@ -60,6 +67,8 @@ scope、default TTL、user profile memory、chat summaries 和 procedural memory
 
 - archive: [`archives/microsoft-foundry-memory-overview.md`](archives/microsoft-foundry-memory-overview.md)
 - Docs:https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/what-is-memory
+- How-to:https://learn.microsoft.com/en-us/azure/foundry/agents/how-to/memory-usage
+- Build 2026:https://devblogs.microsoft.com/foundry/agent-service-build2026/
 
 ---
 

--- a/products/openai-memory.md
+++ b/products/openai-memory.md
@@ -10,7 +10,7 @@ memory_modules:
   - ingest-adapter
   - retriever-reranker
 status: full
-last_revised: 2026-05-19
+last_revised: 2026-06-24
 archive: archives/openai-memory-overview.md
 ---
 
@@ -52,6 +52,13 @@ Memory 中查看 / 编辑 / 删除任意一条,或整体关闭;"Temporary Chat" 
   不开放
 - **runtime**:与 OpenAI 模型强绑定
 
+## 3.1 2026-06 refresh
+
+OpenAI 2026-06 公布 ChatGPT Memory Dreaming,把 memory 改进描述为后台综合过去
+对话、memory source/summary、减少 stale 或 contradictory memory 的能力。ChatGPT
+release notes 同期写到 memory 会更及时地保持更新。对本仓而言,这属于已有
+vendor-managed memory 的 UX/治理升级,不是新的开放 memory kernel。
+
 ## 4. 决策相关性 / Decision relevance
 
 - **对照点**:它定义了 "vendor-managed memory" 的对照基线 — 用户/开发者
@@ -90,8 +97,10 @@ Memory 中查看 / 编辑 / 删除任意一条,或整体关闭;"Temporary Chat" 
 
 - archive: [`archives/openai-memory-overview.md`](archives/openai-memory-overview.md)
 - 帮助中心:https://help.openai.com/en/articles/8983136-what-is-the-memory-feature
+- Memory FAQ:https://help.openai.com/articles/8590148-memory-faq
 - Assistants API:https://platform.openai.com/docs/assistants/how-it-works
 - 公告:https://openai.com/index/memory-and-new-controls-for-chatgpt/
+- Dreaming:https://openai.com/index/chatgpt-memory-dreaming/
 
 ---
 


### PR DESCRIPTION
## Summary
- Add a 2026-06 memory radar refresh covering papers, products, GitHub projects, watchlist/reject decisions, and evidence gaps.
- Add seed notes for Agent Memory, RaMem, AdaMem, AtomMem June, LightMem, GateMem, plus four GitHub product notes and archives.
- Update README/docs maps, products landscape, benchmark landscape, signals, research radar, Ymem binding, and existing official product notes.

## Review / consistency work
- Checked new paper entries against existing index/stubs and arXiv IDs, including AtomMem Jan vs Jun disambiguation.
- Checked new products against existing product slugs, titles, archives, and landscape/discovery/architecture docs.
- Resolved reviewer findings by clarifying scraped-paper/manual-radar count semantics, benchmark catalog row wording, pending product diagrams, and deep-note vs frontmatter status.

## Validation
- git diff --check
- README/tree count script: 38 product notes, 37 archives, 7 full + 7 seed paper notes, 13 benchmark catalog rows
- changed Markdown local-link script
- duplicate arXiv/product slug checks
- Ruby YAML parse for benchmarks/claims/claims.yaml, 23 events, no duplicate event IDs
- cross-document token checks for papers/products/benchmarks/signals/radar/Ymem binding
- code-reviewer re-review: APPROVE

## Not tested
- Full external link crawl.
- Per-product Mermaid diagrams for agentmemory, Memori, memU, and memsearch remain pending by design; the architecture diagram page now marks them as pending diagrams.
