### PR TITLE
Automate weekly memory radar refreshes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,15 +12,18 @@ decide what to read before opening the paper index or the product notes.
 3. [`research-radar.md`](research-radar.md) — workflow for turning papers,
    products, and benchmark evidence into ResearchItems, ImpactReports,
    experiments, and ADRs.
-4. [`memory-radar-2026-06.md`](memory-radar-2026-06.md) — latest current-source
+4. [`weekly-memory-refresh-runbook.md`](weekly-memory-refresh-runbook.md) —
+   Codex weekly refresh runbook for papers, products, GitHub discovery, and
+   benchmarks.
+5. [`memory-radar-2026-06.md`](memory-radar-2026-06.md) — latest current-source
    refresh across papers, products, GitHub projects, and reviewer decisions.
-5. [`benchmarks-landscape.md`](benchmarks-landscape.md) — benchmark map by
+6. [`benchmarks-landscape.md`](benchmarks-landscape.md) — benchmark map by
    capability, usage type, and evidence independence.
-6. [`products-landscape.md`](products-landscape.md) — product map by domain and
+7. [`products-landscape.md`](products-landscape.md) — product map by domain and
    audience.
-7. [`product-architecture-diagrams.md`](product-architecture-diagrams.md) —
+8. [`product-architecture-diagrams.md`](product-architecture-diagrams.md) —
    architecture diagrams for the current memory product notes.
-8. [`product-memory-architectures.md`](product-memory-architectures.md) —
+9. [`product-memory-architectures.md`](product-memory-architectures.md) —
    cross-product memory architecture patterns and comparison tables.
 
 ## Concept docs
@@ -41,6 +44,7 @@ decide what to read before opening the paper index or the product notes.
 | File | Purpose |
 |---|---|
 | [`research-radar.md`](research-radar.md) | Generic Radar loop: paper/product/benchmark -> ResearchItem or BenchmarkItem -> ImpactReport -> sandbox -> ADR. |
+| [`weekly-memory-refresh-runbook.md`](weekly-memory-refresh-runbook.md) | Weekly Codex automation contract for source search, subagent review, verification, and PR output. |
 | [`memory-radar-2026-06.md`](memory-radar-2026-06.md) | 2026-06 current-source refresh with must-add, update-existing, watchlist, and reject decisions. |
 | [`information-sources.md`](information-sources.md) | Source catalog for papers, products, communities, and zh-CN information channels. |
 | [`related-work.md`](related-work.md) | Positioning against sibling agent-memory awesome-lists. |

--- a/docs/research-radar.md
+++ b/docs/research-radar.md
@@ -187,6 +187,7 @@ v1:
 - 定期 radar:每周/每月扫描论文和产品更新
 - 自动归类到 taxonomy
 - 半自动生成 ImpactReport 草稿
+- 每周 Codex 执行契约见 [`weekly-memory-refresh-runbook.md`](weekly-memory-refresh-runbook.md)
 
 v2:
 - 自动 benchmark / shadow run

--- a/docs/weekly-memory-refresh-runbook.md
+++ b/docs/weekly-memory-refresh-runbook.md
@@ -22,6 +22,10 @@ The Codex App owns the schedule:
 - base ref: fetch and start from the latest `origin/main`;
 - output gate: create a PR only when verified changes exist.
 
+Only the reusable behavior contract belongs in this repository. Local Codex
+automation IDs, cron registration details, machine-specific paths, and
+credentials stay in the local Codex automation store or private environment.
+
 Each weekly run should refresh `awesome-agent-memory` across four evidence
 surfaces:
 
