### PR TITLE
[codex] Align community workflow with evidence governance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,21 +1,30 @@
 ---
-name: Bug report
-about: Report incorrect behavior or a broken workflow
-title: "[Bug] "
+name: Evidence or documentation bug
+about: Report incorrect metadata, stale claims, broken links, or workflow issues
+title: "[Evidence bug] "
 labels: bug
 assignees: ""
 ---
 
-## What happened?
+## Affected area
+
+- [ ] Paper index or note
+- [ ] Product note or archive
+- [ ] Benchmark note or claims ledger
+- [ ] Synthesis doc
+- [ ] Repository workflow or template
+- [ ] Other:
+
+## What is wrong?
 
 
-## Expected behavior
+## Source or evidence
+
+Link the canonical source, affected file, or command output when possible.
+
+## Expected correction
 
 
-## Reproduction steps
+## Verification notes
 
-
-## Environment
-
-
-## Additional context
+Mention any local check you ran, such as `ruby scripts/verify_memory_refresh.rb`.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,18 +1,39 @@
 ---
-name: Feature request
-about: Propose a product, architecture, or implementation improvement
-title: "[Feature] "
+name: Evidence addition or improvement
+about: Propose a paper, product, benchmark, source, or synthesis improvement
+title: "[Proposal] "
 labels: enhancement
 assignees: ""
 ---
 
-## Problem
+## Contribution type
+
+- [ ] Paper note or stub upgrade
+- [ ] Product note or archive
+- [ ] Benchmark note or claims ledger event
+- [ ] Information source or signal
+- [ ] Synthesis or taxonomy update
+- [ ] Governance, template, or workflow improvement
+
+## Candidate source
+
+Add canonical URLs, dates, and any archive location if available.
+
+## Why it belongs
+
+Explain the agent-memory relevance and what decision this evidence could
+support.
+
+## Evidence class
+
+- [ ] Primary paper evidence
+- [ ] Product behavior or vendor claim
+- [ ] Affiliated evaluation
+- [ ] Independent reproduction
+- [ ] Maintainer synthesis
+- [ ] Discovery lead only
+
+## Proposed files to change
 
 
-## Proposed direction
-
-
-## Alternatives considered
-
-
-## Acceptance criteria
+## Review risks or follow-up

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,34 @@
-## Summary
+## Purpose
 
 -
+
+## Evidence Class
+
+- [ ] Paper note or metadata
+- [ ] Product note, archive, or landscape entry
+- [ ] Benchmark note or claims ledger event
+- [ ] Source map, signal, or related-work update
+- [ ] Synthesis, taxonomy, or architecture guidance
+- [ ] Governance, template, or workflow change
+
+## Source And Provenance
+
+- Canonical URL(s):
+- Source type: primary paper / vendor claim / affiliated evaluation / critique /
+  independent reproduction / maintainer synthesis / not applicable
+- Archive path, if added:
 
 ## Verification
 
--
+- [ ] `ruby scripts/verify_memory_refresh.rb`
+- [ ] Changed links and headings reviewed
+- [ ] Counts, badges, and generated indexes updated if relevant
+
+## Safety Checks
+
+- [ ] No secrets, private data, proprietary records, or unreviewed raw transcripts
+- [ ] PDFs or archives are redistributable, or only canonical links are included
+- [ ] Vendor and affiliated claims remain labeled as such
 
 ## Risks / Follow-Up
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,15 +1,29 @@
 # Code Of Conduct
 
-ZhiOne should be a practical and respectful technical project.
+`awesome-agent-memory` should be a practical and respectful public evidence
+project.
 
 Participants are expected to:
 
 - discuss ideas and tradeoffs directly without personal attacks;
 - assume public comments are read by future contributors;
-- respect privacy boundaries around local knowledge and memory data;
+- respect privacy boundaries around local knowledge, memory data, and agent
+  transcripts;
+- distinguish evidence from opinion when challenging a claim;
 - avoid harassment, discriminatory language, and targeted hostility;
 - accept maintainers' moderation decisions in project spaces.
+
+Unacceptable behavior includes:
+
+- publishing private data, credentials, or non-public correspondence;
+- using issues or pull requests for personal attacks or repeated off-topic
+  arguments;
+- deliberately misrepresenting vendor claims, affiliated evaluations, or
+  independent reproductions.
 
 Unacceptable behavior may be removed from issues, pull requests, discussions, or
 other project spaces. Repeated or severe violations may lead to being blocked
 from participation.
+
+Report conduct issues through a private channel to the repository owner when a
+public issue would expose personal information or create avoidable conflict.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,21 @@ decisions.
 - Do not add PDFs unless the source permits redistribution; keep the canonical
   URL in the corresponding note.
 
