### PR TITLE
[codex] Add agent-memory cost-savings evidence lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ separate buckets.
 | Product page archives | 37 snapshots | [`products/archives/`](products/archives/) | Audit product claims after source pages change. |
 | Benchmark catalog | 18 catalog rows | [`benchmarks/index.md`](benchmarks/index.md) | First-class benchmark records plus stub-backed candidate rows and a usage-claim ledger. |
 | Claims ledger | Structured YAML ledger | [`benchmarks/claims/claims.yaml`](benchmarks/claims/claims.yaml) | Separate vendor claims, paper evaluations, critiques, and reproductions. |
+| Cost-savings lane | Seed landscape | [`docs/cost-savings-landscape.md`](docs/cost-savings-landscape.md) | Find agent-memory papers, methods, code paths, and products that reduce token, latency, or runtime cost. |
 | Survey and taxonomy | 1 living survey + 6 meta-survey records | [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) · [`docs/meta-surveys.md`](docs/meta-surveys.md) | Build a field-level view before choosing an implementation. |
 | Impact reports | Template only for now | [`impact-reports/README.md`](impact-reports/README.md) | Promote strong evidence into kernel-design recommendations. |
 
@@ -77,6 +78,7 @@ Start with the path that matches your question:
 | Find relevant papers | [`papers/index.md`](papers/index.md), then full notes under [`papers/`](papers/) |
 | Compare memory products | [`docs/products-landscape.md`](docs/products-landscape.md), [`docs/product-memory-architectures.md`](docs/product-memory-architectures.md), [`docs/product-architecture-diagrams.md`](docs/product-architecture-diagrams.md) |
 | Check why a product was included or rejected | [`docs/product-discovery-log.md`](docs/product-discovery-log.md) |
+| Explore cost-saving memory approaches | [`docs/cost-savings-landscape.md`](docs/cost-savings-landscape.md), then [`benchmarks/fact-based-memory-vs-long-context.md`](benchmarks/fact-based-memory-vs-long-context.md) and [`papers/mem0-paper.md`](papers/mem0-paper.md) |
 | Evaluate benchmark claims | [`docs/benchmarks-landscape.md`](docs/benchmarks-landscape.md), [`benchmarks/index.md`](benchmarks/index.md), [`benchmarks/claims/claims.yaml`](benchmarks/claims/claims.yaml) |
 | Track new releases and source channels | [`docs/signals.md`](docs/signals.md), [`docs/information-sources.md`](docs/information-sources.md) |
 | Turn research into a memory-kernel decision | [`docs/research-radar.md`](docs/research-radar.md), then [`impact-reports/README.md`](impact-reports/README.md) |
@@ -123,6 +125,7 @@ flowchart LR
 | [`docs/meta-surveys.md`](docs/meta-surveys.md) | External meta-survey index from late 2025 through 2026 H1. |
 | [`docs/research-radar.md`](docs/research-radar.md) | Workflow for turning papers, products, and benchmark evidence into ImpactReports and ADR inputs. |
 | [`docs/memory-radar-2026-06.md`](docs/memory-radar-2026-06.md) | 2026-06 current-source refresh across papers, products, GitHub projects, and reviewer decisions. |
+| [`docs/cost-savings-landscape.md`](docs/cost-savings-landscape.md) | Focused lane for agent-memory token reduction, budgeted retrieval, runtime-cost methods, code paths, and product practice signals. |
 | [`docs/information-sources.md`](docs/information-sources.md) | Source catalog for papers, products, communities, and zh-CN information channels. |
 | [`docs/related-work.md`](docs/related-work.md) | Discovery-input attribution and scrape provenance. |
 | [`docs/signals.md`](docs/signals.md) | Reverse-chronological release, comparison, and blog signal log. |

