### PR TITLE
[codex] Add repo-local fit-review skill

### DIFF
--- a/.codex/skills/awesome-agent-memory/SKILL.md
+++ b/.codex/skills/awesome-agent-memory/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: awesome-agent-memory
+description: "Use when comparing an external project, codebase, algorithm, product, startup, or research direction against the awesome-agent-memory evidence base for agent-memory fit, gaps, risks, benchmarks, product analogs, or implementation guidance."
+---
+
+# Awesome Agent Memory
+
+## Overview
+
+Use this repository as a decision-grade evidence base for evaluating an external project, codebase, algorithm, product, or research direction against the current agent-memory field. The goal is not to maintain this repo; it is to map the user's object onto known memory architectures, product patterns, benchmark protocols, evidence gaps, and implementation risks.
+
+Keep every recommendation traceable to a canonical evidence class. Do not invent new labels when an existing class fits.
+
+## Start Here
+
+First separate the two workspaces:
+
+| Root | Meaning | How to resolve |
+| --- | --- | --- |
+| `TARGET_ROOT` | The user's project, codebase, product docs, algorithm notes, or research artifact being evaluated | Use the current workspace when it is the user's object, or the path/URL/file they provide |
+| `AAM_ROOT` | The `awesome-agent-memory` evidence repository checkout | Use this repo when already inside it; otherwise locate an awesome-agent-memory checkout or ask for its path before reading repo evidence |
+
+Do not treat `README.md`, `docs/`, `papers/`, `products/`, or `benchmarks/` as evidence paths until `AAM_ROOT` is known. When working from another repository, prefix evidence reads with `AAM_ROOT`.
+
+Then extract the user's object from `TARGET_ROOT`:
+
+| User object | Extract |
+| --- | --- |
+| Codebase or algorithm | memory write/read path, storage model, retrieval/ranking, consolidation, forgetting, personalization, evaluation hooks |
+| Product or startup | target user, memory promise, workflow surface, retention/control model, competitive set, buyer risk |
+| Research idea | claimed novelty, task setting, baselines, datasets, metrics, expected failure modes |
+| Architecture proposal | memory modules, data lifecycle, provenance, privacy, latency/cost envelope, observability |
+
+Minimum input gate: inspect at least one concrete path, URL, document, code file, design note, README, product page, or architecture description from the user before giving a verdict. If the user only gives a vague description, ask for the smallest missing artifact and do not judge from a vague description.
+
+Then read only the repo lane that can answer the comparison:
+
+| Task | First files |
+| --- | --- |
+| Field overview | `README.md`, `docs/README.md`, `docs/agent-memory-survey.md`, `docs/taxonomy.md` |
+| Architecture fit | `docs/product-memory-architectures.md`, `docs/product-architecture-diagrams.md`, relevant `products/*.md` |
+| Product positioning | `docs/products-landscape.md`, `docs/product-discovery-log.md`, relevant `products/*.md` and `products/archives/*.md` |
+| Research or algorithm comparison | `papers/index.md`, relevant `papers/*.md`, `docs/research-radar.md` |
+| Evaluation plan | `docs/benchmarks-landscape.md`, `benchmarks/index.md`, `benchmarks/claims/claims.yaml` |
+| Recent signals | latest `docs/memory-radar-*.md`, `docs/signals.md`, `docs/information-sources.md` |
+| Memory-kernel module mapping | `docs/ymem-binding/README.md`, `docs/ymem-binding/taxonomy-modules.md` |
+
+## Workflow
+
+1. State the comparison target in one sentence: what the user is building or evaluating and what decision they need.
+2. Resolve `TARGET_ROOT` and `AAM_ROOT`, then inspect the minimum user artifact before making claims.
+3. Build a lightweight feature map: memory type, lifecycle, storage, retrieval, update policy, personalization, privacy/governance, evaluation, and product surface.
+4. Search `AAM_ROOT` for matching papers, products, benchmarks, and synthesis pages. Prefer `rg` over broad reading.
+5. Compare against the closest evidence-backed analogs. Separate exact matches, partial analogs, missing evidence, and out-of-scope similarities.
+6. Evaluate fit and risks using explicit criteria: novelty, technical soundness, product differentiation, implementation complexity, evaluation readiness, and evidence strength.
+7. Produce guidance: what to keep, what to change, what to test next, which benchmark or paper/product note to inspect, and what claims the user should avoid making.
+
+If current product claims, APIs, releases, pricing, or policies affect the judgment, browse official or primary sources before treating them as current.
+
+## Evidence Rules
+
+Allowed evidence classes:
+
+| Evidence class | Can support | Must not support by itself |
+| --- | --- | --- |
+| `primary_paper` | Method, benchmark protocol, reported setup, author-reported results | Independent product performance or broad market claims |
+| `paper_stub` | Discovery coverage and candidate relevance | Method claims, architecture recommendations, or benchmark conclusions without upgrading the stub |
+| `product_behavior` | What a product page, product note, or archived page says or offers | Independent reproduction, objective superiority, or durability claims |
+| `vendor_benchmark_claim` | Vendor-reported or affiliated benchmark claims under the actor's setup | Independent benchmark evidence |
+| `affiliated_evaluation` | Labeled comparison under the actor's setup | Independent benchmark evidence |
+| `independent_reproduction_or_critique` | Narrow claim with setup and comparability notes | Broader conclusions than the reproduction or critique tested |
+| `maintainer_synthesis_or_inference` | Prioritization, taxonomy, architecture judgment, or explicitly labeled inference | Direct evidence unless linked to an underlying source |
+
+Keep uncertain matches labeled as `strong match`, `partial match`, `weak analogy`, `watchlist`, or `needs verification`. Do not turn vendor positioning, affiliated benchmark pages, or product marketing into independent evidence.
+
+## Output Shape
+
+For a concise review, use:
+
+```markdown
+## Verdict
+[1-3 sentence judgment tied to the user's decision]
+
+## Fit Map
+| Dimension | User object | Closest AAM evidence (path + section/heading/line when available) | Evidence class (allowed value above) | Confidence | Assessment |
+| --- | --- | --- | --- | --- | --- |
+
+## Comparable References
+- `AAM repo path` + section/heading/line when available, or URL: why it matters; evidence class; confidence
+
+## Gaps And Risks
+- [risk]: supporting AAM repo path + section/heading/line when available, evidence class, confidence, and impact
+
+## Recommendations
+- [action]: why, source-backed rationale with AAM path/section/heading/line when available, next validation, expected signal
+```
+
+When citing repository evidence, use the narrowest stable locator available: file path first, then section or heading, and line number when the tool output provides one.
+
+For deeper work, add a benchmark plan, product positioning matrix, architecture delta, or paper-to-implementation checklist.
+
+## Common Mistakes
+
+- Over-reading the repo before extracting the user's concrete memory surface.
+- Comparing only against products when the real issue is an evaluation or algorithm claim.
+- Treating local stubs, watchlist items, vendor claims, or affiliated benchmarks as strong evidence.
+- Giving generic agent-memory advice without naming the closest repo evidence.
+- Saying a project is novel before checking product notes, paper notes, and benchmark claims.
+
+## Avoid
+
+- Do not edit repository evidence files unless the user explicitly asks to maintain the repo.
+- Do not commit secrets, private code, proprietary records, or unreviewed raw transcripts from the user's project.
+- Do not force every project into Ymem-specific terminology; use `docs/ymem-binding/` only when module mapping is useful.
+- Do not claim market or benchmark superiority without independent evidence.