+## Contribution Types
+
+Most contributions should fit one of these lanes:
+
+- Paper note: upgrade a `papers/stubs/` entry into a full `papers/` note, or fix
+  metadata in `papers/index.md`.
+- Product note: add or refresh a `products/` note, with an archive under
+  `products/archives/` when the source page is important or likely to drift.
+- Benchmark evidence: add or refresh a benchmark note and record claim usage in
+  `benchmarks/claims/claims.yaml`.
+- Source map: improve `docs/information-sources.md`, `docs/related-work.md`, or
+  `docs/signals.md`.
+- Synthesis: update docs only after the underlying note, source, or ledger entry
+  supports the claim.
+
 ## Good First Contributions
 
 - Upgrade an existing `papers/stubs/` entry into a `papers/` full note after
@@ -34,7 +49,7 @@ decisions.
   memory-kernel architecture.
 - Identify privacy, provenance, or auditability risks.
 
-## Note Expectations
+## Evidence Expectations
 
 Full paper and product notes should preserve the ResearchItem shape described in
 `docs/research-radar.md`:
@@ -52,6 +67,29 @@ Benchmark notes should preserve the BenchmarkItem shape in
 reproduction claim should have a ledger event in
 `benchmarks/claims/claims.yaml`. Do not reclassify a vendor blog, product page,
 or affiliated paper result as independent reproduction.
+
+For every evidence-bearing change:
+
+- include the canonical source URL and access date when the note format supports
+  it;
+- separate direct evidence, vendor claims, affiliated evaluation, independent
+  reproduction, and maintainer inference;
+- keep uncertain items marked as `check`, `seed`, or follow-up work;
+- update the smallest canonical surface first, then update summaries that depend
+  on it;
+- keep quoted external text short and use summaries for the rest.
+
+## Verification
+
+Run the repository verifier before opening a PR:
+
+```bash
+ruby scripts/verify_memory_refresh.rb
+```
+
+If you add new tracked data files, make sure they are tracked before relying on
+count checks. For documentation-only changes, also review changed markdown links
+and headings directly.
 
 ## Commit Messages
 
@@ -73,5 +111,6 @@ PR descriptions should include:
 
 - the problem being solved;
 - the chosen approach;
+- the evidence class and source type when the change adds or promotes claims;
 - verification performed;
 - known risks or follow-up work.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,13 +1,14 @@
 # Security Policy
 
-ZhiOne is designed around local knowledge, personal memory, and agent context.
-Security and privacy issues should be treated seriously even before production
-code exists.
+`awesome-agent-memory` is a public research and evidence repository, not a
+production service. Security and privacy issues still matter because the repo can
+contain archived source pages, PDFs, public claims about memory systems, and
+workflow scripts that contributors may run locally.
 
 ## Supported Versions
 
-There is no released version yet. Security reports should target the `main`
-branch.
+There are no released versions. Security reports should target the `main` branch
+and any open pull request that introduces the issue.
 
 ## Reporting A Vulnerability
 
@@ -21,6 +22,23 @@ include:
 - potential impact;
 - suggested mitigation if known.
 
+## What To Report Privately
+
+Use a private channel for:
+
+- committed secrets, tokens, private keys, or confidential documents;
+- raw agent transcripts, personal notes, or customer data that were published by
+  mistake;
+- archived PDFs or source snapshots that appear to violate redistribution terms;
+- malicious links, poisoned archives, or scripts that could affect contributors'
+  local machines;
+- vulnerability details that would make exploitation easier before a fix is
+  available.
+
+Use a normal issue or pull request for public documentation errors, stale product
+claims, broken links, or benchmark-classification disagreements that do not
+expose sensitive information.
+
 ## Sensitive Data
 
 Do not commit:
@@ -31,4 +49,6 @@ Do not commit:
 - raw agent transcripts that have not been reviewed for public release.
 
 If sensitive data is committed, rotate affected secrets first, then remove the
-data from the repository and history as appropriate.
+data from the repository and history as appropriate. If the issue is a
+redistribution or privacy problem rather than a secret, remove or rewrite the
+affected artifact and preserve only the public canonical URL when possible.


### PR DESCRIPTION
## Purpose

Align the GitHub community profile files with the repository as a public evidence corpus for agent-memory research.

## What changed

- Updated contribution guidance with contribution lanes, evidence expectations, and verifier instructions.
- Replaced stale `ZhiOne` references in the code of conduct and security policy.
- Expanded issue and pull request templates so contributors provide affected area, canonical source, evidence class, verification, and privacy checks.

## Verification

- `git diff --check`
- Issue template front matter YAML parse
- `ruby scripts/verify_memory_refresh.rb`

## Risks / Follow-Up

- GitHub web rendering of the Markdown issue templates was not manually checked.