--- a/README_cn.md
+++ b/README_cn.md
@@ -61,6 +61,7 @@
 | 产品页面快照 | 37 个快照 | [`products/archives/`](products/archives/) | 在源页面变化后审计产品 claims。 |
 | Benchmark 目录 | 18 个 catalog 行 | [`benchmarks/index.md`](benchmarks/index.md) | 理解 memory benchmark、stub-backed 候选行及其 claims 来源。 |
 | Claims ledger | 结构化 YAML ledger | [`benchmarks/claims/claims.yaml`](benchmarks/claims/claims.yaml) | 区分厂商自报、论文评测、方法批评和独立复现。 |
+| 成本节省专题 | seed landscape | [`docs/cost-savings-landscape.md`](docs/cost-savings-landscape.md) | 查找能减少 token、延迟或运行成本的 agent-memory 论文、方法、代码和产品。 |
 | 综述与 taxonomy | 1 份活综述 + 6 条 meta-survey 记录 | [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) · [`docs/meta-surveys.md`](docs/meta-surveys.md) | 在选型或设计前建立领域视角。 |
 | Impact reports | 目前只有模板 | [`impact-reports/README.md`](impact-reports/README.md) | 把强证据提升为 memory-kernel 架构建议。 |
 
@@ -75,6 +76,7 @@
 | 找相关论文 | [`papers/index.md`](papers/index.md)，再看 [`papers/`](papers/) 下的 full note |
 | 比较记忆产品 | [`docs/products-landscape.md`](docs/products-landscape.md)、[`docs/product-memory-architectures.md`](docs/product-memory-architectures.md)、[`docs/product-architecture-diagrams.md`](docs/product-architecture-diagrams.md) |
 | 查看产品为什么入库或被拒绝 | [`docs/product-discovery-log.md`](docs/product-discovery-log.md) |
+| 探索 agent memory 如何节省成本 | [`docs/cost-savings-landscape.md`](docs/cost-savings-landscape.md)，再读 [`benchmarks/fact-based-memory-vs-long-context.md`](benchmarks/fact-based-memory-vs-long-context.md) 和 [`papers/mem0-paper.md`](papers/mem0-paper.md) |
 | 评估 benchmark claims | [`docs/benchmarks-landscape.md`](docs/benchmarks-landscape.md)、[`benchmarks/index.md`](benchmarks/index.md)、[`benchmarks/claims/claims.yaml`](benchmarks/claims/claims.yaml) |
 | 跟踪新发布和信息源 | [`docs/signals.md`](docs/signals.md)、[`docs/information-sources.md`](docs/information-sources.md) |
 | 把研究转成 kernel 决策 | [`docs/research-radar.md`](docs/research-radar.md)，再用 [`impact-reports/README.md`](impact-reports/README.md) |
@@ -121,6 +123,7 @@ flowchart LR
 | [`docs/meta-surveys.md`](docs/meta-surveys.md) | 2025 年末到 2026 H1 的外部 meta-survey 索引。 |
 | [`docs/research-radar.md`](docs/research-radar.md) | 把论文、产品、benchmark 证据转成 ImpactReport 和 ADR 输入的工作流。 |
 | [`docs/memory-radar-2026-06.md`](docs/memory-radar-2026-06.md) | 2026-06 当前来源刷新，覆盖论文、产品、GitHub 项目和 reviewer 分流结论。 |
+| [`docs/cost-savings-landscape.md`](docs/cost-savings-landscape.md) | agent-memory token reduction、预算检索、运行成本方法、代码路径和产品实践信号专题。 |
 | [`docs/information-sources.md`](docs/information-sources.md) | 论文、产品、社区和中文信息源 catalog。 |
 | [`docs/related-work.md`](docs/related-work.md) | 发现线索归因和抓取来源记录。 |
 | [`docs/signals.md`](docs/signals.md) | release、对比文章和博客信号的反时序日志。 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,13 +17,16 @@ decide what to read before opening the paper index or the product notes.
    benchmarks.
 5. [`memory-radar-2026-06.md`](memory-radar-2026-06.md) — latest current-source
    refresh across papers, products, GitHub projects, and reviewer decisions.
-6. [`benchmarks-landscape.md`](benchmarks-landscape.md) — benchmark map by
+6. [`cost-savings-landscape.md`](cost-savings-landscape.md) — focused map of
+   agent-memory papers, algorithms, code paths, and products that reduce token,
+   latency, or runtime cost.
+7. [`benchmarks-landscape.md`](benchmarks-landscape.md) — benchmark map by
    capability, usage type, and evidence independence.