--- a/.codex/skills/awesome-agent-memory/agents/openai.yaml
+++ b/.codex/skills/awesome-agent-memory/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Agent Memory Fit Review"
+  short_description: "Compare projects with agent-memory evidence"
+  default_prompt: "Use $awesome-agent-memory to compare my project, code, algorithm, or product as TARGET_ROOT against the awesome-agent-memory evidence base as AAM_ROOT. Ask for either path if missing, then give source-backed guidance."

--- a/README.md
+++ b/README.md
@@ -82,6 +82,41 @@ Start with the path that matches your question:
 | Turn research into a memory-kernel decision | [`docs/research-radar.md`](docs/research-radar.md), then [`impact-reports/README.md`](impact-reports/README.md) |
 | See Ymem-specific bindings | [`docs/ymem-binding/README.md`](docs/ymem-binding/README.md) |
 
+### Use It With The Repo-Local Skill
+
+Users of skill-enabled agent tools can also invoke the repo-local skill
+`$awesome-agent-memory` to use this repository as an evidence-backed review tool.
+
+Prerequisite: open this repository in an agent tool that loads
+`.codex/skills/*/SKILL.md`, or install or enable this skill in your agent
+environment. If `$awesome-agent-memory` is not available, use
+`.codex/skills/awesome-agent-memory/SKILL.md` as the instruction and pass this
+checkout as `AAM_ROOT`.
+
+Use it when you want to compare your own project, codebase, algorithm, product,
+startup idea, or research direction against the papers, product notes, benchmark
+records, and synthesis docs in this repository.
+
+Typical entry modes:
+
+| Where you are | What to ask |
+|---|---|
+| Inside this repository | Treat this checkout as `AAM_ROOT` and compare `/path/to/my-project` as `TARGET_ROOT`. |
+| Inside your own project, with this skill installed or enabled | Treat the current project as `TARGET_ROOT` and point the skill to `/path/to/awesome-agent-memory` as `AAM_ROOT`; otherwise start from this repository and pass your project path as `TARGET_ROOT`. |
+
+Example:
+
+```text
+Use $awesome-agent-memory to compare /path/to/my-project as TARGET_ROOT
+against this checkout as AAM_ROOT.
+Focus on architecture fit, product analogs, benchmark plan, and risky claims.
+```
+
+The skill expects a concrete target artifact such as a path, URL, README, design
+note, product page, or code file. It separates `TARGET_ROOT` from `AAM_ROOT`,
+then returns a fit map, comparable references, gaps and risks, and source-backed
+recommendations with evidence class and confidence.
+
 ## Evidence Model
 
 The repository is organized so claims can be traced back to their source type.
