### PR TITLE
Add FeishuLuo benchmark discovery intake

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Papers](https://img.shields.io/badge/papers-989-brightgreen.svg)](papers/index.md)
 [![PDFs](https://img.shields.io/badge/local_PDFs-534-orange.svg)](papers/pdfs/)
 [![Memory products](https://img.shields.io/badge/memory%20products-38-purple.svg)](products/)
-[![Benchmarks](https://img.shields.io/badge/benchmarks-13-blueviolet.svg)](benchmarks/)
+[![Benchmarks](https://img.shields.io/badge/benchmarks-16-blueviolet.svg)](benchmarks/)
 [![Surveys](https://img.shields.io/badge/meta_surveys-6-yellow.svg)](docs/meta-surveys.md)
 [![Updated](https://img.shields.io/badge/updated-2026--06-lightgrey.svg)](docs/signals.md)
 
@@ -61,7 +61,7 @@ separate buckets.
 | Full / seed paper notes | 7 full + 7 seed | [`papers/`](papers/) | Use human-read notes for architectural decisions. |
 | Memory product notes | 38 notes | [`products/`](products/) | Compare memory layers, memory SDKs, managed memory, and memory-enabled agents. |
 | Product page archives | 37 snapshots | [`products/archives/`](products/archives/) | Audit product claims after source pages change. |
-| Benchmark catalog | 13 catalog rows | [`benchmarks/index.md`](benchmarks/index.md) | First-class benchmark records plus stub-backed candidate rows and a usage-claim ledger. |
+| Benchmark catalog | 16 catalog rows | [`benchmarks/index.md`](benchmarks/index.md) | First-class benchmark records plus stub-backed candidate rows and a usage-claim ledger. |
 | Claims ledger | Structured YAML ledger | [`benchmarks/claims/claims.yaml`](benchmarks/claims/claims.yaml) | Separate vendor claims, paper evaluations, critiques, and reproductions. |
 | Survey and taxonomy | 1 living survey + 6 meta-survey records | [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) · [`docs/meta-surveys.md`](docs/meta-surveys.md) | Build a field-level view before choosing an implementation. |
 | Impact reports | Template only for now | [`impact-reports/README.md`](impact-reports/README.md) | Promote strong evidence into kernel-design recommendations. |
@@ -146,7 +146,7 @@ flowchart LR
 | [`papers/stubs/`](papers/stubs/) | 988 generated stubs for papers not yet fully read. |
 | [`papers/pdfs/`](papers/pdfs/) | 534 archived PDFs, about 1.8 GB. See the archival policy below. |
 | [`papers/_scrape/`](papers/_scrape/) | Reproducibility artifacts: scrape script and dedup JSON. |
-| [`benchmarks/`](benchmarks/) | 13 benchmark catalog rows, including protocol notes, stub-backed candidate rows, and the note template. |
+| [`benchmarks/`](benchmarks/) | 16 benchmark catalog rows, including protocol notes, stub-backed candidate rows, and the note template. |
 | [`benchmarks/claims/`](benchmarks/claims/) | Usage-event ledger for benchmark mentions, vendor claims, critiques, and reproductions. |
 | [`benchmarks/archives/`](benchmarks/archives/) | Optional source-page snapshots for benchmark pages, repositories, or dataset cards. |
 | [`docs/benchmarks-landscape.md`](docs/benchmarks-landscape.md) | Benchmark landscape by capability, usage type, and evidence independence. |

--- a/README_cn.md
+++ b/README_cn.md
@@ -10,7 +10,7 @@
 [![Papers](https://img.shields.io/badge/papers-989-brightgreen.svg)](papers/index.md)
 [![PDFs](https://img.shields.io/badge/local_PDFs-534-orange.svg)](papers/pdfs/)
 [![记忆产品](https://img.shields.io/badge/memory%20products-38-purple.svg)](products/)
-[![Benchmarks](https://img.shields.io/badge/benchmarks-13-blueviolet.svg)](benchmarks/)
+[![Benchmarks](https://img.shields.io/badge/benchmarks-16-blueviolet.svg)](benchmarks/)
 [![Surveys](https://img.shields.io/badge/meta_surveys-6-yellow.svg)](docs/meta-surveys.md)
 [![Updated](https://img.shields.io/badge/updated-2026--06-lightgrey.svg)](docs/signals.md)
 
@@ -59,7 +59,7 @@
 | full / seed 论文笔记 | 7 个 full + 7 个 seed | [`papers/`](papers/) | 为架构决策引用人工阅读笔记。 |
 | 记忆产品笔记 | 38 个笔记 | [`products/`](products/) | 对比 memory layer、memory SDK、managed memory 和带记忆的 agent 产品。 |
 | 产品页面快照 | 37 个快照 | [`products/archives/`](products/archives/) | 在源页面变化后审计产品 claims。 |
-| Benchmark 目录 | 13 个 catalog 行 | [`benchmarks/index.md`](benchmarks/index.md) | 理解 memory benchmark、stub-backed 候选行及其 claims 来源。 |
+| Benchmark 目录 | 16 个 catalog 行 | [`benchmarks/index.md`](benchmarks/index.md) | 理解 memory benchmark、stub-backed 候选行及其 claims 来源。 |
 | Claims ledger | 结构化 YAML ledger | [`benchmarks/claims/claims.yaml`](benchmarks/claims/claims.yaml) | 区分厂商自报、论文评测、方法批评和独立复现。 |
 | 综述与 taxonomy | 1 份活综述 + 6 条 meta-survey 记录 | [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) · [`docs/meta-surveys.md`](docs/meta-surveys.md) | 在选型或设计前建立领域视角。 |
 | Impact reports | 目前只有模板 | [`impact-reports/README.md`](impact-reports/README.md) | 把强证据提升为 memory-kernel 架构建议。 |
@@ -144,7 +144,7 @@ flowchart LR
 | [`papers/stubs/`](papers/stubs/) | 988 个尚未 full 阅读论文的生成 stub。 |
 | [`papers/pdfs/`](papers/pdfs/) | 534 个本地 PDF，约 1.8 GB。详见下方存档策略。 |
 | [`papers/_scrape/`](papers/_scrape/) | 可复现产物：抓取脚本和 dedup JSON。 |
-| [`benchmarks/`](benchmarks/) | 13 个 benchmark catalog 行，包含协议笔记、stub-backed 候选行和笔记模板。 |
+| [`benchmarks/`](benchmarks/) | 16 个 benchmark catalog 行，包含协议笔记、stub-backed 候选行和笔记模板。 |
 | [`benchmarks/claims/`](benchmarks/claims/) | benchmark 提及、厂商自报、方法批评和复现的 usage-event ledger。 |
 | [`benchmarks/archives/`](benchmarks/archives/) | benchmark 页面、repo 或 dataset card 的可选审计快照。 |
 | [`docs/benchmarks-landscape.md`](docs/benchmarks-landscape.md) | 按能力、使用方式和证据独立性整理的 benchmark 全景。 |

--- a/benchmarks/claims/claims.yaml
+++ b/benchmarks/claims/claims.yaml
@@ -94,6 +94,76 @@ events:
     evidence_refs:
       - benchmarks/gatemem.md
     extract_confidence: medium
+  - event_id: structmemeval-origin-2026
+    benchmark_id: structmemeval
+    source_kind: paper
+    source_id: https://arxiv.org/abs/2602.11243
+    source_date: 2026-02
+    actor: StructMemEval authors
+    actor_type: paper_authors
+    usage_type: originates_benchmark
+    claim_direction: methodological_only
+    compared_systems: []
+    reported_metrics: []
+    experimental_setup: "Preprint introduces structured memory organization tasks beyond factual recall; local note is seed quality."
+    reproduction_status: not_reproduced
+    evidence_level: primary_pdf
+    independence_class: survey_only
+    comparability_notes: "Core benchmark candidate; arXiv is the primary preprint, while the supplementary repo calls it a working paper; protocol/results still need full normalization."
+    evidence_refs:
+      - benchmarks/structmemeval.md
+      - https://arxiv.org/abs/2602.11243
+    extract_confidence: medium
+  - event_id: memoryrewardbench-origin-2026
+    benchmark_id: memoryrewardbench
+    source_kind: paper
+    source_id: papers/stubs/memoryrewardbench-benchmarking-reward-models-for-long-term.md
+    source_date: 2026-01
+    actor: MemoryRewardBench authors
+    actor_type: paper_authors
+    usage_type: originates_benchmark
+    claim_direction: methodological_only
+    compared_systems: []
+    reported_metrics: []
+    experimental_setup: "Benchmark for reward models judging long-term memory management across 10 settings and 8K-128K contexts; source note is stub quality."
+    reproduction_status: not_reproduced
+    evidence_level: primary_pdf
+    independence_class: survey_only
+    comparability_notes: "Evaluator benchmark only; do not treat as direct end-agent memory quality evidence."
+    evidence_refs:
+      - benchmarks/memoryrewardbench.md
+      - papers/stubs/memoryrewardbench-benchmarking-reward-models-for-long-term.md
+      - https://arxiv.org/abs/2601.11969
+    extract_confidence: medium
+  - event_id: fact-memory-vs-long-context-baseline-2026
+    benchmark_id: fact-memory-vs-long-context
+    source_kind: paper
+    source_id: papers/stubs/beyond-the-context-window-a-cost-performance-analysis-of.md
+    source_date: 2026-03
+    actor: Beyond the Context Window authors
+    actor_type: paper_authors
+    usage_type: baseline_comparison
+    claim_direction: mixed
+    compared_systems:
+      - fact-based memory
+      - long-context LLM
+    reported_metrics:
+      - metric: accuracy
+        value: "reported across LongMemEval, LoCoMo, PersonaMem-v2 in source paper"
+        unit: source_claim
+      - metric: cumulative_api_cost
+        value: "reported as cost-performance and break-even analysis"
+        unit: source_claim
+    experimental_setup: "Meta-protocol comparing fact-based memory with long-context inference on existing memory benchmarks; source note is stub quality."
+    reproduction_status: not_reproduced
+    evidence_level: primary_pdf
+    independence_class: affiliated_eval
+    comparability_notes: "Cost-performance analysis, not a standalone new dataset; API-pricing assumptions are time-sensitive."
+    evidence_refs:
+      - benchmarks/fact-based-memory-vs-long-context.md
+      - papers/stubs/beyond-the-context-window-a-cost-performance-analysis-of.md
+      - https://arxiv.org/abs/2603.04814
+    extract_confidence: medium
   - event_id: mem0-paper-locomo-2025
     benchmark_id: locomo
     source_kind: paper

--- a/benchmarks/fact-based-memory-vs-long-context.md
+++ b/benchmarks/fact-based-memory-vs-long-context.md
@@ -1,0 +1,102 @@
+---
+title: Fact-based memory vs long-context cost-performance benchmark
+benchmark_id: fact-memory-vs-long-context
+name: Fact-based memory vs long-context cost-performance
+aliases:
+  - Beyond the Context Window
+  - Cost-Performance Analysis of Fact-Based Memory vs. Long-Context LLMs
+status: candidate
+origin_type: paper_origin
+origin_source: ../papers/stubs/beyond-the-context-window-a-cost-performance-analysis-of.md
+first_public_date: 2026-03
+domain: memory_vs_long_context_tradeoff
+modality: text
+task_grain: persistent_agent_cost_accuracy_analysis
+capability_axes:
+  - memory_vs_context_cost
+  - factual_recall
+  - persona_consistency
+  - cumulative_api_cost
+dataset_size:
+  benchmark_inputs: "LongMemEval, LoCoMo, PersonaMem-v2"
+data_nature: derived_from_existing_benchmarks
+metrics:
+  - accuracy
+  - cumulative_api_cost
+  - break_even_turns
+judge_type: inherited_from_source_benchmarks
+code_available: check
+data_available: check
+license: check
+known_limitations:
+  - source is still a paper stub in this repo
+  - compares one fact-based memory implementation against long-context inference
+  - not a standalone memory capability benchmark
+canonical_sources:
+  - ../papers/stubs/beyond-the-context-window-a-cost-performance-analysis-of.md
+  - https://arxiv.org/abs/2603.04814
+confidence: low
+memory_modules:
+  - evaluator-benchmark
+  - context-packer
+  - retriever-reranker
+last_revised: 2026-06-24
+---
+
+# Fact-based memory vs long-context cost-performance
+
+## What It Measures
+
+This candidate benchmark tracks the production trade-off between passing full
+conversation history to a long-context LLM and maintaining a fact-based memory
+system. It is useful because agent-memory systems need cost and accuracy
+criteria, not only recall metrics.
+
+## Dataset / Scale
+
+The paper compares on LongMemEval, LoCoMo, and PersonaMem-v2. It also models
+cumulative API cost over interaction turns.
+
+## Protocol
+
+The protocol compares a fact-based memory system against long-context inference
+under persistent-agent workloads. It should be treated as a cost-performance
+analysis framework rather than a standalone new dataset.
+
+## Metrics and Judging
+
+Metrics include factual recall accuracy, cumulative API cost, and reported
+break-even turns. Judge details are inherited from the underlying benchmark
+tasks and need source normalization.
+
+## Baselines and Reported Results
+
+The arXiv abstract reports that long-context GPT-5-mini has stronger factual
+recall on LongMemEval and LoCoMo, while the memory system is competitive on
+PersonaMem-v2; it also reports a cost break-even around ten turns at 100K
+tokens. Treat these as source-paper claims until normalized.
+
+## Validity / Contamination / License Caveats
+
+- Candidate quality only.
+- The comparison is implementation-specific and should not be generalized to all
+  memory layers without reruns.
+- API-pricing assumptions are time-sensitive.
+
+## Comparability Notes
+
+Use this row for cost/accuracy trade-off planning. Do not mix it into pure
+memory-capability leaderboards.
+
+## Related Papers
+
+- [`../papers/stubs/beyond-the-context-window-a-cost-performance-analysis-of.md`](../papers/stubs/beyond-the-context-window-a-cost-performance-analysis-of.md)
+
+## Related Products
+
+- [`../products/mem0.md`](../products/mem0.md)
+
+## Impact Use
+
+- Ready for ImpactReport: no.
+- Recommended use: evaluator lane for memory-vs-context economic trade-offs.

--- a/benchmarks/index.md
+++ b/benchmarks/index.md
@@ -33,7 +33,10 @@ official repository, dataset card, or independent reproduction.
 | ConvoMem | full | paper-origin | conversational memory scaling | multi-evidence / preference / abstention | [`convomem.md`](convomem.md) | yes |
 | MemoryAgentBench | seed | paper-origin | incremental multi-turn agent memory | retrieval / learning / long-range / forgetting | [`memoryagentbench.md`](memoryagentbench.md) | yes |
 | GateMem | seed | paper-origin | multi-principal shared memory governance | utility / access control / active forgetting | [`gatemem.md`](gatemem.md) | backlog |
+| StructMemEval | seed | paper-origin | structured memory organization | structure selection / state tracking / task-specific organization | [`structmemeval.md`](structmemeval.md) | yes |
 | BEAM | candidate | paper-origin | million-token memory scale | long-scale recall / temporal degradation | [`beam.md`](beam.md) | yes |
+| MemoryRewardBench | candidate | paper-origin | reward models for memory management | memory-quality judging / reward-model calibration | [`memoryrewardbench.md`](memoryrewardbench.md) | yes |
+| Fact-based memory vs long-context | candidate | paper-origin | memory-vs-context cost analysis | cost / accuracy / break-even turns | [`fact-based-memory-vs-long-context.md`](fact-based-memory-vs-long-context.md) | yes |
 | RealMem | candidate | paper-origin | real-world memory-driven interaction | multi-source / real-world interaction | [`../papers/stubs/realmem-benchmarking-llms-in-real-world-memory-driven.md`](../papers/stubs/realmem-benchmarking-llms-in-real-world-memory-driven.md) | backlog |
 | CloneMem | candidate | paper-origin | AI clone memory | identity continuity / personalization | [`../papers/stubs/clonemem-benchmarking-long-term-memory-for-ai-clones.md`](../papers/stubs/clonemem-benchmarking-long-term-memory-for-ai-clones.md) | backlog |
 | KnowMe-Bench | candidate | paper-origin | lifelong digital companion memory | person understanding / personalization | [`../papers/stubs/knowme-bench-benchmarking-person-understanding-for-lifelong.md`](../papers/stubs/knowme-bench-benchmarking-person-understanding-for-lifelong.md) | backlog |

--- a/benchmarks/memoryrewardbench.md
+++ b/benchmarks/memoryrewardbench.md
@@ -1,0 +1,95 @@
+---
+title: MemoryRewardBench — reward-model evaluation for long-term memory management
+benchmark_id: memoryrewardbench
+name: MemoryRewardBench
+aliases:
+  - MemRewardBench
+status: candidate
+origin_type: paper_origin
+origin_source: ../papers/stubs/memoryrewardbench-benchmarking-reward-models-for-long-term.md
+first_public_date: 2026-01
+domain: memory_quality_judging
+modality: text
+task_grain: reward_model_preference_judgment
+capability_axes:
+  - memory_quality_judging
+  - long_context_memory_management
+  - reward_model_calibration
+dataset_size:
+  context_length: "8K-128K tokens"
+  settings: 10
+data_nature: check
+metrics:
+  - reward_model_accuracy
+  - preference_judgment_quality
+judge_type: reward_model
+code_available: yes
+data_available: check
+license: check
+known_limitations:
+  - source is still a paper stub in this repo
+  - evaluates reward models for memory management, not end-agent memory quality directly
+canonical_sources:
+  - ../papers/stubs/memoryrewardbench-benchmarking-reward-models-for-long-term.md
+  - https://arxiv.org/abs/2601.11969
+  - https://github.com/LCM-Lab/MemRewardBench
+confidence: low
+memory_modules:
+  - evaluator-benchmark
+last_revised: 2026-06-24
+---
+
+# MemoryRewardBench
+
+## What It Measures
+
+MemoryRewardBench evaluates whether reward models can judge long-term memory
+management processes. It is relevant to this repo because memory kernels need
+quality signals for memory writes, summaries, and retained context, but it is
+one step removed from direct agent-memory task performance.
+
+## Dataset / Scale
+
+The arXiv abstract reports 10 settings with different memory management
+patterns and context lengths from 8K to 128K tokens. Dataset size, splits, and
+license should be checked before using the benchmark for decisions.
+
+## Protocol
+
+The benchmark asks reward models to evaluate memory quality across long-context
+comprehension and long-form generation settings. Protocol details remain
+candidate quality until the source stub is upgraded.
+
+## Metrics and Judging
+
+Metrics are reward-model judgment quality and calibration style measures. Exact
+metric definitions need source normalization.
+
+## Baselines and Reported Results
+
+The paper reports evaluation over 13 reward models. This repo does not yet
+normalize those results.
+
+## Validity / Contamination / License Caveats
+
+- Candidate quality only.
+- It is most useful as a meta-evaluator benchmark for memory-management
+  judgments, not as a direct product leaderboard.
+
+## Comparability Notes
+
+Do not compare MemoryRewardBench scores with agent task benchmarks such as
+MemoryAgentBench, LongMemEval, or LoCoMo.
+
+## Related Papers
+
+- [`../papers/stubs/memoryrewardbench-benchmarking-reward-models-for-long-term.md`](../papers/stubs/memoryrewardbench-benchmarking-reward-models-for-long-term.md)
+
+## Related Products
+
+-
+
+## Impact Use
+
+- Ready for ImpactReport: no.
+- Recommended use: backlog item for evaluator and critic-model selection.

--- a/benchmarks/structmemeval.md
+++ b/benchmarks/structmemeval.md
@@ -1,0 +1,103 @@
+---
+title: StructMemEval — memory-structure organization benchmark
+benchmark_id: structmemeval
+name: StructMemEval
+aliases:
+  - Evaluating Memory Structure in LLM Agents
+status: seed
+origin_type: paper_origin
+origin_source: https://arxiv.org/abs/2602.11243
+first_public_date: 2026-02
+domain: structured_memory_organization
+modality: text
+task_grain: structured_task_suite
+capability_axes:
+  - memory_structure_selection
+  - structured_state_tracking
+  - task_specific_organization
+  - retrieval_beyond_fact_recall
+dataset_size:
+  task_families: "accounting, tree-based, state tracking, recommendations"
+data_nature: synthetic_structured_tasks
+metrics:
+  - task_accuracy
+judge_type: deterministic_or_task_specific
+code_available: yes
+data_available: yes
+license: Apache-2.0 code; dataset license check
+known_limitations:
+  - seed note; full protocol, splits, and result tables still need normalization
+  - source emphasizes prompting memory agents to use an appropriate structure
+canonical_sources:
+  - https://arxiv.org/abs/2602.11243
+  - https://github.com/yandex-research/StructMemEval
+confidence: medium
+memory_modules:
+  - evaluator-benchmark
+  - parser-chunker
+  - retriever-reranker
+last_revised: 2026-06-24
+---
+
+# StructMemEval
+
+## What It Measures
+
+StructMemEval tests whether an LLM agent can organize long-term memory into
+task-useful structures instead of only recalling facts. The paper frames this as
+a gap in existing long-term memory benchmarks, which often measure simple
+fact retention, multi-hop recall, or temporal updates but do not stress complex
+memory hierarchies.
+
+## Dataset / Scale
+
+The supplementary repository lists raw benchmark data for accounting,
+tree-based, state-machine location, and recommendation-style tasks. The exact
+split sizes and license details still need a full source read before this note
+can support ImpactReport-grade claims.
+
+## Protocol
+
+Tasks are designed around structures that humans would naturally maintain, such
+as transaction ledgers, to-do lists, trees, and state trackers. The key protocol
+question is whether the agent can choose and maintain the right structure for
+the task, not merely retrieve a stored fact.
+
+## Metrics and Judging
+
+The primary metric is task accuracy. Judge implementation and confidence
+reporting need source normalization.
+
+## Baselines and Reported Results
+
+The arXiv abstract reports that simple retrieval-augmented LLMs struggle on
+these tasks, while memory agents can perform reliably when prompted to organize
+memory. Treat that as paper-origin evidence only until results are fully
+normalized here.
+
+## Validity / Contamination / License Caveats
+
+- This note is seed quality.
+- The benchmark may be sensitive to prompt hints that tell an agent which
+  memory structure to use.
+- Code appears to be Apache-2.0 in the supplementary repository; dataset
+  redistribution status still needs a full check.
+
+## Comparability Notes
+
+StructMemEval is not directly comparable to LoCoMo, LongMemEval, or ConvoMem:
+it targets memory organization and structure selection rather than conversational
+fact recall.
+
+## Related Papers
+
+- [arXiv 2602.11243](https://arxiv.org/abs/2602.11243)
+
+## Related Products
+
+-
+
+## Impact Use
+
+- Ready for ImpactReport: no, upgrade to full note first.
+- Recommended use: add an evaluator lane for structure-aware memory tasks.

--- a/docs/benchmarks-landscape.md
+++ b/docs/benchmarks-landscape.md
@@ -24,7 +24,10 @@ language: zh-CN
 | 对话记忆规模曲线 | [`ConvoMem`](../benchmarks/convomem.md) | long-context vs block extraction vs RAG crossover | full,同时批评 LongMemEval/LoCoMo |
 | agent 记忆能力维度 | [`MemoryAgentBench`](../benchmarks/memoryagentbench.md) | retrieval / test-time learning / long-range / forgetting | seed,适合定义能力轴 |
 | shared-memory governance | [`GateMem`](../benchmarks/gatemem.md) | utility / access control / active forgetting | seed,6 月新增治理 benchmark |
+| 结构化记忆组织 | [`StructMemEval`](../benchmarks/structmemeval.md) | structure selection / state tracking / task-specific organization | seed,FeishuLuo survey 查漏后新增;primary arXiv + working-paper repo |
 | 百万 token 规模 | [`BEAM`](../benchmarks/beam.md) | 1M/10M 长尺度记忆退化 | candidate,目前主要来自 Mem0 自报 |
+| memory evaluator | [`MemoryRewardBench`](../benchmarks/memoryrewardbench.md) | reward model judging for long-term memory management | candidate,评估 reward models 而非 end-agent memory |
+| memory vs long-context economics | [`Fact-based memory vs long-context`](../benchmarks/fact-based-memory-vs-long-context.md) | cost / accuracy / break-even turns | candidate,meta-protocol/成本分析,不是独立新数据集 |
 | 真实交互 / persona | RealMem / CloneMem / KnowMe-Bench / PersonaMem-v2 | real-world memory, identity continuity, companion personalization | candidate,先列入 backlog |
 | agent 任务 / 多 agent | LoCoBench-Agent / MemoryArena / MemBench | coding agent, shared memory conflict, write/manage 评测 | candidate,需升级 source note |
 
@@ -42,6 +45,9 @@ language: zh-CN
 | BEAM | 2 | Mem0 BEAM 1M / 10M vendor claims |
 | MemoryAgentBench | 2 | origin + survey mention |
 | GateMem | 1 | origin paper logged; metrics/results not yet normalized |
+| StructMemEval | 1 | origin paper logged; protocol/results not yet normalized |
+| MemoryRewardBench | 1 | origin paper logged; evaluator benchmark only |
+| Fact-based memory vs long-context | 1 | source-paper cost analysis over existing benchmarks |
 | PersonaMem-v2 | 2 | Hy-Memory + TencentDB Agent Memory self-claims |
 | MemBench | 1 | survey mention |
 | MemoryArena | 1 | survey mention |
@@ -52,6 +58,7 @@ language: zh-CN
 |---|---:|---|
 | LoCoMo | 1 | Mem0 paper affiliated evaluation; useful for paper analysis, not independent reproduction |
 | ConvoMem | 1 | Origin paper baseline comparison against Mem0-style RAG; useful for protocol/crossover analysis |
+| Fact-based memory vs long-context | 1 | Source-paper comparison of fact-based memory against long-context inference; useful for cost/accuracy trade-off analysis, not independent reproduction |
 
 ### B3. Vendor claims
 
@@ -106,21 +113,41 @@ language: zh-CN
 | `independent_report` | Needed before a claim becomes independent reproduction. |
 | `survey_mention` | Useful for discovery and prioritization, not score/ranking evidence. |
 
-## D. Next Upgrade Queue
+## D. FeishuLuo Survey Intake (2026-06-24)
 
-1. Upgrade LoCoMo from seed to full because it is the most product-used
+The [FeishuLuo companion list](https://github.com/FeishuLuo/Evolving-LLM-Agent-Memory-Survey)
+for **From Storage to Experience** is useful as a discovery source, but it is not
+primary evidence. This intake keeps source classes explicit before any row
+enters the catalog.
+
+| Decision | Candidate | Handling | Caveat |
+|---|---|---|---|
+| add | [`StructMemEval`](../benchmarks/structmemeval.md) | Core structured-memory benchmark candidate. | Primary source is arXiv 2602.11243; supplementary repo calls it a working paper. |
+| add | [`MemoryRewardBench`](../benchmarks/memoryrewardbench.md) | Evaluator benchmark for memory-management reward models. | Not direct end-agent memory quality. |
+| add | [`Fact-based memory vs long-context`](../benchmarks/fact-based-memory-vs-long-context.md) | Meta-protocol for cost/accuracy comparison against long-context inference. | Not a standalone new dataset; pricing assumptions drift. |
+| adjacent | HELMET(arXiv 2410.02694) | Keep out of core catalog unless a memory paper/product uses it as a baseline. | General long-context benchmark. |
+| watchlist | arXiv 2510.17132 | Track only under the primary title, "Do LLMs Recognize Your Latent Preferences?" | Feishu row title is mismatched; do not import as "LLM Self-Awareness via Internal Circuits." |
+| reject label | "LLM Self-Awareness via Internal Circuits" / 2510.17132 | Reject the title/link pairing as-is. | Likely intended self-awareness paper is a different arXiv ID. |
+
+## E. Next Upgrade Queue
+
+1. Upgrade StructMemEval because it is the most direct new benchmark for memory
+   structure selection and organization.
+2. Upgrade LoCoMo from seed to full because it is the most product-used
    benchmark in current notes.
-2. Upgrade BEAM source before using Mem0's 1M/10M claims in any decision.
-3. Upgrade PersonaMem-v2 because TencentDB Agent Memory and Hy-Memory both cite
+3. Upgrade BEAM source before using Mem0's 1M/10M claims in any decision.
+4. Upgrade PersonaMem-v2 because TencentDB Agent Memory and Hy-Memory both cite
    PersonaMem-style claims.
-4. Promote MemoryArena and MemBench if multi-agent conflict or write/manage
+5. Upgrade MemoryRewardBench only when reward-model judging becomes an evaluator
+   priority.
+6. Promote MemoryArena and MemBench if multi-agent conflict or write/manage
    evaluation becomes a kernel priority.
-5. Upgrade GateMem if shared-memory governance or enterprise scoped recall becomes
+7. Upgrade GateMem if shared-memory governance or enterprise scoped recall becomes
    a kernel priority.
-6. Add independent reproduction rows only when the source gives enough setup
+8. Add independent reproduction rows only when the source gives enough setup
    detail to distinguish reruns from marketing summaries.
 
-## E. Maintenance Contract
+## F. Maintenance Contract
 
 - New benchmark protocol -> add or update `../benchmarks/<slug>.md`.
 - New product score -> add a `vendor_claim` event, not a leaderboard row.

--- a/papers/from-storage-to-experience.md
+++ b/papers/from-storage-to-experience.md
@@ -19,7 +19,7 @@ memory_modules:
   - retriever-reranker
   - evaluator-benchmark
 status: full
-last_revised: 2026-05-19
+last_revised: 2026-06-24
 ---
 
 # From Storage to Experience(arXiv 2605.06716)
@@ -116,6 +116,10 @@ PDF 在 §8 提到 LongMemEval、MemBench 都不足以衡量 experience-level �
 - §5.4 active exploration 章节列举的论文(本 radar 未一一抄录)值得补 stub。
 - 评估 K(rule set)的 transferability 没有现成 benchmark,`evaluator-
   benchmark` 模块可以把这个空白作为 v2 自研方向。
+- 配套 GitHub list
+  ([FeishuLuo/Evolving-LLM-Agent-Memory-Survey](https://github.com/FeishuLuo/Evolving-LLM-Agent-Memory-Survey))
+  可作为 benchmark discovery source,但进入本仓 catalog 前必须回到 arXiv /
+  OpenReview / ACL / 官方 repo 等 primary source 核验。
 
 ---
 


### PR DESCRIPTION
## Summary
- Add FeishuLuo/Evolving-LLM-Agent-Memory-Survey as a benchmark discovery source only, not a primary evidence source.
- Add benchmark notes/catalog rows for StructMemEval, MemoryRewardBench, and Fact-based memory vs long-context.
- Keep HELMET as adjacent long-context evidence and reject the mismatched `LLM Self-Awareness via Internal Circuits` / `2510.17132` title-link pairing.
- Update README/README_cn benchmark counts from 13 to 16.

## Review Outcome
- Final code-reviewer verdict: APPROVE.
- Accepted: StructMemEval, MemoryRewardBench, Fact-based memory vs long-context.
- Watchlist: arXiv 2510.17132 under its actual title, not the Feishu mismatched label.
- Adjacent/reject: HELMET remains adjacent; the mismatched self-awareness label is rejected as-is.

## Validation
- `rg -n '<<<<<<<|=======|>>>>>>>' README.md README_cn.md docs benchmarks papers`
- `ruby --disable-gems -e 'require "yaml"; YAML.load_file("benchmarks/claims/claims.yaml"); puts "claims.yaml parsed"'`
- benchmark count/token Ruby check: 16 catalog rows and README/README_cn sync
- changed Markdown local-link Ruby check
- benchmark/event duplicate Ruby check
- targeted source reachability check for FeishuLuo + arXiv URLs
- `git diff --check`

## Known Gaps
- No full external link crawl.
- No full-paper reads for the three new benchmark papers in this pass.