-7. [`products-landscape.md`](products-landscape.md) — product map by domain and
+8. [`products-landscape.md`](products-landscape.md) — product map by domain and
    audience.
-8. [`product-architecture-diagrams.md`](product-architecture-diagrams.md) —
+9. [`product-architecture-diagrams.md`](product-architecture-diagrams.md) —
    architecture diagrams for the current memory product notes.
-9. [`product-memory-architectures.md`](product-memory-architectures.md) —
+10. [`product-memory-architectures.md`](product-memory-architectures.md) —
    cross-product memory architecture patterns and comparison tables.
 
 ## Concept docs
@@ -34,6 +37,7 @@ decide what to read before opening the paper index or the product notes.
 | [`taxonomy.md`](taxonomy.md) | Cross-walk of external taxonomies and common memory-kernel responsibilities. |
 | [`meta-surveys.md`](meta-surveys.md) | External survey index from late 2025 through 2026 H1. |
 | [`signals.md`](signals.md) | Reverse-chronological release, comparison, and blog signal log. |
+| [`cost-savings-landscape.md`](cost-savings-landscape.md) | Dedicated cost-savings lane for token reduction, budgeted retrieval, SLM/offline consolidation, and product practice signals. |
 | [`benchmarks-landscape.md`](benchmarks-landscape.md) | Benchmark usage landscape split by raw mentions, eval uses, vendor claims, and independent evidence. |
 | [`product-discovery-log.md`](product-discovery-log.md) | Multi-agent product discovery log with Tier A / Tier B / reject decisions. |
 | [`product-memory-architectures.md`](product-memory-architectures.md) | Cross-product architecture patterns across memory OS, graph, MCP/local, platform-managed, and personal memory. |