@@ -160,6 +195,7 @@ flowchart LR
 | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) | Community conduct policy. |
 | [`SECURITY.md`](SECURITY.md) | Security reporting guidance. |
 | [`CITATION.cff`](CITATION.cff) | Citation metadata. |
+| [`.codex/skills/awesome-agent-memory/`](.codex/skills/awesome-agent-memory/) | Repo-local skill for comparing external projects, code, algorithms, or products against this evidence base. |
 | [`docs/ymem-binding/`](docs/ymem-binding/) | Project-specific bindings for the maintainer's [Ymem](https://github.com/Snseam/Ymem) kernel. Safe to skip if you only need the generic evidence base. |
 
 ## Scope Boundaries

--- a/README_cn.md
+++ b/README_cn.md
@@ -80,6 +80,38 @@
 | 把研究转成 kernel 决策 | [`docs/research-radar.md`](docs/research-radar.md)，再用 [`impact-reports/README.md`](impact-reports/README.md) |
 | 查看 Ymem 特定绑定 | [`docs/ymem-binding/README.md`](docs/ymem-binding/README.md) |
 
+### 用 repo-local Skill 使用本仓
+
+使用支持 repo-local skill 的 agent 工具时，也可以调用
+`$awesome-agent-memory`，把本仓作为一个有证据支撑的评审工具使用。
+
+前提：在能加载 `.codex/skills/*/SKILL.md` 的 agent 工具中打开本仓，或先把这个
+skill 安装或启用到你的 agent 环境。如果 `$awesome-agent-memory` 不可用，就直接
+使用 `.codex/skills/awesome-agent-memory/SKILL.md` 里的指令，并把当前 checkout
+作为 `AAM_ROOT`。
+
+适用场景：你想把自己的项目、代码库、算法、产品、创业方向或研究方向，与本仓的
+论文、产品笔记、benchmark 记录和综合文档进行对比。
+
+常见入口：
+
+| 你在哪里 | 怎么说 |
+|---|---|
+| 在本仓 | 把当前 checkout 作为 `AAM_ROOT`，把 `/path/to/my-project` 作为 `TARGET_ROOT`。 |
+| 在自己的项目仓库，且 skill 已安装或启用 | 把当前项目作为 `TARGET_ROOT`，并指定 `/path/to/awesome-agent-memory` 作为 `AAM_ROOT`；否则先从本仓启动，再把你的项目路径作为 `TARGET_ROOT`。 |
+
+示例：
+
+```text
+使用 $awesome-agent-memory，把 /path/to/my-project 作为 TARGET_ROOT，
+与当前 checkout 这个 AAM_ROOT 对比。
+重点看架构适配、相似产品、benchmark 方案和不能随便宣称的风险点。
+```
+
+这个 skill 需要一个具体目标材料，例如路径、URL、README、设计文档、产品页面或
+代码文件。它会区分 `TARGET_ROOT` 和 `AAM_ROOT`，然后输出适配图、可比参考、
+差距与风险，以及带证据类别和置信度的建议。
+
 ## 证据模型
 
 仓库按来源类型组织 claims，方便追溯：
@@ -158,6 +190,7 @@ flowchart LR
 | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) | 社区行为准则。 |
 | [`SECURITY.md`](SECURITY.md) | 安全问题报告方式。 |
 | [`CITATION.cff`](CITATION.cff) | 引用元数据。 |
+| [`.codex/skills/awesome-agent-memory/`](.codex/skills/awesome-agent-memory/) | repo-local skill，用来把外部项目、代码、算法或产品与本仓证据库进行对比。 |
 | [`docs/ymem-binding/`](docs/ymem-binding/) | 维护者的 [Ymem](https://github.com/Snseam/Ymem) kernel 项目绑定；如果只需要通用证据库，可以跳过。 |
 
 ## 范围边界


### PR DESCRIPTION
## Summary

- Add a repo-local `$awesome-agent-memory` skill for comparing external projects, codebases, algorithms, products, startups, or research directions against this repository evidence base.
- Document the skill in both top-level READMEs, including the `TARGET_ROOT` / `AAM_ROOT` split, supported entry modes, discovery fallback, and repository layout entry.
- Canonicalize evidence classes in the skill output contract so reviews keep paper, product, benchmark, reproduction, and maintainer synthesis evidence separate.

## Why

This repository is increasingly useful as an evidence base, not only as a reading list. The repo-local skill gives developers and agent-tool users a concrete workflow for bringing their own artifact to the corpus and getting a source-backed fit review without confusing the evaluated project with the evidence repository.

## Validation

- `git diff --check`
- staged diff whitespace check
- `ruby scripts/verify_memory_refresh.rb`
- skill YAML/frontmatter smoke check
- README/skill content smoke check for `TARGET_ROOT`, `AAM_ROOT`, canonical evidence classes, and skill discovery fallback

## Notes

- `quick_validate.py` was not present in this checkout, so it was not run.
- This PR is draft until final maintainer review.