@@ -139,6 +143,11 @@ Always run:
 ruby scripts/verify_memory_refresh.rb
 git diff --check
 ```
+
+Run the final structural verifier against the staged or PR tree, not against a
+loose scratch workspace. The verifier intentionally derives counts and duplicate
+checks from Git-tracked files so temporary local artifacts do not affect public
+catalog counts.
 
 Also run a targeted source reachability check for canonical URLs added or
 changed in the weekly run. This can be `curl -L -s -o /dev/null -w ...` or an

--- a/docs/weekly-memory-refresh-runbook.md
+++ b/docs/weekly-memory-refresh-runbook.md
@@ -15,9 +15,9 @@ accepted item must still be grounded in primary evidence.
 
 The Codex App owns the schedule:
 
-- automation id: `awesome-agent-memory-weekly-radar-refresh`;
+- recommended local automation name: `awesome-agent-memory weekly radar refresh`;
 - cadence: weekly cron, Monday 09:00 in the user's local timezone;
-- workspace: `/Users/yyl-macbookpro/Program/awesome-agent-memory`;
+- workspace: `<repo-root>`;
 - execution environment: isolated Codex worktree;
 - base ref: fetch and start from the latest `origin/main`;
 - output gate: create a PR only when verified changes exist.

--- a/docs/weekly-memory-refresh-runbook.md
+++ b/docs/weekly-memory-refresh-runbook.md
@@ -1,0 +1,154 @@
+---
+title: Weekly Memory Refresh Runbook
+date: 2026-06-24
+status: working-spec
+language: zh-CN
+---
+
+# Weekly Memory Refresh Runbook
+
+This runbook turns the manual memory-radar refresh into a repeatable Codex job.
+It is intentionally conservative: automation reduces missed signals, but every
+accepted item must still be grounded in primary evidence.
+
+## 1. Weekly Objective
+
+The Codex App owns the schedule:
+
+- automation id: `awesome-agent-memory-weekly-radar-refresh`;
+- cadence: weekly cron, Monday 09:00 in the user's local timezone;
+- workspace: `/Users/yyl-macbookpro/Program/awesome-agent-memory`;
+- execution environment: isolated Codex worktree;
+- base ref: fetch and start from the latest `origin/main`;
+- output gate: create a PR only when verified changes exist.
+
+Each weekly run should refresh `awesome-agent-memory` across four evidence
+surfaces:
+
+- papers: new arXiv, OpenReview, ACL Anthology, and major-conference entries;
+- products: official memory product docs, release notes, and product pages;
+- GitHub / lists: repositories, benchmark lists, and companion survey repos as
+  discovery signals only;
+- benchmarks: protocol notes, claims-ledger events, adjacent baselines, and
+  source mismatches.
+
+The job must end in exactly one of two states:
+
+- a ready pull request with verified docs/evidence changes; or
+- a no-change weekly report that explains the search scope and why nothing was
+  promoted.
+
+Do not merge the PR automatically. Do not create an empty PR.
+
+## 2. Source Targets
+
+Use official and primary sources first.
+
+| Lane | Primary targets | Notes |
+|---|---|---|
+| Papers | arXiv, OpenReview, ACL Anthology, conference pages for ICLR / ICML / NeurIPS / ACL / EMNLP / COLM | Prefer paper pages, PDFs, official code, and conference metadata over summaries. |
+| Products | AWS, Google, Microsoft, Cloudflare, OpenAI, Anthropic, Letta, Mem0, Zep, Graphiti, LangGraph / LangMem, Redis, Tencent, Alibaba, Oracle | Vendor pages support product-behavior claims, not independent performance conclusions. |
+| GitHub / lists | GitHub repos, GitHub topics, release pages, FeishuLuo-style companion lists, MCP catalogs | Discovery only. Stars and README prose are weak signals until checked against source docs or papers. |
+| Benchmarks | benchmark papers, dataset cards, official repositories, independent reproductions | Separate origin protocol, vendor claim, affiliated eval, independent reproduction, and critique. |
+
+## 3. Subagent Plan
+
+Use up to six Codex subagents. Keep prompts bounded and ask each subagent for
+candidate rows plus evidence URLs and rejection rationale.
+
+| Subagent | Responsibility | Output |
+|---|---|---|
+| `researcher/papers` | Search current paper sources for agent-memory and memory-benchmark updates. | Candidate papers with title, date, venue/source, URL, why relevant, and likely landing file. |
+| `researcher/products` | Search official product docs/blogs/release notes. | Product candidates, official source URLs, product capability summary, evidence class. |
+| `researcher/github-benchmarks` | Search GitHub projects, benchmark lists, and survey companion repos. | Discovery candidates only, with license/activity/readme evidence and primary-source follow-up links. |
+| `explore/repo-map` | Inspect this repository for existing entries, aliases, counts, and landing files. | Duplicate-risk map and exact files that need updates. |
+| `verifier/source-check` | Re-check candidate URLs, dates, titles, evidence class, and availability. | Verified / needs-verification / inaccessible decisions with source URLs. |
+| `critic/relevance-review` | Score relevance and evidence strength. | `must-add`, `update-existing`, `watchlist`, `adjacent`, and `reject` lists. |
+
+The main agent owns integration. It must not delegate final classification or
+README count synchronization.
+
+## 4. Promotion Rules
+
+Use the smallest durable change that preserves provenance.
+
+| Decision | Meaning | Required landing |
+|---|---|---|
+| `must-add` | Directly relevant memory paper/product/benchmark with primary source. | Add or update note plus the relevant landscape/index/ledger entry. |
+| `update-existing` | Existing entry needs date, source, venue, evidence, or caveat repair. | Update the existing note and every aggregate that depends on it. |
+| `watchlist` | Relevant but evidence, accessibility, or implementation status is not strong enough. | Mention in radar/discovery log only; do not count as a core item. |
+| `adjacent` | Useful context, but not first-class agent memory by itself. | Keep out of core counts unless a memory source uses it as a baseline. |
+| `reject` | Duplicate, mislabeled, inaccessible, generic, or out of scope. | Record reason in the relevant discovery/radar document when the item is likely to recur. |
+
+Hard rules:
+
+- Primary paper/product pages beat survey lists, GitHub stars, screenshots, and
+  third-party summaries.
+- Long-context-only benchmarks, generic agent frameworks, and prompt-cache
+  systems do not enter core memory counts by default.
+- Source mismatch is a blocker. Use the canonical title and URL, or reject the
+  mismatched pairing.
+- Vendor claims remain vendor or affiliated evidence unless an independent
+  reproduction gives enough setup detail.
+
+## 5. Integration Checklist
+
+For each accepted item, update all linked surfaces:
+
+- papers: `papers/index.md`, a full/seed note or existing stub, and radar docs;
+- products: `products/*.md`, optional archive, `docs/products-landscape.md`,
+  `docs/product-discovery-log.md`, `docs/signals.md`, and README counts;
+- benchmarks: `benchmarks/index.md`, `benchmarks/*.md`,
+  `benchmarks/claims/claims.yaml`, and `docs/benchmarks-landscape.md`;
+- synthesis: `docs/memory-radar-YYYY-MM.md` or current radar file when the run
+  changes weekly decisions;
+- public map: `README.md`, `README_cn.md`, and `docs/README.md` when counts or
+  entry points change.
+
+If no item is promoted, do not create a documentation-only noise PR. Produce a
+weekly report with searched sources, watchlist items, rejects, and blockers.
+
+## 6. PR Contract
+
+Create a branch named `codex/weekly-memory-radar-YYYY-MM-DD` from the latest
+`origin/main` inside the automation worktree. If the worktree starts from a
+stale base, fetch first and recreate or rebase the branch before editing.
+
+The automation should leave the worktree intact when a PR is created so follow-up
+review fixes can continue on the same branch. If no changes are promoted, report
+the no-change result and leave no branch-only noise behind.
+
+The PR body must include:
+
+- accepted additions;
+- updated existing entries;
+- watchlist items;
+- adjacent/rejected items;
+- source mismatches;
+- verification commands and results;
+- known gaps such as full external link crawl or full-paper reads not done.
+
+Use the repository's Lore commit protocol for the commit message. Do not merge
+the PR automatically.
+
+## 7. Verification
+
+Always run:
+
+```bash
+ruby scripts/verify_memory_refresh.rb
+git diff --check
+```
+
+Also run a targeted source reachability check for canonical URLs added or
+changed in the weekly run. This can be `curl -L -s -o /dev/null -w ...` or an
+equivalent browser/API check.
+
+Before creating the PR, run a final `code-reviewer` pass over the diff. The
+review must explicitly check:
+
+- duplicate papers/products/benchmarks and alias confusion;
+- README / README_cn / index / landscape / ledger count sync;
+- evidence class wording in `benchmarks/claims/claims.yaml`;
+- discovery sources not promoted to primary evidence;
+- adjacent/watchlist/reject decisions recorded when needed.

--- a/scripts/verify_memory_refresh.rb
+++ b/scripts/verify_memory_refresh.rb
@@ -1,0 +1,207 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "yaml"
+require "English"
+require "shellwords"
+
+ROOT = File.expand_path("..", __dir__)
+
+def read(path)
+  File.read(File.join(ROOT, path))
+end
+
+def fail_check(message)
+  warn "ERROR: #{message}"
+  exit 1
+end
+
+def assert(condition, message)
+  fail_check(message) unless condition
+end
+
+def badge_count(markdown, label)
+  escaped = Regexp.escape(label)
+  match = markdown.match(%r{img\.shields\.io/badge/#{escaped}-(\d+)-})
+  match && match[1].to_i
+end
+
+def tracked_files(pattern)
+  output = `git -C #{Shellwords.escape(ROOT)} ls-files #{Shellwords.escape(pattern)}`
+  fail_check("git ls-files failed for #{pattern}") unless $CHILD_STATUS.success?
+
+  output.lines.map(&:strip).reject(&:empty?).map { |path| File.join(ROOT, path) }
+end
+
+def count_benchmark_rows
+  read("benchmarks/index.md").lines.count do |line|
+    line.start_with?("| ") &&
+      !line.include?("---") &&
+      !line.start_with?("| Benchmark |")
+  end
+end
+
+def count_product_notes
+  Dir[File.join(ROOT, "products", "*.md")].count do |path|
+    base = File.basename(path)
+    base != "README.md" && !base.start_with?("_")
+  end
+end
+
+def count_product_archives
+  Dir[File.join(ROOT, "products", "archives", "*.md")].count do |path|
+    File.basename(path) != "README.md"
+  end
+end
+
+def count_pdfs
+  Dir[File.join(ROOT, "papers", "pdfs", "*")].count { |path| File.file?(path) }
+end
+
+def count_stubs
+  Dir[File.join(ROOT, "papers", "stubs", "*.md")].count
+end
+
+def paper_total_from_index
+  read("papers/index.md")[/Total unique papers:\s*(\d+)/, 1]&.to_i
+end
+
+def scan_conflict_markers
+  files = Dir[
+    File.join(ROOT, "{README.md,README_cn.md}"),
+    File.join(ROOT, "{docs,benchmarks,products,papers,impact-reports}", "**", "*.{md,yml,yaml}")
+  ]
+
+  offenders = files.select do |path|
+    body = File.read(path)
+    body.lines.any? { |line| line.match?(/\A(?:<{7}|={7}|>{7})(?:\s|$)/) }
+  end
+
+  assert(offenders.empty?, "conflict markers found in #{offenders.map { |p| p.delete_prefix("#{ROOT}/") }.join(", ")}")
+end
+
+def check_yaml
+  YAML.load_file(File.join(ROOT, "benchmarks", "claims", "claims.yaml"))
+end
+
+def check_counts
+  readme = read("README.md")
+  readme_cn = read("README_cn.md")
+
+  expected = {
+    "papers" => paper_total_from_index,
+    "local_PDFs" => count_pdfs,
+    "memory%20products" => count_product_notes,
+    "benchmarks" => count_benchmark_rows
+  }
+
+  expected.each do |label, value|
+    assert(!value.nil?, "could not calculate expected count for #{label}")
+    assert(badge_count(readme, label) == value, "README.md badge #{label} is not #{value}")
+    assert(badge_count(readme_cn, label) == value, "README_cn.md badge #{label} is not #{value}")
+  end
+
+  checks = {
+    "README.md" => [
+      "#{count_stubs} stubs",
+      "#{count_product_notes} notes",
+      "#{count_product_archives} snapshots",
+      "#{count_benchmark_rows} catalog rows",
+      "#{count_benchmark_rows} benchmark catalog rows"
+    ],
+    "README_cn.md" => [
+      "#{count_stubs} 个 stub",
+      "#{count_product_notes} 个笔记",
+      "#{count_product_archives} 个快照",
+      "#{count_benchmark_rows} 个 catalog 行",
+      "#{count_benchmark_rows} 个 benchmark catalog 行"
+    ]
+  }
+
+  checks.each do |file, tokens|
+    body = read(file)
+    tokens.each do |token|
+      assert(body.include?(token), "#{file} missing synchronized count token #{token.inspect}")
+    end
+  end
+end
+
+def extract_front_matter_value(path, key)
+  body = File.read(path)
+  body[/^#{Regexp.escape(key)}:\s*(.+)$/, 1]&.strip
+end
+
+def check_duplicates
+  claims = YAML.load_file(File.join(ROOT, "benchmarks", "claims", "claims.yaml"))
+  event_ids = claims.fetch("events").map { |event| event.fetch("event_id") }
+  dup_events = event_ids.group_by(&:itself).select { |_id, rows| rows.size > 1 }
+  assert(dup_events.empty?, "duplicate benchmark claim event_ids: #{dup_events.keys.join(", ")}")
+
+  benchmark_ids = Dir[File.join(ROOT, "benchmarks", "*.md")]
+                  .reject { |path| File.basename(path) == "_template.md" }
+                  .map { |path| [extract_front_matter_value(path, "benchmark_id"), path] }
+                  .reject { |value, _path| value.nil? || value.empty? }
+  dup_benchmarks = benchmark_ids.group_by(&:first).select { |_id, rows| rows.size > 1 }
+  assert(dup_benchmarks.empty?, "duplicate benchmark_ids: #{dup_benchmarks.keys.join(", ")}")
+
+  benchmark_titles = Dir[File.join(ROOT, "benchmarks", "*.md")]
+                     .reject { |path| File.basename(path) == "_template.md" }
+                     .map { |path| [extract_front_matter_value(path, "title"), path] }
+                     .reject { |value, _path| value.nil? || value.empty? }
+  dup_benchmark_titles = benchmark_titles.group_by { |value, _path| value.downcase }.select { |_value, rows| rows.size > 1 }
+  assert(dup_benchmark_titles.empty?, "duplicate benchmark titles: #{dup_benchmark_titles.keys.join(", ")}")
+
+  benchmark_names = Dir[File.join(ROOT, "benchmarks", "*.md")]
+                    .reject { |path| File.basename(path) == "_template.md" }
+                    .map { |path| [extract_front_matter_value(path, "name"), path] }
+                    .reject { |value, _path| value.nil? || value.empty? }
+  dup_benchmark_names = benchmark_names.group_by { |value, _path| value.downcase }.select { |_value, rows| rows.size > 1 }
+  assert(dup_benchmark_names.empty?, "duplicate benchmark names: #{dup_benchmark_names.keys.join(", ")}")
+
+  product_titles = Dir[File.join(ROOT, "products", "*.md")]
+                   .map { |path| [extract_front_matter_value(path, "title"), path] }
+                   .reject { |value, _path| value.nil? || value.empty? }
+  dup_product_titles = product_titles.group_by { |value, _path| value.downcase }.select { |_value, rows| rows.size > 1 }
+  assert(dup_product_titles.empty?, "duplicate product titles: #{dup_product_titles.keys.join(", ")}")
+
+  product_ids = Dir[File.join(ROOT, "products", "*.md")].map do |path|
+    explicit_id = extract_front_matter_value(path, "product_id")
+    [explicit_id || File.basename(path, ".md"), path]
+  end.reject { |value, _path| value.nil? || value.empty? }
+  dup_product_ids = product_ids.group_by { |value, _path| value.downcase }.select { |_value, rows| rows.size > 1 }
+  assert(dup_product_ids.empty?, "duplicate product ids/slugs: #{dup_product_ids.keys.join(", ")}")
+end
+
+def check_local_markdown_links
+  files = tracked_files("*.md") +
+          tracked_files("docs/**/*.md") +
+          tracked_files("benchmarks/**/*.md") +
+          tracked_files("products/**/*.md") +
+          tracked_files("papers/**/*.md") +
+          tracked_files("impact-reports/**/*.md")
+  files = files.uniq.select { |path| File.exist?(path) }
+
+  missing = []
+  files.each do |path|
+    body = File.read(path)
+    body.scan(/(?<!!)\[[^\]]+\]\(([^)]+)\)/).flatten.each do |raw_target|
+      target = raw_target.split(/[ #]/, 2).first
+      next if target.nil? || target.empty?
+      next if target.match?(/\A(?:https?:|mailto:|#)/)
+
+      candidate = File.expand_path(target, File.dirname(path))
+      missing << "#{path.delete_prefix("#{ROOT}/")}: #{raw_target}" unless File.exist?(candidate)
+    end
+  end
+
+  assert(missing.empty?, "missing local markdown links:\n#{missing.join("\n")}")
+end
+
+scan_conflict_markers
+check_yaml
+check_counts
+check_duplicates
+check_local_markdown_links
+
+puts "verify_memory_refresh passed"
+puts "papers=#{paper_total_from_index} pdfs=#{count_pdfs} stubs=#{count_stubs} products=#{count_product_notes} product_archives=#{count_product_archives} benchmarks=#{count_benchmark_rows}"

--- a/scripts/verify_memory_refresh.rb
+++ b/scripts/verify_memory_refresh.rb
@@ -3,6 +3,7 @@
 
 require "yaml"
 require "English"
+require "set"
 require "shellwords"
 
 ROOT = File.expand_path("..", __dir__)
@@ -27,10 +28,56 @@ def badge_count(markdown, label)
 end
 
 def tracked_files(pattern)
-  output = `git -C #{Shellwords.escape(ROOT)} ls-files #{Shellwords.escape(pattern)}`
+  output = `git -C #{Shellwords.escape(ROOT)} ls-files -- #{Shellwords.escape(pattern)}`
   fail_check("git ls-files failed for #{pattern}") unless $CHILD_STATUS.success?
 
   output.lines.map(&:strip).reject(&:empty?).map { |path| File.join(ROOT, path) }
+end
+
+def all_tracked_files
+  output = `git -C #{Shellwords.escape(ROOT)} ls-files`
+  fail_check("git ls-files failed") unless $CHILD_STATUS.success?
+
+  output.lines.map(&:strip).reject(&:empty?).map { |path| File.join(ROOT, path) }
+end
+
+def repo_files(*patterns)
+  patterns.flat_map { |pattern| tracked_files(pattern) }
+          .uniq
+          .select { |path| File.file?(path) }
+end
+
+def tracked_file_index
+  @tracked_file_index ||= all_tracked_files
+                          .select { |path| File.file?(path) }
+                          .map { |path| File.expand_path(path) }
+                          .to_set
+end
+
+def tracked_directory_index
+  @tracked_directory_index ||= begin
+    dirs = Set.new
+    tracked_file_index.each do |path|
+      dir = File.dirname(path)
+      while dir.start_with?(ROOT)
+        dirs << dir
+        break if dir == ROOT
+
+        dir = File.dirname(dir)
+      end
+    end
+    dirs
+  end
+end
+
+def tracked_repo_target?(path)
+  normalized = File.expand_path(path)
+  tracked_file_index.include?(normalized) || tracked_directory_index.include?(normalized)
+end
+
+def files_in_dir(relative_dir, pattern)
+  dir = File.join(ROOT, relative_dir)
+  repo_files(pattern).select { |path| File.dirname(path) == dir }
 end
 
 def count_benchmark_rows
@@ -42,24 +89,49 @@ def count_benchmark_rows
 end
 
 def count_product_notes
-  Dir[File.join(ROOT, "products", "*.md")].count do |path|
+  files_in_dir("products", "products/*.md").count do |path|
     base = File.basename(path)
     base != "README.md" && !base.start_with?("_")
   end
 end
 
 def count_product_archives
-  Dir[File.join(ROOT, "products", "archives", "*.md")].count do |path|
+  files_in_dir("products/archives", "products/archives/*.md").count do |path|
     File.basename(path) != "README.md"
   end
 end
 
 def count_pdfs
-  Dir[File.join(ROOT, "papers", "pdfs", "*")].count { |path| File.file?(path) }
+  files_in_dir("papers/pdfs", "papers/pdfs/*").count
 end
 
 def count_stubs
-  Dir[File.join(ROOT, "papers", "stubs", "*.md")].count
+  files_in_dir("papers/stubs", "papers/stubs/*.md").count
+end
+
+def paper_note_files
+  files_in_dir("papers", "papers/*.md").select do |path|
+    File.basename(path) != "index.md" &&
+      !File.basename(path).start_with?("_")
+  end
+end
+
+def paper_status_counts
+  paper_note_files.each_with_object(Hash.new(0)) do |path, counts|
+    status = extract_front_matter_value(path, "status")
+    counts[status] += 1 if %w[full seed].include?(status)
+  end
+end
+
+def check_paper_note_statuses
+  invalid = paper_note_files.each_with_object([]) do |path, rows|
+    status = extract_front_matter_value(path, "status")
+    next if %w[full seed].include?(status)
+
+    rows << "#{path.delete_prefix("#{ROOT}/")}: #{status || "(missing)"}"
+  end
+
+  assert(invalid.empty?, "paper notes with invalid status values:\n#{invalid.join("\n")}")
 end
 
 def paper_total_from_index
@@ -67,10 +139,25 @@ def paper_total_from_index
 end
 
 def scan_conflict_markers
-  files = Dir[
-    File.join(ROOT, "{README.md,README_cn.md}"),
-    File.join(ROOT, "{docs,benchmarks,products,papers,impact-reports}", "**", "*.{md,yml,yaml}")
-  ]
+  files = repo_files(
+    "README.md",
+    "README_cn.md",
+    "docs/**/*.md",
+    "docs/**/*.yml",
+    "docs/**/*.yaml",
+    "benchmarks/**/*.md",
+    "benchmarks/**/*.yml",
+    "benchmarks/**/*.yaml",
+    "products/**/*.md",
+    "products/**/*.yml",
+    "products/**/*.yaml",
+    "papers/**/*.md",
+    "papers/**/*.yml",
+    "papers/**/*.yaml",
+    "impact-reports/**/*.md",
+    "impact-reports/**/*.yml",
+    "impact-reports/**/*.yaml"
+  )
 
   offenders = files.select do |path|
     body = File.read(path)
@@ -87,6 +174,9 @@ end
 def check_counts
   readme = read("README.md")
   readme_cn = read("README_cn.md")
+  status_counts = paper_status_counts
+  full_notes = status_counts.fetch("full", 0)
+  seed_notes = status_counts.fetch("seed", 0)
 
   expected = {
     "papers" => paper_total_from_index,
@@ -103,25 +193,29 @@ def check_counts
 
   checks = {
     "README.md" => [
-      "#{count_stubs} stubs",
-      "#{count_product_notes} notes",
-      "#{count_product_archives} snapshots",
-      "#{count_benchmark_rows} catalog rows",
-      "#{count_benchmark_rows} benchmark catalog rows"
+      ["paper note status counts", /#{full_notes}\s+full\s+\+\s+#{seed_notes}\s+seed/],
+      ["paper tree status counts", /#{full_notes}\s+full paper notes,\s+#{seed_notes}\s+seed notes/],
+      ["paper stub count", /#{count_stubs}\s+stubs\b/],
+      ["product note count", /#{count_product_notes}\s+notes\b/],
+      ["product archive count", /#{count_product_archives}\s+snapshots\b/],
+      ["benchmark catalog row count", /#{count_benchmark_rows}\s+catalog rows\b/],
+      ["benchmark tree row count", /#{count_benchmark_rows}\s+benchmark catalog rows\b/]
     ],
     "README_cn.md" => [
-      "#{count_stubs} 个 stub",
-      "#{count_product_notes} 个笔记",
-      "#{count_product_archives} 个快照",
-      "#{count_benchmark_rows} 个 catalog 行",
-      "#{count_benchmark_rows} 个 benchmark catalog 行"
+      ["paper note status counts", /#{full_notes}\s+个 full\s+\+\s+#{seed_notes}\s+个 seed/],
+      ["paper tree status counts", /#{full_notes}\s+个 full 论文笔记、#{seed_notes}\s+个 seed 笔记/],
+      ["paper stub count", /#{count_stubs}\s+个 stub\b/],
+      ["product note count", /#{count_product_notes}\s+个笔记/],
+      ["product archive count", /#{count_product_archives}\s+个快照/],
+      ["benchmark catalog row count", /#{count_benchmark_rows}\s+个 catalog 行/],
+      ["benchmark tree row count", /#{count_benchmark_rows}\s+个 benchmark catalog 行/]
     ]
   }
 
-  checks.each do |file, tokens|
+  checks.each do |file, expectations|
     body = read(file)
-    tokens.each do |token|
-      assert(body.include?(token), "#{file} missing synchronized count token #{token.inspect}")
+    expectations.each do |description, pattern|
+      assert(body.match?(pattern), "#{file} missing synchronized #{description}")
     end
   end
 end
@@ -137,34 +231,36 @@ def check_duplicates
   dup_events = event_ids.group_by(&:itself).select { |_id, rows| rows.size > 1 }
   assert(dup_events.empty?, "duplicate benchmark claim event_ids: #{dup_events.keys.join(", ")}")
 
-  benchmark_ids = Dir[File.join(ROOT, "benchmarks", "*.md")]
+  benchmark_files = files_in_dir("benchmarks", "benchmarks/*.md")
+                    .reject { |path| File.basename(path) == "_template.md" }
+  product_files = files_in_dir("products", "products/*.md")
+
+  benchmark_ids = benchmark_files
                   .reject { |path| File.basename(path) == "_template.md" }
                   .map { |path| [extract_front_matter_value(path, "benchmark_id"), path] }
                   .reject { |value, _path| value.nil? || value.empty? }
   dup_benchmarks = benchmark_ids.group_by(&:first).select { |_id, rows| rows.size > 1 }
   assert(dup_benchmarks.empty?, "duplicate benchmark_ids: #{dup_benchmarks.keys.join(", ")}")
 
-  benchmark_titles = Dir[File.join(ROOT, "benchmarks", "*.md")]
-                     .reject { |path| File.basename(path) == "_template.md" }
+  benchmark_titles = benchmark_files
                      .map { |path| [extract_front_matter_value(path, "title"), path] }
                      .reject { |value, _path| value.nil? || value.empty? }
   dup_benchmark_titles = benchmark_titles.group_by { |value, _path| value.downcase }.select { |_value, rows| rows.size > 1 }
   assert(dup_benchmark_titles.empty?, "duplicate benchmark titles: #{dup_benchmark_titles.keys.join(", ")}")
 
-  benchmark_names = Dir[File.join(ROOT, "benchmarks", "*.md")]
-                    .reject { |path| File.basename(path) == "_template.md" }
+  benchmark_names = benchmark_files
                     .map { |path| [extract_front_matter_value(path, "name"), path] }
                     .reject { |value, _path| value.nil? || value.empty? }
   dup_benchmark_names = benchmark_names.group_by { |value, _path| value.downcase }.select { |_value, rows| rows.size > 1 }
   assert(dup_benchmark_names.empty?, "duplicate benchmark names: #{dup_benchmark_names.keys.join(", ")}")
 
-  product_titles = Dir[File.join(ROOT, "products", "*.md")]
+  product_titles = product_files
                    .map { |path| [extract_front_matter_value(path, "title"), path] }
                    .reject { |value, _path| value.nil? || value.empty? }
   dup_product_titles = product_titles.group_by { |value, _path| value.downcase }.select { |_value, rows| rows.size > 1 }
   assert(dup_product_titles.empty?, "duplicate product titles: #{dup_product_titles.keys.join(", ")}")
 
-  product_ids = Dir[File.join(ROOT, "products", "*.md")].map do |path|
+  product_ids = product_files.map do |path|
     explicit_id = extract_front_matter_value(path, "product_id")
     [explicit_id || File.basename(path, ".md"), path]
   end.reject { |value, _path| value.nil? || value.empty? }
@@ -173,13 +269,14 @@ def check_duplicates
 end
 
 def check_local_markdown_links
-  files = tracked_files("*.md") +
-          tracked_files("docs/**/*.md") +
-          tracked_files("benchmarks/**/*.md") +
-          tracked_files("products/**/*.md") +
-          tracked_files("papers/**/*.md") +
-          tracked_files("impact-reports/**/*.md")
-  files = files.uniq.select { |path| File.exist?(path) }
+  files = repo_files(
+    "*.md",
+    "docs/**/*.md",
+    "benchmarks/**/*.md",
+    "products/**/*.md",
+    "papers/**/*.md",
+    "impact-reports/**/*.md"
+  )
 
   missing = []
   files.each do |path|
@@ -190,7 +287,7 @@ def check_local_markdown_links
       next if target.match?(/\A(?:https?:|mailto:|#)/)
 
       candidate = File.expand_path(target, File.dirname(path))
-      missing << "#{path.delete_prefix("#{ROOT}/")}: #{raw_target}" unless File.exist?(candidate)
+      missing << "#{path.delete_prefix("#{ROOT}/")}: #{raw_target}" unless tracked_repo_target?(candidate)
     end
   end
 
@@ -199,9 +296,11 @@ end
 
 scan_conflict_markers
 check_yaml
+check_paper_note_statuses
 check_counts
 check_duplicates
 check_local_markdown_links
 
 puts "verify_memory_refresh passed"
-puts "papers=#{paper_total_from_index} pdfs=#{count_pdfs} stubs=#{count_stubs} products=#{count_product_notes} product_archives=#{count_product_archives} benchmarks=#{count_benchmark_rows}"
+status_counts = paper_status_counts
+puts "papers=#{paper_total_from_index} pdfs=#{count_pdfs} stubs=#{count_stubs} full_notes=#{status_counts.fetch("full", 0)} seed_notes=#{status_counts.fetch("seed", 0)} products=#{count_product_notes} product_archives=#{count_product_archives} benchmarks=#{count_benchmark_rows}"


### PR DESCRIPTION
## Summary
- Add `docs/weekly-memory-refresh-runbook.md` as the weekly Codex refresh contract for papers, products, GitHub/list discovery, and benchmarks.
- Add `scripts/verify_memory_refresh.rb` to validate conflict markers, YAML, README count sync, local Markdown links, and duplicate benchmark/product IDs/titles.
- Link the runbook from `docs/README.md` and `docs/research-radar.md`.
- Configure a local Codex App cron automation for Monday 09:00 local time, `worktree` execution, `gpt-5.5`, high reasoning. The local automation instance and machine-specific paths are intentionally not published in repo docs.

## Automation Behavior
- Starts weekly from latest `origin/main` on `codex/weekly-memory-radar-YYYY-MM-DD`.
- Uses up to six bounded subagents for papers, products, GitHub/benchmark discovery, repo mapping, source checking, and relevance review.
- Creates a PR only when verified `must-add` or `update-existing` changes exist.
- Does not auto-merge and does not promote survey/GitHub discovery without primary evidence.

## Validation
- `ruby --disable-gems -c scripts/verify_memory_refresh.rb`
- `ruby --disable-gems scripts/verify_memory_refresh.rb`
- conflict-marker scan across README/docs/benchmarks/papers/products/scripts
- public path/id scan for local machine identifiers
- `git diff --check`
- automation TOML field check for cron/ACTIVE/worktree/model/schedule
- final `code-reviewer` re-review: APPROVE

## Known Gaps
- The scheduled live run has not executed yet.
- Full external source crawl remains part of each weekly job, not this local verifier.