--- a/docs/cost-savings-landscape.md
+++ b/docs/cost-savings-landscape.md
@@ -1,0 +1,140 @@
+---
+title: Agent-memory cost-savings landscape
+date: 2026-06-30
+status: seed
+language: zh-CN
+---
+
+# Agent-memory cost-savings landscape
+
+本页是 agent memory 的成本专题入口,专门跟踪能减少 token、在线 LLM 调用、
+延迟、存储/图构建成本或人工维护成本的论文、算法、代码实现和产品实践。
+
+这个板块不做排行榜。它只回答三个问题:
+
+1. 哪些 memory 设计声称或证明能省成本?
+2. 省的是哪一种成本,代价是什么?
+3. 当前仓库里应该把它当成强证据、候选线索,还是 vendor self-claim?
+
+## Reading rules
+
+| Rule | Why |
+|---|---|
+| 把 `token reduction`、`API cost`、`latency`、`compute`、`storage/indexing cost` 分开记录 | 同样叫省成本,可能发生在完全不同路径。 |
+| 区分 paper evaluation、affiliated evaluation、vendor self-report、independent reproduction | 产品自报可以作为实践信号,不能当独立结论。 |
+| 每个成本 claim 都要同时看质量指标 | 省 token 但丢 recall、temporal reasoning 或 provenance,不是可直接采用的设计。 |
+| API/pricing 相关结论必须带日期 | 模型价格、prompt caching、context-window 价格和输入/输出倍率会变。 |
+| 进入 ImpactReport 前优先升级本页的 stub-only 条目 | stub 只证明发现覆盖,不能支撑架构决策。 |
+
+## Cost levers
+
+| Lever | Saves | Representative evidence | Implementation shape | Main caveat |
+|---|---|---|---|---|
+| Full-history replacement | 输入 token、API cost、长上下文延迟 | [`Mem0 paper`](../papers/mem0-paper.md), [`Fact-based memory vs long-context`](../benchmarks/fact-based-memory-vs-long-context.md), [`ConvoMem`](../benchmarks/convomem.md) | 抽取 facts / user profile / task state,检索后只装配相关片段 | full-context 在部分 recall 任务仍可能更准;break-even 依赖价格和轮数。 |
+| Structured distillation | 长期 profile token、重复事实、上下文膨胀 | [`Structured Distillation`](../papers/stubs/structured-distillation-for-personalized-agent-memory-11.md), DimMem external candidate, TencentDB L0-L3 分层 | 把长交互压成 structured memory,再按 scope/context 召回 | 容易丢 provenance、冲突和少数长尾事实;需要审计轨迹。 |
+| Budgeted retrieval / tier routing | 每次 query 的检索、rerank、LLM reasoning 成本 | [`BudgetMem`](../papers/stubs/budgetmem-learning-query-aware-budget-tier-routing-for.md), [`A2RAG`](../papers/stubs/a2rag-adaptive-agentic-graph-retrieval-for-cost-aware-and.md), [`LightMem`](../papers/lightmem-agent-memory.md) | 轻量 tier 先答简单查询,困难查询再升级到 graph / agentic retrieval / larger model | router 训练、难例识别和 fallback 失败会把质量风险藏起来。 |
+| Offline / SLM consolidation | 热路径大模型调用、在线延迟 | [`LightMem`](../papers/lightmem-agent-memory.md), [`Agent Memory systems`](../papers/agent-memory-systems-characterization.md) | 用 small language model 或离线 worker 做写入、整理、consolidation | freshness、错误累积和小模型质量要被持续测量。 |
+| Phase-aware systems profiling | 选型时的隐藏成本 | [`Agent Memory systems`](../papers/agent-memory-systems-characterization.md), [`MEMAUDIT`](../papers/stubs/memaudit-an-exact-package-oracle-evaluation-protocol-for.md) | 把 construction / retrieval / generation / write budget 分账 | 画像必须用真实 query volume、更新频率和 tenant pattern 重跑。 |
+| Productized context offloading | coding-agent 长任务上下文、人工整理成本 | [`OpenViking`](../products/openviking.md), [`TencentDB Agent Memory`](../products/tencentdb-agent-memory.md), [`Mem0`](../products/mem0.md), Searchat external implementation | context DB、memory API server、分层 artifact、agent/tool 接入 | 大多是产品或关联方数字,要继续标注为 vendor self-report。 |
+
+## Evidence inventory
+
+### Promotion gates
+
+本页中的候选项只有通过下面 gate 后,才能进入 ImpactReport 或架构实验:
+
+| Gate | Required evidence before promotion |
+|---|---|
+| Paper gate | local note 从 `stub` 升级到 `seed` 或 `full`,并记录 source date、method summary、benchmark setup、limitations。 |
+| Code gate | canonical repo 可访问,license 明确,核心实现路径可定位,不是只停留在 README claim。 |
+| Metric gate | 同时记录 cost metric 和 quality metric;只给 token reduction、不给 recall/task success 的条目不能作为采用理由。 |
+| Reproduction gate | 明确 `affiliated_eval`、`vendor_self_report` 或 `independent_reproduction`;没有第三方设置时不得写成独立结论。 |
+| Pricing gate | 涉及 API cost / break-even 的条目必须写明模型、价格日期、prompt caching/context-window 假设。 |
+
+未通过 gate 的条目只能用于 discovery、watchlist 或实验候选,不能直接支持
+`adopt_as_plugin`、`consider_core_change` 或产品排名。
+
+### Stronger local anchors
+
+| Item | Current repo status | Cost-saving relevance | Evidence boundary |
+|---|---|---|---|
+| [`Mem0 paper`](../papers/mem0-paper.md) | full note | 把 full-context 26k token / conversation 对照 Mem0 1.7k、Mem0g 3.6k;论文声称 p95 latency 和 token cost 明显低于 full-context。 | 论文来自 Mem0 作者,是 affiliated evidence;LOCOMO 样本小。 |
+| [`Fact-based memory vs long-context`](../benchmarks/fact-based-memory-vs-long-context.md) | candidate benchmark note | 直接比较 fact-based memory 和 long-context inference 的 accuracy、cumulative API cost、break-even turns。 | stub-quality source note;pricing assumptions time-sensitive。 |
+| [`ConvoMem`](../benchmarks/convomem.md) | full benchmark note | 提供 1k-3M token 可调 context 下的 accuracy/cost/latency crossover 视角。 | synthetic data;不要把"前 150 个 conversations 不需要 RAG"泛化到所有产品。 |
+| [`LightMem agent memory`](../papers/lightmem-agent-memory.md) | seed paper note | 用 SLM 负责 retrieval、writing、offline consolidation,强调 bounded online cost 和低延迟路径。 | seed 质量;需补 PDF/code/license 细读。 |
+| [`Agent Memory systems characterization`](../papers/agent-memory-systems-characterization.md) | seed paper note | 把 memory construction、retrieval、generation 作为系统成本画像对象。 | seed 质量;尚未复核 profiling harness 细节。 |
+
+### Candidate papers and code paths to upgrade
+
+| Item | Local anchor | External source checked 2026-06-30 | Why it belongs here | Upgrade path |
+|---|---|---|---|---|
+| BudgetMem | [`stub`](../papers/stubs/budgetmem-learning-query-aware-budget-tier-routing-for.md) | <https://arxiv.org/abs/2602.06025> and <https://github.com/ViktorAxelsen/BudgetMem> | query-aware budget-tier routing:按查询难度选择不同 memory processing tier。 | 升级为 full note;记录 code license、router training、LoCoMo/LongMemEval/HotpotQA 设置。 |
+| Structured Distillation for Personalized Agent Memory | [`stub`](../papers/stubs/structured-distillation-for-personalized-agent-memory-11.md) | <https://arxiv.org/abs/2603.13017> and <https://github.com/Process-Point-Technologies-Corporation/searchat> | 论文声称 11x token reduction with retrieval preservation,并有 Searchat 代码实现。 | 复核 compression ratio、MRR 设置、是否保存 provenance/conflict。 |
+| MEMAUDIT | [`stub`](../papers/stubs/memaudit-an-exact-package-oracle-evaluation-protocol-for.md) | <https://arxiv.org/abs/2605.02199> | budgeted long-term memory writing 的 evaluator,可约束"省空间但不乱写"。 | 升级 benchmark/evaluator note;明确 package oracle 和 storage budget。 |
+| A2RAG | [`stub`](../papers/stubs/a2rag-adaptive-agentic-graph-retrieval-for-cost-aware-and.md) | <https://arxiv.org/abs/2601.21162> | cost-aware adaptive Graph-RAG,只在需要时触发更贵的 graph/verification 路径。 | 判断是否属于 agent memory core 还是 Graph-RAG 相邻方法。 |
+| DimMem | external candidate | <https://arxiv.org/abs/2605.15759>, <https://github.com/ChowRunFa/DimMem> | dimensional structuring + Qwen3-4B extractor,报告 LoCoMo per-query token cost reduction。 | 新建 paper stub/full note 前要避开旧 radar 中错误 DimMem arXiv ID。 |
+| LIGHTMEM: Lightweight and Efficient Memory-Augmented Generation | [`stub`](../papers/stubs/lightmem-lightweight-and-efficient-memory-augmented.md) | <https://arxiv.org/abs/2510.18866> | adjacent memory-augmented generation cost method,不是同名 ACL 2026 LightMem。 | 如纳入,必须 disambiguate name collision。 |
+
+### Product and practice signals
+
+| Product / implementation | Local anchor | Cost-saving mechanism | Evidence boundary |
+|---|---|---|---|
+| Mem0 | [`product note`](../products/mem0.md), [`paper note`](../papers/mem0-paper.md) | ADD/UPDATE/DELETE/NOOP memory ops,scope filtering,只把检索到的 memory 放回 prompt。 | 产品和论文都与 vendor 相关;claims ledger 仍按 affiliated/vendor 读。 |
+| TencentDB Agent Memory | [`product note`](../products/tencentdb-agent-memory.md) | L0 Conversation / L1 Atom / L2 Scenario / L3 Persona + short-term context offloading。 | token reduction 和 PersonaMem claim 是官方自测。 |
+| OpenViking | [`product note`](../products/openviking.md) | L0/L1/L2 hierarchical context loading,filesystem-style context DB,减少长期任务直接塞 full context。 | benchmark/token 数字按 vendor-claimed 处理;它是 context database,不只是 memory layer。 |
+| Searchat | external implementation | structured persistent memory + retrieval-preserving distillation implementation. | 当前仓库没有 product note;先作为 code path,不是产品结论。 |
+
+## Code / implementation index
+
+| Code path | Source | What to inspect for cost-saving practice | Local status |
+|---|---|---|---|
+| BudgetMem | <https://github.com/ViktorAxelsen/BudgetMem> | module budget tiers、RL router、LoCoMo/LongMemEval/HotpotQA data prep、cost-aware objective。 | local paper stub only。 |
+| Searchat | <https://github.com/Process-Point-Technologies-Corporation/searchat> | structured persistent memory pipeline、distillation/retrieval preservation、release maturity。 | external only。 |
+| DimMem | <https://github.com/ChowRunFa/DimMem> | Qwen3-4B extractor、dimension schema、reported LoCoMo token reduction setup。 | external only;needs new local note。 |
+| Mem0 | <https://github.com/mem0ai/mem0> | ADD/UPDATE/DELETE/NOOP memory ops、scope filtering、host SDK API、graph optional path。 | local product + full paper note。 |
+| TencentDB Agent Memory | <https://github.com/TencentCloud/TencentDB-Agent-Memory> | L0-L3 artifact pipeline、context offloading、local SQLite/sqlite-vec path。 | local product note。 |
+| OpenViking | <https://github.com/volcengine/OpenViking> | L0/L1/L2 context loading、filesystem-style context DB、MCP/OpenClaw integration。 | local product note。 |
+
+## Method checklist for a cost-saving memory experiment
+
+1. 定义成本维度:input tokens、output tokens、LLM calls、retrieval calls、p95 latency、
+   storage/indexing、human review time 至少选一个主指标。
+2. 建 full-context baseline,并记录当前模型价格和 prompt caching 状态。
+3. 同时跑质量指标:recall、temporal reasoning、multi-hop、preference consistency、
+   abstention 或 task success。
+4. 给 memory 写路径分账:extract、dedup、merge/update、delete/forget、offline
+   consolidation、index refresh。
+5. 给读路径分账:embedding、candidate retrieval、rerank、graph traversal、context
+   packing、final generation。
+6. 对 vendor claim 使用 `vendor_self_report` / `self_claim` 语言,不要写成 independent
+   reproduction。
+7. 若方法牺牲 provenance、valid time、delete/export 或 human review,必须把治理成本写进
+   caveat。
+
+## ImpactReport use policy
+
+| Evidence status | Allowed use |
+|---|---|
+| full local note + ledger row where needed | 可进入 ImpactReport evidence;仍需列出 cost / quality / risk 三类指标。 |
+| seed local note | 可提出 `monitor` 或 `prototype` 建议;不可单独支持 core change。 |
+| stub-only paper | 只能列为 discovery gap 或 upgrade candidate。 |
+| external-only code path | 只能列为 implementation path to inspect;不能当成本效果证据。 |
+| vendor self-report | 只能写成 vendor claim;除非有独立复现,不得和 paper/independent rows 合并。 |
+
+## Current gaps
+
+| Gap | Why it matters |
+|---|---|
+| BudgetMem、Structured Distillation、MEMAUDIT、A2RAG 仍是 stub-only | 它们是最像"成本专题"的论文,但还不能直接用于 ImpactReport。 |
+| DimMem 尚无本地 note | 外部 source 看起来相关,但需要先加入纸面证据和正确 arXiv ID。 |
+| 产品 claims 没有独立复现 | Mem0、TencentDB、OpenViking 都适合做实践样本,但不能直接排名。 |
+| API-pricing drift | cost break-even 需要随模型价格、缓存、context window 和输入/输出倍率重算。 |
+
+## Next refresh queries
+
+- `agent memory cost token reduction`
+- `agent memory budgeted retrieval`
+- `runtime agent memory budget routing`
+- `long context vs memory API cost`
+- `structured distillation personalized agent memory`
+- `context database AI agents token cost`

--- a/docs/research-radar.md
+++ b/docs/research-radar.md
@@ -41,6 +41,11 @@ catalog,中文社区单独成节。该文档是 Radar 信息面的 single source
 并行子 agent 搜索、主 agent 整合、source/relevance review 后的 must-add /
 update-existing / watchlist / reject 决策,避免把快照判断散落到单条笔记里。
 
+如果问题聚焦 token reduction、runtime cost、budgeted retrieval、SLM/offline
+consolidation 或产品化 context offloading,先看成本专题入口
+[`cost-savings-landscape.md`](cost-savings-landscape.md),再决定是否升级单篇
+ResearchItem、BenchmarkItem 或 ImpactReport。
+
 ## 3. ResearchItem schema
 
 每篇论文/产品笔记的最小字段:
@@ -153,6 +158,10 @@ candidate plugin / module
      - latency/cost
      - regression rate
 ```
+
+成本驱动实验要回链到 [`cost-savings-landscape.md`](cost-savings-landscape.md) 中的
+成本维度和证据边界,避免只报告"省 token"而不报告质量、延迟、写路径成本或 vendor
+self-report 边界。
 
 ## 7. 架构决策(ADR)
 

--- a/docs/ymem-binding/research-radar.md
+++ b/docs/ymem-binding/research-radar.md
@@ -62,6 +62,10 @@ decision_relevance: |
 [`taxonomy-modules.md`](taxonomy-modules.md);若发现新模块概念,先在那里 PR
 增加,再写笔记。
 
+如果候选项的主要价值是降低 token、latency、LLM call 或运行成本,先从通用成本专题
+[`../cost-savings-landscape.md`](../cost-savings-landscape.md) 读取证据边界,再决定
+是否进入 Ymem ImpactReport 或沙盒实验。
+
 ## 3. Ymem 沙盒实验细节
 
 ```text
@@ -77,6 +81,9 @@ candidate plugin / module
      - latency/cost
      - regression rate
 ```
+
+成本类实验必须同时记录 quality regression 与 runtime/cost profile,并把 vendor
+self-report、affiliated evaluation 和 independent reproduction 分开引用。
 
 EvalCase suite 当前来自:
 - LongMemEval([`../../papers/longmemeval.md`](../../papers/longmemeval.md))

--- a/impact-reports/README.md
+++ b/impact-reports/README.md
@@ -37,12 +37,20 @@ reproductions do not get mixed.
 - Benchmark, product behavior, implementation detail, or source-page evidence.
 - Keep vendor self-report, affiliated evaluation, critique, and independent
   reproduction in separate bullets.
+- Cost-saving claims must cite a full local note or an explicitly labeled
+  candidate from `../docs/cost-savings-landscape.md`; stub-only and external-only
+  rows are allowed only as upgrade gaps, not as decision evidence.
 
 ## Costs and risks
 - Implementation cost:
 - Runtime cost:
 - Privacy/provenance risk:
 - Maintenance risk:
+- Cost-saving evidence quality:
+  - cost metric reported:
+  - quality metric reported:
+  - pricing/model/date assumptions:
+  - reproduction class:
 
 ## Recommendation
 - ignore | monitor | prototype | adopt_as_plugin | consider_core_change


### PR DESCRIPTION
## Summary

- Add `docs/cost-savings-landscape.md` as a dedicated zh-CN seed landscape for agent-memory cost-saving papers, methods, code paths, and products.
- Wire the new lane into the English/Chinese READMEs, docs index, global research radar, and Ymem research radar.
- Strengthen ImpactReport guidance so cost-saving claims must carry cost, quality, pricing/date, and reproduction boundaries before they support decisions.

## Validation

- `git diff --cached --check`
- `ruby scripts/verify_memory_refresh.rb`
- Ruby `Net::HTTP` URL check for external links in `docs/cost-savings-landscape.md`