### PR TITLE
Refresh July memory radar

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 [![Papers](https://img.shields.io/badge/papers-989-brightgreen.svg)](papers/index.md)
 [![PDFs](https://img.shields.io/badge/local_PDFs-534-orange.svg)](papers/pdfs/)
 [![Memory products](https://img.shields.io/badge/memory%20products-38-purple.svg)](products/)
-[![Benchmarks](https://img.shields.io/badge/benchmarks-18-blueviolet.svg)](benchmarks/)
+[![Benchmarks](https://img.shields.io/badge/benchmarks-21-blueviolet.svg)](benchmarks/)
 [![Surveys](https://img.shields.io/badge/meta_surveys-6-yellow.svg)](docs/meta-surveys.md)
-[![Updated](https://img.shields.io/badge/updated-2026--06-lightgrey.svg)](docs/signals.md)
+[![Updated](https://img.shields.io/badge/updated-2026--07-lightgrey.svg)](docs/signals.md)
 
 </div>
 
@@ -55,13 +55,13 @@ separate buckets.
 
 | Area | Current coverage | Entry point | Use it when you need to |
 |---|---:|---|---|
-| Paper index | 989 scraped papers + 2026-06 manual radar additions | [`papers/index.md`](papers/index.md) | Searchable entry point for agent-memory papers; the 989 count is the 2026-05 scrape baseline. |
+| Paper index | 989 scraped papers + manual radar additions through 2026-07 | [`papers/index.md`](papers/index.md) | Searchable entry point for agent-memory papers; the 989 count is the 2026-05 scrape baseline. |
 | Paper stubs | 988 stubs | [`papers/stubs/`](papers/stubs/) | Track papers that are covered but not yet fully read. |
 | Local PDFs | 534 files | [`papers/pdfs/`](papers/pdfs/) | Re-read sources and audit paper notes. |
-| Full / seed paper notes | 7 full + 12 seed | [`papers/`](papers/) | Use human-read notes for architectural decisions. |
+| Full / seed paper notes | 7 full + 15 seed | [`papers/`](papers/) | Use human-read notes for architectural decisions. |
 | Memory product notes | 38 notes | [`products/`](products/) | Compare memory layers, memory SDKs, managed memory, and memory-enabled agents. |
 | Product page archives | 37 snapshots | [`products/archives/`](products/archives/) | Audit product claims after source pages change. |
-| Benchmark catalog | 18 catalog rows | [`benchmarks/index.md`](benchmarks/index.md) | First-class benchmark records plus stub-backed candidate rows and a usage-claim ledger. |
+| Benchmark catalog | 21 catalog rows | [`benchmarks/index.md`](benchmarks/index.md) | First-class benchmark records plus stub-backed candidate rows and a usage-claim ledger. |
 | Claims ledger | Structured YAML ledger | [`benchmarks/claims/claims.yaml`](benchmarks/claims/claims.yaml) | Separate vendor claims, paper evaluations, critiques, and reproductions. |
 | Cost-savings lane | Seed landscape | [`docs/cost-savings-landscape.md`](docs/cost-savings-landscape.md) | Find agent-memory papers, methods, code paths, and products that reduce token, latency, or runtime cost. |
 | Survey and taxonomy | 1 living survey + 6 meta-survey records | [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) · [`docs/meta-surveys.md`](docs/meta-surveys.md) | Build a field-level view before choosing an implementation. |
@@ -74,7 +74,7 @@ Start with the path that matches your question:
 | Goal | Read these first |
 |---|---|
 | Get the field overview | [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md), then [`docs/taxonomy.md`](docs/taxonomy.md) |
-| Read the latest source refresh | [`docs/memory-radar-2026-06.md`](docs/memory-radar-2026-06.md), then [`docs/signals.md`](docs/signals.md) |
+| Read the latest source refresh | [`docs/memory-radar-2026-07.md`](docs/memory-radar-2026-07.md), then [`docs/signals.md`](docs/signals.md) |
 | Find relevant papers | [`papers/index.md`](papers/index.md), then full notes under [`papers/`](papers/) |
 | Compare memory products | [`docs/products-landscape.md`](docs/products-landscape.md), [`docs/product-memory-architectures.md`](docs/product-memory-architectures.md), [`docs/product-architecture-diagrams.md`](docs/product-architecture-diagrams.md) |
 | Check why a product was included or rejected | [`docs/product-discovery-log.md`](docs/product-discovery-log.md) |
@@ -159,7 +159,7 @@ flowchart LR
 | [`docs/taxonomy.md`](docs/taxonomy.md) | Shared vocabulary for classifying agent-memory systems and memory-kernel responsibilities. |
 | [`docs/meta-surveys.md`](docs/meta-surveys.md) | External meta-survey index from late 2025 through 2026 H1. |
 | [`docs/research-radar.md`](docs/research-radar.md) | Workflow for turning papers, products, and benchmark evidence into ImpactReports and ADR inputs. |
-| [`docs/memory-radar-2026-06.md`](docs/memory-radar-2026-06.md) | 2026-06 current-source refresh across papers, products, GitHub projects, and reviewer decisions. |
+| [`docs/memory-radar-2026-07.md`](docs/memory-radar-2026-07.md) | 2026-07 weekly refresh across papers, products, GitHub projects, and reviewer decisions. |
 | [`docs/cost-savings-landscape.md`](docs/cost-savings-landscape.md) | Focused lane for agent-memory token reduction, budgeted retrieval, runtime-cost methods, code paths, and product practice signals. |
 | [`docs/information-sources.md`](docs/information-sources.md) | Source catalog for papers, products, communities, and zh-CN information channels. |
 | [`docs/related-work.md`](docs/related-work.md) | Discovery-input attribution and scrape provenance. |
@@ -180,11 +180,11 @@ flowchart LR
 
 | Path | Purpose |
 |---|---|
-| [`papers/`](papers/) | 7 full paper notes, 12 seed notes, and the master [`index.md`](papers/index.md). |
+| [`papers/`](papers/) | 7 full paper notes, 15 seed notes, and the master [`index.md`](papers/index.md). |
 | [`papers/stubs/`](papers/stubs/) | 988 generated stubs for papers not yet fully read. |
 | [`papers/pdfs/`](papers/pdfs/) | 534 archived PDFs, about 1.8 GB. See the archival policy below. |
 | [`papers/_scrape/`](papers/_scrape/) | Reproducibility artifacts: scrape script and dedup JSON. |
-| [`benchmarks/`](benchmarks/) | 18 benchmark catalog rows, including protocol notes, stub-backed candidate rows, and the note template. |
+| [`benchmarks/`](benchmarks/) | 21 benchmark catalog rows, including protocol notes, stub-backed candidate rows, and the note template. |
 | [`benchmarks/claims/`](benchmarks/claims/) | Usage-event ledger for benchmark mentions, vendor claims, critiques, and reproductions. |
 | [`benchmarks/archives/`](benchmarks/archives/) | Optional source-page snapshots for benchmark pages, repositories, or dataset cards. |
 | [`docs/benchmarks-landscape.md`](docs/benchmarks-landscape.md) | Benchmark landscape by capability, usage type, and evidence independence. |

--- a/README_cn.md
+++ b/README_cn.md
@@ -10,9 +10,9 @@
 [![Papers](https://img.shields.io/badge/papers-989-brightgreen.svg)](papers/index.md)
 [![PDFs](https://img.shields.io/badge/local_PDFs-534-orange.svg)](papers/pdfs/)
 [![记忆产品](https://img.shields.io/badge/memory%20products-38-purple.svg)](products/)
-[![Benchmarks](https://img.shields.io/badge/benchmarks-18-blueviolet.svg)](benchmarks/)
+[![Benchmarks](https://img.shields.io/badge/benchmarks-21-blueviolet.svg)](benchmarks/)
 [![Surveys](https://img.shields.io/badge/meta_surveys-6-yellow.svg)](docs/meta-surveys.md)
-[![Updated](https://img.shields.io/badge/updated-2026--06-lightgrey.svg)](docs/signals.md)
+[![Updated](https://img.shields.io/badge/updated-2026--07-lightgrey.svg)](docs/signals.md)
 
 </div>
 
@@ -53,13 +53,13 @@
 
 | 板块 | 当前覆盖 | 入口 | 适合用来 |
 |---|---:|---|---|
-| 论文索引 | 989 篇抓取论文 + 2026-06 手工 radar 新增 | [`papers/index.md`](papers/index.md) | 搜索 agent-memory 论文和发现线索；989 是 2026-05 抓取基线。 |
+| 论文索引 | 989 篇抓取论文 + 截至 2026-07 的手工 radar 新增 | [`papers/index.md`](papers/index.md) | 搜索 agent-memory 论文和发现线索；989 是 2026-05 抓取基线。 |
 | 论文 stub | 988 个 stub | [`papers/stubs/`](papers/stubs/) | 跟踪已覆盖但尚未 full 阅读的论文。 |
 | 本地 PDF | 534 个文件 | [`papers/pdfs/`](papers/pdfs/) | 复读来源和审计论文笔记。 |
-| full / seed 论文笔记 | 7 个 full + 12 个 seed | [`papers/`](papers/) | 为架构决策引用人工阅读笔记。 |
+| full / seed 论文笔记 | 7 个 full + 15 个 seed | [`papers/`](papers/) | 为架构决策引用人工阅读笔记。 |
 | 记忆产品笔记 | 38 个笔记 | [`products/`](products/) | 对比 memory layer、memory SDK、managed memory 和带记忆的 agent 产品。 |
 | 产品页面快照 | 37 个快照 | [`products/archives/`](products/archives/) | 在源页面变化后审计产品 claims。 |
-| Benchmark 目录 | 18 个 catalog 行 | [`benchmarks/index.md`](benchmarks/index.md) | 理解 memory benchmark、stub-backed 候选行及其 claims 来源。 |
+| Benchmark 目录 | 21 个 catalog 行 | [`benchmarks/index.md`](benchmarks/index.md) | 理解 memory benchmark、stub-backed 候选行及其 claims 来源。 |
 | Claims ledger | 结构化 YAML ledger | [`benchmarks/claims/claims.yaml`](benchmarks/claims/claims.yaml) | 区分厂商自报、论文评测、方法批评和独立复现。 |
 | 成本节省专题 | seed landscape | [`docs/cost-savings-landscape.md`](docs/cost-savings-landscape.md) | 查找能减少 token、延迟或运行成本的 agent-memory 论文、方法、代码和产品。 |
 | 综述与 taxonomy | 1 份活综述 + 6 条 meta-survey 记录 | [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) · [`docs/meta-surveys.md`](docs/meta-surveys.md) | 在选型或设计前建立领域视角。 |
@@ -72,7 +72,7 @@
 | 目标 | 先读这些 |
 |---|---|
 | 快速理解领域 | [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md)，再读 [`docs/taxonomy.md`](docs/taxonomy.md) |
-| 阅读最新来源刷新 | [`docs/memory-radar-2026-06.md`](docs/memory-radar-2026-06.md)，再看 [`docs/signals.md`](docs/signals.md) |
+| 阅读最新来源刷新 | [`docs/memory-radar-2026-07.md`](docs/memory-radar-2026-07.md)，再看 [`docs/signals.md`](docs/signals.md) |
 | 找相关论文 | [`papers/index.md`](papers/index.md)，再看 [`papers/`](papers/) 下的 full note |
 | 比较记忆产品 | [`docs/products-landscape.md`](docs/products-landscape.md)、[`docs/product-memory-architectures.md`](docs/product-memory-architectures.md)、[`docs/product-architecture-diagrams.md`](docs/product-architecture-diagrams.md) |
 | 查看产品为什么入库或被拒绝 | [`docs/product-discovery-log.md`](docs/product-discovery-log.md) |
@@ -154,7 +154,7 @@ flowchart LR
 | [`docs/taxonomy.md`](docs/taxonomy.md) | 分类 agent-memory 系统和 memory-kernel 职责的共享词表。 |
 | [`docs/meta-surveys.md`](docs/meta-surveys.md) | 2025 年末到 2026 H1 的外部 meta-survey 索引。 |
 | [`docs/research-radar.md`](docs/research-radar.md) | 把论文、产品、benchmark 证据转成 ImpactReport 和 ADR 输入的工作流。 |
-| [`docs/memory-radar-2026-06.md`](docs/memory-radar-2026-06.md) | 2026-06 当前来源刷新，覆盖论文、产品、GitHub 项目和 reviewer 分流结论。 |
+| [`docs/memory-radar-2026-07.md`](docs/memory-radar-2026-07.md) | 2026-07 周更来源刷新，覆盖论文、产品、GitHub 项目和 reviewer 分流结论。 |
 | [`docs/cost-savings-landscape.md`](docs/cost-savings-landscape.md) | agent-memory token reduction、预算检索、运行成本方法、代码路径和产品实践信号专题。 |
 | [`docs/information-sources.md`](docs/information-sources.md) | 论文、产品、社区和中文信息源 catalog。 |
 | [`docs/related-work.md`](docs/related-work.md) | 发现线索归因和抓取来源记录。 |
@@ -175,11 +175,11 @@ flowchart LR
 
 | 路径 | 用途 |
 |---|---|
-| [`papers/`](papers/) | 7 个 full 论文笔记、12 个 seed 笔记和主索引 [`index.md`](papers/index.md)。 |
+| [`papers/`](papers/) | 7 个 full 论文笔记、15 个 seed 笔记和主索引 [`index.md`](papers/index.md)。 |
 | [`papers/stubs/`](papers/stubs/) | 988 个尚未 full 阅读论文的生成 stub。 |
 | [`papers/pdfs/`](papers/pdfs/) | 534 个本地 PDF，约 1.8 GB。详见下方存档策略。 |
 | [`papers/_scrape/`](papers/_scrape/) | 可复现产物：抓取脚本和 dedup JSON。 |
-| [`benchmarks/`](benchmarks/) | 18 个 benchmark catalog 行，包含协议笔记、stub-backed 候选行和笔记模板。 |
+| [`benchmarks/`](benchmarks/) | 21 个 benchmark catalog 行，包含协议笔记、stub-backed 候选行和笔记模板。 |
 | [`benchmarks/claims/`](benchmarks/claims/) | benchmark 提及、厂商自报、方法批评和复现的 usage-event ledger。 |
 | [`benchmarks/archives/`](benchmarks/archives/) | benchmark 页面、repo 或 dataset card 的可选审计快照。 |
 | [`docs/benchmarks-landscape.md`](docs/benchmarks-landscape.md) | 按能力、使用方式和证据独立性整理的 benchmark 全景。 |

--- a/benchmarks/claims/claims.yaml
+++ b/benchmarks/claims/claims.yaml
@@ -135,6 +135,66 @@ events:
       - papers/stubs/memoryrewardbench-benchmarking-reward-models-for-long-term.md
       - https://arxiv.org/abs/2601.11969
     extract_confidence: medium
+  - event_id: memsyco-bench-origin-2026
+    benchmark_id: memsyco-bench
+    source_kind: paper
+    source_id: benchmarks/memsyco-bench.md
+    source_date: 2026-07
+    actor: MemSyco-Bench authors
+    actor_type: paper_authors
+    usage_type: originates_benchmark
+    claim_direction: methodological_only
+    compared_systems: []
+    reported_metrics: []
+    experimental_setup: "Benchmark for memory-induced sycophancy across scope, conflict, update, and personalization tasks; local note is seed quality."
+    reproduction_status: not_reproduced
+    evidence_level: primary_pdf
+    independence_class: survey_only
+    comparability_notes: "Origin protocol only; author-reported results and released resources need full normalization before use."
+    evidence_refs:
+      - benchmarks/memsyco-bench.md
+      - https://arxiv.org/abs/2607.01071
+    extract_confidence: medium
+  - event_id: memleak-origin-2026
+    benchmark_id: memleak
+    source_kind: paper
+    source_id: benchmarks/memleak.md
+    source_date: 2026-06
+    actor: MemLeak authors
+    actor_type: paper_authors
+    usage_type: originates_benchmark
+    claim_direction: methodological_only
+    compared_systems: []
+    reported_metrics: []
+    experimental_setup: "Benchmark for residual information recovery after deletion in multimodal memory systems; local note is seed quality."
+    reproduction_status: not_reproduced
+    evidence_level: primary_pdf
+    independence_class: survey_only
+    comparability_notes: "Origin protocol only; image sources, production-memory setup, and reported recovery rates need full read."
+    evidence_refs:
+      - benchmarks/memleak.md
+      - https://arxiv.org/abs/2606.29788
+    extract_confidence: medium
+  - event_id: memdelta-methodology-2026
+    benchmark_id: memdelta
+    source_kind: paper
+    source_id: benchmarks/memdelta.md
+    source_date: 2026-06
+    actor: MemDelta author
+    actor_type: paper_authors
+    usage_type: baseline_comparison
+    claim_direction: methodological_only
+    compared_systems: []
+    reported_metrics: []
+    experimental_setup: "Controlled evaluation protocol over LongMemEval-S for memory-vs-RAG/full-context comparisons; local note is seed quality."
+    reproduction_status: not_reproduced
+    evidence_level: primary_pdf
+    independence_class: survey_only
+    comparability_notes: "Use as a methodology checklist; do not treat source comparisons as independent product evidence."
+    evidence_refs:
+      - benchmarks/memdelta.md
+      - https://arxiv.org/abs/2606.29914
+    extract_confidence: medium
   - event_id: fact-memory-vs-long-context-baseline-2026
     benchmark_id: fact-memory-vs-long-context
     source_kind: paper

--- a/benchmarks/index.md
+++ b/benchmarks/index.md
@@ -46,6 +46,9 @@ official repository, dataset card, or independent reproduction.
 | MemBench | candidate | paper-origin | memory of LLM-based agents | write / manage / memory mechanism | [`../papers/stubs/membench-towards-more-comprehensive-evaluation-on-the.md`](../papers/stubs/membench-towards-more-comprehensive-evaluation-on-the.md) | yes |
 | DynamicMem | seed | paper-origin | evolving multi-app user profile memory | profile reconstruction / temporal update / retrieval at scale | [`dynamicmem.md`](dynamicmem.md) | yes |
 | MEMPROBE | seed | paper-origin | hidden user-state memory artifact audit | hidden-state recovery / full-store vs top-k probing | [`memprobe.md`](memprobe.md) | yes |
+| MemSyco-Bench | seed | paper-origin | memory-induced sycophancy | scope / conflict resolution / update / valid personalization | [`memsyco-bench.md`](memsyco-bench.md) | yes |
+| MemLeak | seed | paper-origin | multimodal deletion leakage | deletion compliance / provenance / residual image leakage | [`memleak.md`](memleak.md) | yes |
+| MemDelta | seed | paper-origin | memory-evaluation baseline control | component delta / model-family sensitivity / write-path cost | [`memdelta.md`](memdelta.md) | yes |
 
 ## Evidence Ledgers
 

--- a/benchmarks/memdelta.md
+++ b/benchmarks/memdelta.md
@@ -1,0 +1,76 @@
+---
+title: MemDelta — controlled baselines for agent-memory evaluation
+benchmark_id: memdelta
+name: MemDelta
+aliases:
+  - MemDelta
+status: seed
+origin_type: paper_origin
+origin_source: https://arxiv.org/abs/2606.29914
+first_public_date: 2026-06
+domain: memory_evaluation_methodology
+modality: text
+task_grain: controlled_memory_vs_rag_evaluation
+capability_axes:
+  - baseline_control
+  - cost_reporting
+  - model_family_sensitivity
+  - embedding_model_sensitivity
+data_nature: LongMemEval-S controlled protocol
+metrics:
+  - accuracy
+  - cost
+  - refusal_rate
+  - component_delta
+judge_type: source_protocol_check
+code_available: check
+data_available: check
+license: check
+known_limitations:
+  - seed note; protocol, significance tests, and compared pipelines need full read
+canonical_sources:
+  - https://arxiv.org/abs/2606.29914
+confidence: medium
+memory_modules:
+  - evaluator-benchmark
+  - retriever-reranker
+last_revised: 2026-07-06
+---
+
+# MemDelta
+
+## What It Measures
+
+MemDelta is a controlled evaluation protocol for agent-memory claims. It asks
+whether reported memory gains are actually caused by the memory architecture or
+by confounds such as the language model, embedding model, retrieval pipeline, or
+write-path cost.
+
+## Protocol
+
+The abstract describes one-component-at-a-time comparisons on LongMemEval-S
+across multiple model families. It recommends fixing embedding models across
+comparisons, stratifying by model family, and reporting write-path cost before
+attributing gains to a memory architecture.
+
+## Baselines and Reported Results
+
+No normalized results are logged here. MemDelta's reported comparisons remain
+paper-origin methodological claims until the setup is fully mapped.
+
+## Comparability Notes
+
+Use MemDelta as a claims-ledger discipline tool. It is not a new end-user memory
+task, but it is directly relevant when comparing Mem0, RAG, full context, and
+memory servers on LongMemEval-like protocols.
+
+## Related Papers
+
+- Paper:https://arxiv.org/abs/2606.29914
+
+## Impact Use
+
+- `evaluator-benchmark`:baseline-control checklist for future benchmark notes.
+- `retriever-reranker`:warns against comparing retrieval stacks with different
+  embedding models as if only memory architecture changed.
+- Ready for ImpactReport:no, upgrade after full protocol read.

--- a/benchmarks/memleak.md
+++ b/benchmarks/memleak.md
@@ -1,0 +1,79 @@
+---
+title: MemLeak — multimodal memory information-leak benchmark
+benchmark_id: memleak
+name: MemLeak
+aliases:
+  - MemLeak
+status: seed
+origin_type: paper_origin
+origin_source: https://arxiv.org/abs/2606.29788
+first_public_date: 2026-06
+domain: multimodal_memory_privacy
+modality: text_image
+task_grain: deletion_and_residual_recovery
+capability_axes:
+  - deletion_compliance
+  - provenance
+  - multimodal_residual_leakage
+  - policy_privacy
+data_nature: real_images_and_synthetic_or_curated_memory_pairs
+metrics:
+  - recovery_rate
+  - false_positive_rate
+  - judge_agreement
+judge_type: human_validated_and_model_probe
+code_available: check
+data_available: check
+license: check
+known_limitations:
+  - seed note; image sourcing, production-memory setup, and deletion protocol need full read
+canonical_sources:
+  - https://arxiv.org/abs/2606.29788
+confidence: medium
+memory_modules:
+  - evaluator-benchmark
+  - policy-privacy
+  - semantic-dedup
+last_revised: 2026-07-06
+---
+
+# MemLeak
+
+## What It Measures
+
+MemLeak evaluates whether facts requested for deletion can remain recoverable
+from retained multimodal memory artifacts, especially images that carry implicit
+visual cues correlated with deleted text facts.
+
+## Protocol
+
+The paper introduces an Information Provenance Graph taxonomy for deletion
+affordances and tests a deletion cascade. The arXiv abstract reports direct
+probing, correlated retained text, retained images, and content-aware semantic
+deletion conditions.
+
+## Baselines and Reported Results
+
+Reported recovery rates and human-validation agreement are paper-origin claims.
+This seed does not register them as independent reproduction evidence.
+
+## Validity / Contamination / License Caveats
+
+The paper mentions real Unsplash-licensed photographs and a production memory
+system. Full source, license, and exact probe setup must be reviewed before
+using MemLeak as a production gate.
+
+## Comparability Notes
+
+MemLeak complements GateMem and memory-poisoning work by shifting privacy tests
+from text-only access control to multimodal residual leakage after deletion.
+
+## Related Papers
+
+- Paper:https://arxiv.org/abs/2606.29788
+
+## Impact Use
+
+- `policy-privacy`:candidate benchmark for deletion semantics and provenance.
+- `evaluator-benchmark`:multimodal memory deletion audit pressure.
+- Ready for ImpactReport:no, upgrade after full protocol read.

--- a/benchmarks/memsyco-bench.md
+++ b/benchmarks/memsyco-bench.md
@@ -1,0 +1,76 @@
+---
+title: MemSyco-Bench — memory-induced sycophancy benchmark
+benchmark_id: memsyco-bench
+name: MemSyco-Bench
+aliases:
+  - MemSyco
+  - MemSyco-Bench
+status: seed
+origin_type: paper_origin
+origin_source: https://arxiv.org/abs/2607.01071
+first_public_date: 2026-07
+domain: memory_induced_sycophancy
+modality: text
+task_grain: downstream_reasoning_with_retrieved_memory
+capability_axes:
+  - memory_scope
+  - conflict_resolution
+  - memory_update
+  - personalization
+  - objective_evidence_use
+data_nature: check
+metrics:
+  - sycophancy_resistance
+  - valid_memory_use
+judge_type: check
+code_available: check
+data_available: check
+license: check
+known_limitations:
+  - seed note; protocol, task counts, resources, and reported results need full read
+canonical_sources:
+  - https://arxiv.org/abs/2607.01071
+confidence: medium
+memory_modules:
+  - evaluator-benchmark
+  - retriever-reranker
+  - policy-privacy
+last_revised: 2026-07-06
+---
+
+# MemSyco-Bench
+
+## What It Measures
+
+MemSyco-Bench evaluates when retrieved memories should and should not influence
+an agent's downstream reasoning. It focuses on memory-induced sycophancy: cases
+where an agent over-aligns with remembered user statements at the expense of
+objective evidence or factual reasoning.
+
+## Protocol
+
+The arXiv abstract describes five task families: rejecting memory as factual
+evidence, respecting memory scope, resolving conflicts between memory and
+objective evidence, tracking memory updates, and using valid memory for
+personalization. Full task definitions and resource links need a deeper read.
+
+## Baselines and Reported Results
+
+No normalized scores are logged here. Reported system results remain
+paper-origin claims until the setup is mapped into `claims/claims.yaml`.
+
+## Comparability Notes
+
+Compare with LongMemEval / LoCoMo only on memory-use behavior, not raw recall.
+MemSyco-Bench is most useful for testing whether retrieved memories are used
+with the right authority and scope.
+
+## Related Papers
+
+- Paper:https://arxiv.org/abs/2607.01071
+
+## Impact Use
+
+- `evaluator-benchmark`:candidate benchmark for harmful overuse of memory.
+- `policy-privacy`:useful for memory authority and objective-evidence gates.
+- Ready for ImpactReport:no, upgrade after full protocol read.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ decide what to read before opening the paper index or the product notes.
 4. [`weekly-memory-refresh-runbook.md`](weekly-memory-refresh-runbook.md) —
    Codex weekly refresh runbook for papers, products, GitHub discovery, and
    benchmarks.
-5. [`memory-radar-2026-06.md`](memory-radar-2026-06.md) — latest current-source
+5. [`memory-radar-2026-07.md`](memory-radar-2026-07.md) — latest current-source
    refresh across papers, products, GitHub projects, and reviewer decisions.
 6. [`cost-savings-landscape.md`](cost-savings-landscape.md) — focused map of
    agent-memory papers, algorithms, code paths, and products that reduce token,
@@ -49,7 +49,7 @@ decide what to read before opening the paper index or the product notes.
 |---|---|
 | [`research-radar.md`](research-radar.md) | Generic Radar loop: paper/product/benchmark -> ResearchItem or BenchmarkItem -> ImpactReport -> sandbox -> ADR. |
 | [`weekly-memory-refresh-runbook.md`](weekly-memory-refresh-runbook.md) | Weekly Codex automation contract for source search, subagent review, verification, and PR output. |
-| [`memory-radar-2026-06.md`](memory-radar-2026-06.md) | 2026-06 current-source refresh with must-add, update-existing, watchlist, and reject decisions. |
+| [`memory-radar-2026-07.md`](memory-radar-2026-07.md) | 2026-07 weekly refresh with must-add, update-existing, watchlist, adjacent, and reject decisions. |
 | [`information-sources.md`](information-sources.md) | Source catalog for papers, products, communities, and zh-CN information channels. |
 | [`related-work.md`](related-work.md) | Positioning against sibling agent-memory awesome-lists. |
 

--- a/docs/benchmarks-landscape.md
+++ b/docs/benchmarks-landscape.md
@@ -32,6 +32,9 @@ language: zh-CN
 | agent 任务 / 多 agent | LoCoBench-Agent / MemoryArena / MemBench | coding agent, shared memory conflict, write/manage 评测 | candidate,需升级 source note |
 | evolving profile memory | [`DynamicMem`](../benchmarks/dynamicmem.md) | 15-month multi-app histories / profile reconstruction / temporal update | seed,origin paper logged; protocol/results not normalized |
 | auditable memory artifact | [`MEMPROBE`](../benchmarks/memprobe.md) | hidden user-state recovery from memory stores / full-store vs top-k probing | seed,origin paper logged; protocol/results not normalized |
+| memory-induced sycophancy | [`MemSyco-Bench`](../benchmarks/memsyco-bench.md) | whether retrieved memory should influence factual reasoning, conflicts, updates, and personalization | seed,origin paper logged; results/resources not normalized |
+| multimodal deletion leakage | [`MemLeak`](../benchmarks/memleak.md) | residual recovery after deletion via correlated text and retained images | seed,origin paper logged; image/data/setup not normalized |
+| baseline-control methodology | [`MemDelta`](../benchmarks/memdelta.md) | component-controlled memory-vs-RAG/full-context evaluation and write-path cost discipline | seed,methodology event logged; not an end-agent leaderboard |
 
 ## B. 初始交叉统计
 
@@ -55,6 +58,9 @@ language: zh-CN
 | MemoryArena | 1 | survey mention |
 | DynamicMem | 1 | origin paper logged; metrics/results not yet normalized |
 | MEMPROBE | 1 | origin paper logged; metrics/results not yet normalized |
+| MemSyco-Bench | 1 | origin paper logged; memory-induced sycophancy protocol not yet normalized |
+| MemLeak | 1 | origin paper logged; multimodal deletion-leakage protocol not yet normalized |
+| MemDelta | 1 | methodology event logged; use for claims discipline, not direct benchmark ranking |
 
 ### B2. Evaluation uses / baseline comparisons
 

--- a/docs/memory-radar-2026-07.md
+++ b/docs/memory-radar-2026-07.md
@@ -1,0 +1,91 @@
+---
+title: 2026-07 Memory Radar refresh
+date: 2026-07-06
+status: current-source-refresh
+language: zh-CN
+---
+
+# 2026-07 Memory Radar refresh
+
+本页记录 2026-07-06 的 weekly radar refresh。主 agent 从最新 `origin/main`
+创建 `codex/weekly-memory-radar-2026-07-06`,并用 paper/product/GitHub discovery
+子 agent 做候选检索。所有 GitHub/list/catalog 信号只作为 discovery;最终收录只依赖
+primary paper/product sources。
+
+## 执行模型
+
+| Lane | 角色 | 输出 |
+|---|---|---|
+| papers/conferences | `researcher` | arXiv / ACL Anthology 2026 候选与 duplicate 风险 |
+| products/platforms | `researcher` | 官方产品文档、release notes、changelog |
+| GitHub/benchmarks | `researcher` | repo/list/dataset discovery signals only |
+| repo-map | `explore` | counts、landing files、现有条目和别名风险 |
+| source/relevance review | main agent + later reviewer | must-add / update-existing / watchlist / adjacent / reject |
+
+## Must-add / update-existing
+
+### Papers and benchmarks
+
+| Action | Item | Why it matters | Local anchor |
+|---|---|---|---|
+| must-add | A-TMA | 把 ghost memory 拆成 bank / retrieval / answer-time state-resolution failure,强调 current/historical/transition state roles | [`../papers/atma-state-aware-memory-failures.md`](../papers/atma-state-aware-memory-failures.md) |
+| must-add | MemSyco-Bench | 评估 retrieved memory 什么时候不应影响事实判断,补 memory-induced sycophancy / authority 维度 | [`../benchmarks/memsyco-bench.md`](../benchmarks/memsyco-bench.md) |
+| must-add | MemLeak | 多模态 memory 删除后仍可从保留图片/相关文本恢复事实,补 deletion / provenance / residual leakage 维度 | [`../benchmarks/memleak.md`](../benchmarks/memleak.md) |
+| must-add | MemDelta | 用 controlled baseline 压住 memory-vs-RAG/full-context claims,要求固定 embedding/model family 并报告 write-path cost | [`../benchmarks/memdelta.md`](../benchmarks/memdelta.md) |
+| must-add | Mandol | memory-native graph substrate + agglomerative abstraction,补 unified store / hybrid retrieval 工程路线 | [`../papers/mandol-agglomerative-agent-memory.md`](../papers/mandol-agglomerative-agent-memory.md) |
+| must-add | Forensic Trajectory Signatures | persistent memory poisoning 的 tool-call trajectory audit 视角,补 runtime forensic signal | [`../papers/forensic-trajectory-memory-poisoning.md`](../papers/forensic-trajectory-memory-poisoning.md) |
+| update-existing | Chain-of-Memory / Mem2ActBench / Learning How and What to Memorize / Mnemis | ACL 2026 official pages 已上线,但本仓已有 scrape stub,本轮不重复建 note | `papers/stubs/` |
+
+### Products
+
+| Action | Product | Why it matters | Local anchor |
+|---|---|---|---|
+| update-existing | AWS Bedrock AgentCore Memory | release notes / docs 继续确认 memory record create/update/delete streaming,支持 evented lifecycle 判断 | [`../products/aws-agentcore-memory.md`](../products/aws-agentcore-memory.md) |
+| update-existing | Google Agent Platform Memory Bank | 2026-06-29 release notes 将 Memory Bank generation 默认模型切到 Gemini 3.5 Flash | [`../products/google-memory-bank.md`](../products/google-memory-bank.md) |
+| update-existing | OpenAI ChatGPT Memory | 2026-06-25 Business / Enterprise / Edu release notes 扩展 memory summary/source/correction/delete controls | [`../products/openai-memory.md`](../products/openai-memory.md) |
+| update-existing | Mem0 | changelog highlights 增加 memory expiration controls,作为 lifecycle/retention signal | [`../products/mem0.md`](../products/mem0.md) |
+| update-existing | Redis Agent Memory Server | 2026-07-01 Redis guide 继续强化 short-term + long-term memory positioning | [`../products/redis-agent-memory-server.md`](../products/redis-agent-memory-server.md) |
+
+## Watchlist / adjacent / reject
+
+| Decision | Item | Reason |
+|---|---|---|
+| watchlist | AutoMem | memory as cognitive skill 方向相关,但本轮未完成 project/code/data verification |
+| watchlist | Governed Shared Memory / Forget to Improve | post-window awesome-list commits surfaced pre-window papers;先等 full source read 后再决定是否升级 |
+| watchlist | Cloudflare Think harness | Cloudflare agent harness 暴露 persistent memory/context patterns,但与 Cloudflare Agent Memory 产品边界重叠 |
+| watchlist | Harmix/pam-benchmark | open benchmark harness 相关,但 README results 是 affiliated/self-report |
+| watchlist | Synapse / AegisDB / Ogham / NeverTwice / Tenet / Remnic activity | GitHub activity 是 discovery signal,不能支持质量或 maturity 结论 |
+| adjacent | What Memory Do GUI Agents Really Need? / ContextSniper / Analytic Concept-Centric Memory | 分别偏 GUI execution state、code repair cost memory、embodied manipulation;有参考价值但不进入本轮 core |
+| adjacent | Cloudflare / Redis implementation guides | 产品实践信号,不是独立 memory benchmark |
+| reject as core | catalog-only MCP memory entries | catalog placement 无 canonical source / lifecycle evidence 时不入核心 |
+| reject as performance evidence | GitHub stars, README benchmark numbers, vendor blogs, awesome-list placement | 只能用于 discovery 或 vendor/product behavior,不能支持性能/质量结论 |
+| source mismatch | no new mismatched canonical URL promoted | 本轮未发现需要入库的 title/URL 错配;ACL official pages with existing stubs treated as update-existing |
+
+## Evidence gaps / next verification
+
+| Item | Gap | Why not blocking |
+|---|---|---|
+| A-TMA / MemSyco-Bench / MemLeak / MemDelta / Mandol / trajectory signatures | 尚未 full read PDF、code/data/license、leaderboard 和 exact setup | 本轮只登记 seed note / benchmark-origin event,不登记 score claim |
+| Product updates | release notes and docs support product behavior only | 未写任何 independent benchmark 或 superiority claim |
+| GitHub discovery | repo activity, releases, catalog hits remain noisy | 保留 watchlist,不影响 README counts 或 core product list |
+
+## Trend synthesis
+
+- **State validity is overtaking static recall**:A-TMA、MemSyco-Bench、MemDelta 都要求区分
+  remembered fact 的 authority、scope、currentness 与 evaluation component。
+- **Memory privacy now includes multimodal residue**:MemLeak 显示删除 text memory 之后,
+  correlated images / text 仍可能泄漏被删除事实。
+- **Runtime evidence matters for security**:trajectory-signature work把 memory poisoning
+  从内容检测扩展到 tool-call forensics。
+- **Managed memory products are tuning lifecycle controls**:AWS streaming、Google model
+  default、OpenAI org memory controls、Mem0 expiration、Redis two-tier guide 都说明
+  vendor products 正在把 retention / lifecycle / state scope 做成公开产品面。
+
+## Review notes
+
+- 收录项均要求 primary source:论文用 arXiv / ACL Anthology,产品用官方 docs / release
+  notes / changelog / blog。
+- GitHub stars、README 性能数字、MCP catalog 和 awesome-list placement 只作 discovery。
+- Author-reported benchmark results are paper-origin claims;vendor numbers are vendor claims。
+- 本轮 benchmark catalog 从 18 行增至 21 行;paper seed notes 从 12 增至 15;product
+  note count 不变。

--- a/docs/product-discovery-log.md
+++ b/docs/product-discovery-log.md
@@ -145,3 +145,14 @@ language: zh-CN
   remnic、nram、memanto、LycheeMem、Parcle Memory、Neo4j Agent Memory 等不删除,
   但先作为 Tier B 轻量索引,等待源码/许可/release health 补证。
 - 所有 vendor benchmark 或性能 claim 都按 vendor-claimed / 自报处理,不写成独立实证。
+
+## 10. 2026-07-06 weekly refresh delta
+
+| Decision | Item | Source | Action |
+|---|---|---|---|
+| update-existing | AWS AgentCore Memory | release notes / memory record streaming docs | 更新 `products/aws-agentcore-memory.md`;evented lifecycle 是产品行为证据 |
+| update-existing | Google Agent Platform Memory Bank | Gemini Enterprise Agent Platform release notes 2026-06-29 | 更新 `products/google-memory-bank.md`;默认 generation model 变化不等于独立质量证据 |
+| update-existing | OpenAI ChatGPT Memory | Business / Enterprise / Edu release notes 2026-06-25 | 更新 `products/openai-memory.md`;组织计划 memory controls 仍为 vendor-managed memory |
+| update-existing | Mem0 | changelog highlights 2026-06-27 | 更新 `products/mem0.md`;expiration controls 作为 lifecycle signal |
+| update-existing | Redis Agent Memory Server | Redis blog 2026-07-01 | 更新 `products/redis-agent-memory-server.md`;作为产品定位/实现建议,非 benchmark |
+| watchlist | Cloudflare Think harness | Cloudflare docs | 暂不拆产品;与 Cloudflare Agent Memory 有重叠,先观察是否形成独立 memory product |

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -16,6 +16,14 @@ Radar 动作 enum:`stub` `seed-note` `deep-note` `impact-report` `archive-only`
 (`deep-note` 表示已落地产品/聚合笔记,不等同于 frontmatter `status: full`;
 `archive-only` 表示有趣但不进入 ResearchItem 流程)
 
+## 2026 Q3
+
+| 日期 | 来源 | 类型 | 一句话 | Radar 动作 |
+|---|---|---|---|---|
+| 2026-07-06 | [A-TMA](https://arxiv.org/abs/2607.01935) / [Mandol](https://arxiv.org/abs/2606.29778) / [Forensic Trajectory Signatures](https://arxiv.org/abs/2606.30566) | paper | 周更 radar 追加 state-aware ghost memory、agglomerative memory-native storage、memory-poisoning trajectory forensics 三条 seed note | `seed-note` ✅(见 `papers/`) |
+| 2026-07-06 | [MemSyco-Bench](https://arxiv.org/abs/2607.01071) / [MemLeak](https://arxiv.org/abs/2606.29788) / [MemDelta](https://arxiv.org/abs/2606.29914) | paper | benchmark catalog 新增 memory-induced sycophancy、多模态删除泄漏、controlled baseline methodology | `seed-note` ✅(见 `benchmarks/`) |
+| 2026-07-06 | [AWS AgentCore release notes](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/release-notes.html) / [Google release notes](https://docs.cloud.google.com/gemini-enterprise-agent-platform/release-notes) / [OpenAI Business release notes](https://help.openai.com/en/articles/11391654-chatgpt-business-release-notes) / [Mem0 changelog](https://docs.mem0.ai/changelog/highlights) / [Redis guide](https://redis.io/blog/build-smarter-ai-agents-manage-short-term-and-long-term-memory-with-redis/) | product | 官方产品源补充 AgentCore streaming、Memory Bank model default、ChatGPT org memory controls、Mem0 expiration 和 Redis two-tier guidance | `deep-note` ✅(更新 `products/`) |
+
 ## 2026 Q2
 
 | 日期 | 来源 | 类型 | 一句话 | Radar 动作 |

--- a/papers/atma-state-aware-memory-failures.md
+++ b/papers/atma-state-aware-memory-failures.md
@@ -1,0 +1,67 @@
+---
+title: A-TMA — Decoupling State-Aware Memory Failures in Long-Term Agent Memory
+arxiv_id: 2607.01935
+source: arXiv:2607.01935
+date: 2026-07
+domain: memory
+core_claim: |
+  Long-term agent memory should distinguish current, historical, and transition
+  facts instead of letting old and current user-state records coexist as
+  untyped "ghost memory" during retrieval and answer generation.
+evidence_level: medium
+code_available: check
+license: check
+memory_modules:
+  - memorydiff-generator
+  - retriever-reranker
+  - evaluator-benchmark
+status: seed
+last_revised: 2026-07-06
+urls:
+  - https://arxiv.org/abs/2607.01935
+---
+
+# A-TMA(arXiv 2607.01935)
+
+## Problem statement
+
+A-TMA names a practical failure mode for personalized long-term memory:
+superseded, current, and transition facts can all remain in the memory bank and
+then get retrieved together. The paper calls this **ghost memory** and argues
+that final QA accuracy can hide whether the failure happened in bank
+maintenance, retrieval, or answer-time state resolution.
+
+## Core claim
+
+ATMA is an overlay for existing memory systems. It keeps superseded and
+transition records, builds evidence packets for the query's requested state
+view, and exposes explicit current / historical / transition labels to the QA
+step. The paper introduces LoCoMo Temporal Plus (LTP) as a conflict-heavy
+benchmark for these state-coordination failures.
+
+Reported Graphiti+ATMA gains on LTP and LoCoMo are author-reported evidence
+only. This seed note records the method and benchmark pressure, not an
+independent result.
+
+## Decision relevance
+
+- `memorydiff-generator`:supersede / transition labels should be first-class
+  diff outputs, not implicit overwrite side effects.
+- `retriever-reranker`:retrieval should expose state role metadata, not only
+  similarity.
+- `evaluator-benchmark`:memory evaluation should split bank, retrieval, and
+  answer-level failures instead of relying only on final QA.
+
+## Caveats
+
+本地笔记是 seed 质量。需要 full read 后确认 LTP construction, benchmark license,
+host-memory assumptions, and code availability.
+
+## Sources
+
+- arXiv:https://arxiv.org/abs/2607.01935
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/papers/forensic-trajectory-memory-poisoning.md
+++ b/papers/forensic-trajectory-memory-poisoning.md
@@ -1,0 +1,64 @@
+---
+title: Forensic Trajectory Signatures for Agent Memory Poisoning Detection
+arxiv_id: 2606.30566
+source: arXiv:2606.30566
+date: 2026-06
+domain: memory-security
+core_claim: |
+  Persistent memory poisoning can leave detectable tool-call trajectory
+  signatures, allowing incident responders to distinguish memory-channel attacks
+  from prompt-injection-only attacks in some agent architectures.
+evidence_level: medium
+code_available: check
+license: check
+memory_modules:
+  - policy-privacy
+  - evaluator-benchmark
+status: seed
+last_revised: 2026-07-06
+urls:
+  - https://arxiv.org/abs/2606.30566
+---
+
+# Forensic trajectory signatures(arXiv 2606.30566)
+
+## Problem statement
+
+Memory poisoning is usually discussed at write-time or content-filtering time.
+This paper looks at a runtime forensics surface: whether successful persistent
+memory attacks produce observable tool-call trajectories that defenders can
+detect from logs.
+
+## Core claim
+
+In the evaluated architecture, successful memory poisoning attacks require a
+memory recall step before a privileged action. The paper reports that a simple
+trajectory rule and a classifier over trajectory features can separate
+memory-channel attacks from non-exfiltrating sessions and prompt-injection
+attacks that bypass memory.
+
+These are author-reported results under a specific architecture. The seed note
+records the detection idea and audit pressure, not a general independent
+detection guarantee.
+
+## Decision relevance
+
+- `policy-privacy`:memory systems should preserve enough write/read/action
+  provenance to support incident response.
+- `evaluator-benchmark`:security benchmarks should log memory tool traces, not
+  just final success/failure.
+
+## Caveats
+
+本地笔记是 seed 质量。需要 full read 后 confirm evaluated architecture, companion
+paper dependency, dataset availability, and whether the invariant generalizes to
+agents with hidden retrieval.
+
+## Sources
+
+- arXiv:https://arxiv.org/abs/2606.30566
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/papers/index.md
+++ b/papers/index.md
@@ -19,6 +19,18 @@ removed.
 - By year: 2026=388, 2025=309, 2024=129, 2023=72, 2022=6, 2021=4, 2020=3, 2018=2, 2017=1, undated=75
 - By source-count: 6 sources=6, 5 sources=18, 4 sources=32, 3 sources=66, 2 sources=127, 1 sources=740
 
+## 2026-07 manual radar additions
+
+These entries were added by the 2026-07-06 weekly radar refresh. They are not
+part of the 2026-05-19 nine-list scrape statistics above.
+
+- [A-TMA: Decoupling State-Aware Memory Failures in Long-Term Agent Memory](atma-state-aware-memory-failures.md) — 2026-07 — seed — [arxiv](https://arxiv.org/abs/2607.01935)
+- [MemSyco-Bench: Benchmarking Sycophancy in Agent Memory](../benchmarks/memsyco-bench.md) — 2026-07 — benchmark seed — [arxiv](https://arxiv.org/abs/2607.01071)
+- [MemLeak: Diagnosing Information Leaks in Multimodal Agent Memory](../benchmarks/memleak.md) — 2026-06 — benchmark seed — [arxiv](https://arxiv.org/abs/2606.29788)
+- [MemDelta: Controlled Baselines and Hidden Confounds in Agent Memory Evaluation](../benchmarks/memdelta.md) — 2026-06 — benchmark seed — [arxiv](https://arxiv.org/abs/2606.29914)
+- [Mandol: An Agglomerative Agent Memory System for Long-Term Conversations](mandol-agglomerative-agent-memory.md) — 2026-06 — seed — [arxiv](https://arxiv.org/abs/2606.29778)
+- [Forensic Trajectory Signatures for Agent Memory Poisoning Detection](forensic-trajectory-memory-poisoning.md) — 2026-06 — seed — [arxiv](https://arxiv.org/abs/2606.30566)
+
 ## 2026-06 manual radar additions
 
 These entries were added by the 2026-06-24 current-source radar refresh. They

--- a/papers/mandol-agglomerative-agent-memory.md
+++ b/papers/mandol-agglomerative-agent-memory.md
@@ -1,0 +1,65 @@
+---
+title: Mandol — Agglomerative Agent Memory for Long-Term Conversations
+arxiv_id: 2606.29778
+source: arXiv:2606.29778
+date: 2026-06
+domain: memory
+core_claim: |
+  Long-term conversational memory can reduce cross-database fragmentation by
+  representing raw and abstract memories as structured semantic graphs inside a
+  unified memory-native storage and retrieval architecture.
+evidence_level: medium
+code_available: check
+license: check
+memory_modules:
+  - semantic-dedup
+  - retriever-reranker
+  - dream-consolidator
+status: seed
+last_revised: 2026-07-06
+urls:
+  - https://arxiv.org/abs/2606.29778
+---
+
+# Mandol(arXiv 2606.29778)
+
+## Problem statement
+
+Mandol targets an engineering problem in long-term conversational agents:
+systems often split memory across vector stores, graph databases, and key-value
+records, which adds cross-store I/O and makes correlated clues hard to retrieve
+under a token budget.
+
+## Core claim
+
+The paper proposes a unified agglomerative memory architecture with two memory
+layers: a basic layer for raw information and an abstract layer that aggregates
+basic memories into traceable abstract memories. Both are represented as
+structured semantic graphs. Retrieval combines SemanticMap / SemanticGraph
+operators, query-adaptive routing, denoising, conflict resolution, and
+token-constrained context generation without LLM calls during retrieval.
+
+Reported LoCoMo / LongMemEval accuracy and insertion/retrieval speedups are
+paper-origin claims and are not logged as independent reproduction evidence.
+
+## Decision relevance
+
+- `semantic-dedup`:abstract memories need traceability back to raw evidence.
+- `retriever-reranker`:hybrid retrieval can be implemented below the LLM layer
+  when the memory substrate carries enough structure.
+- `dream-consolidator`:agglomeration gives one concrete shape for offline
+  consolidation output beyond flat facts.
+
+## Caveats
+
+本地笔记是 seed 质量。需要 full read 后确认 code/data availability, graph schema,
+benchmark setup, and whether reported latency includes all storage operations.
+
+## Sources
+
+- arXiv:https://arxiv.org/abs/2606.29778
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/aws-agentcore-memory.md
+++ b/products/aws-agentcore-memory.md
@@ -12,7 +12,7 @@ memory_modules:
   - retriever-reranker
   - policy-privacy
 status: seed
-last_revised: 2026-06-29
+last_revised: 2026-07-06
 archive: archives/aws-agentcore-memory-overview.md
 ---
 
@@ -50,6 +50,13 @@ insights、user preferences、facts 和 session summaries,并在未来会话中�
   BYO memory ARN 或显式关闭 memory。
 - 这使 AgentCore Memory 从"托管 LTM"进一步接近 evented memory lifecycle infra,
   对 Ymem 的 `memorydiff-generator` 和审计流水线有对照价值。
+
+## 3.2 2026-07 refresh
+
+2026-07-06 复核时,AWS AgentCore release notes / developer guide 继续把 memory
+record streaming 作为当前能力面:memory record create / update / delete 事件可流向
+Kinesis,用于下游审计、同步或增量处理。该能力是产品行为证据,可支持"AgentCore Memory
+暴露 evented memory lifecycle"这一判断,但不支持任何独立性能结论。
 
 ## 4. 决策相关性 / Decision relevance
 

--- a/products/google-memory-bank.md
+++ b/products/google-memory-bank.md
@@ -12,7 +12,7 @@ memory_modules:
   - retriever-reranker
   - policy-privacy
 status: seed
-last_revised: 2026-06-29
+last_revised: 2026-07-06
 archive: archives/google-memory-bank-overview.md
 ---
 
@@ -47,6 +47,13 @@ Bank preview,当前入口已明确归入 Gemini Enterprise Agent Platform。
 2026-06-17 release notes 又把 Memory Bank and Sessions 的 multi-regional/global
 endpoint support 标为 GA,并注明 global endpoint 不能使用 CMEK。该更新改变的是
 部署位置与企业治理边界,不代表底层 memory extraction / ranking 机制公开。
+
+## 3.2 2026-07 refresh
+
+Google 2026-06-29 Gemini Enterprise Agent Platform release notes 将 Memory Bank
+generation 的默认模型从 Gemini 2.5 Flash 改为 Gemini 3.5 Flash。该更新说明托管
+memory extraction / generation 仍会随平台模型配置变化;它是产品行为证据,不代表
+memory ranking 机制或质量有独立复现。
 
 ## 4. 决策相关性 / Decision relevance
 

--- a/products/mem0.md
+++ b/products/mem0.md
@@ -11,7 +11,7 @@ evidence_level: medium (open-source library, blog claims need independent benchm
 code_available: yes
 license: Apache 2.0
 status: seed
-last_revised: 2026-05-19
+last_revised: 2026-07-06
 ---
 
 # Mem0
@@ -113,6 +113,15 @@ Mem0 自报的 benchmark(LoCoMo 类基准对比上一代 baseline):
 > 来源:https://mem0.ai/blog/state-of-ai-agent-memory-2026
 > archive:[`archives/mem0-blog-state-of-2026.md`](archives/mem0-blog-state-of-2026.md)、
 > [`archives/mem0-april-2026-release.md`](archives/mem0-april-2026-release.md)
+
+## 2026-06/07 SDK expiration controls
+
+Mem0 changelog highlights around 2026-06-27 added first-class expiration
+controls for memory writes, updates, and reads in Python / TypeScript SDKs. This
+is product-behavior evidence that Mem0 is moving memory lifecycle beyond add /
+search toward retention policy. It should not be mixed with benchmark claims.
+
+> 来源:https://docs.mem0.ai/changelog/highlights
 
 ## Notes
 

--- a/products/openai-memory.md
+++ b/products/openai-memory.md
@@ -10,7 +10,7 @@ memory_modules:
   - ingest-adapter
   - retriever-reranker
 status: full
-last_revised: 2026-06-24
+last_revised: 2026-07-06
 archive: archives/openai-memory-overview.md
 ---
 
@@ -59,6 +59,12 @@ OpenAI 2026-06 公布 ChatGPT Memory Dreaming,把 memory 改进描述为后台�
 release notes 同期写到 memory 会更及时地保持更新。对本仓而言,这属于已有
 vendor-managed memory 的 UX/治理升级,不是新的开放 memory kernel。
 
+2026-06-25 ChatGPT Business / Enterprise / Edu release notes 又把改进版 memory
+扩展到组织计划:可使用相关历史对话上下文,并提供 memory summary、source、纠错、
+删除、标记 not relevant 以及 legacy saved memories 控制。OpenAI 同时说明 Codex
+memory 不受该 ChatGPT 产品 memory 变更影响。该更新继续归类为 vendor-managed
+product behavior,不作为开放 agent-memory API 或独立质量证据。
+
 ## 4. 决策相关性 / Decision relevance
 
 - **对照点**:它定义了 "vendor-managed memory" 的对照基线 — 用户/开发者
@@ -101,6 +107,8 @@ vendor-managed memory 的 UX/治理升级,不是新的开放 memory kernel。
 - Assistants API:https://platform.openai.com/docs/assistants/how-it-works
 - 公告:https://openai.com/index/memory-and-new-controls-for-chatgpt/
 - Dreaming:https://openai.com/index/chatgpt-memory-dreaming/
+- Business release notes:https://help.openai.com/en/articles/11391654-chatgpt-business-release-notes
+- Enterprise/Edu release notes:https://help.openai.com/en/articles/10128477-chatgpt-enterprise-edu-release-notes
 
 ---
 

--- a/products/redis-agent-memory-server.md
+++ b/products/redis-agent-memory-server.md
@@ -12,7 +12,7 @@ memory_modules:
   - retriever-reranker
   - policy-privacy
 status: seed
-last_revised: 2026-06-29
+last_revised: 2026-07-06
 archive: archives/redis-agent-memory-server-overview.md
 ---
 
@@ -45,6 +45,13 @@ Redis 2026-06-17 官方博客继续把 agent memory 定位为 persistence infras
 sessions 解释两层设计。该博客是 vendor positioning,可用于产品架构定位,不能用来
 支持独立性能结论。
 
+## 3.2 2026-07 refresh
+
+Redis 2026-07-01 官方博客继续以 short-term state + long-term vector memory 解释
+agent memory,并把 semantic retrieval、TTL / decay、RedisVL / vector search 等能力
+放进统一实践指南。该来源更新产品定位和实现建议;它不是 Redis Agent Memory Server
+的新独立 benchmark,也不能支持质量优于其他 memory server 的结论。
+
 ## 4. 决策相关性 / Decision relevance
 
 - **对照点**:Redis 把 memory server 包装为可运维 API,区别于纯库或纯 SaaS。
@@ -70,6 +77,7 @@ sessions 解释两层设计。该博客是 vendor positioning,可用于产品架
 - MCP:https://redis.github.io/agent-memory-server/mcp/
 - GitHub:https://github.com/redis/agent-memory-server
 - Blog:https://redis.io/blog/why-bigger-context-window-wont-fix-agent-memory/
+- July guide:https://redis.io/blog/build-smarter-ai-agents-manage-short-term-and-long-term-memory-with-redis/
 
 ---
 


### PR DESCRIPTION
## Accepted additions

- Added paper seed notes for A-TMA, Mandol, and Forensic Trajectory Signatures.
- Added benchmark seed notes for MemSyco-Bench, MemLeak, and MemDelta.
- Added benchmark claims-ledger origin/methodology events without normalized score or reproduction claims.
- Added the July weekly radar report at `docs/memory-radar-2026-07.md`.

## Updated existing entries

- Updated README/README_cn counts and latest radar routing: paper seed notes 12 -> 15, benchmark rows 18 -> 21, updated badge 2026-07.
- Updated `papers/index.md`, `benchmarks/index.md`, `docs/benchmarks-landscape.md`, `docs/README.md`, `docs/signals.md`, and `docs/product-discovery-log.md`.
- Refreshed official product-source notes for AWS AgentCore Memory, Google Memory Bank, OpenAI ChatGPT Memory, Mem0, and Redis Agent Memory Server.

## Watchlist

- AutoMem; Governed Shared Memory / Forget to Improve; Cloudflare Think harness; Harmix/pam-benchmark.
- Synapse, AegisDB, Ogham, NeverTwice, Tenet, Remnic activity remain GitHub discovery signals only.

## Adjacent / rejected

- Adjacent: GUI-agent memory, ContextSniper, Analytic Concept-Centric Memory, Cloudflare/Redis implementation guides.
- Rejected as core: catalog-only MCP memory entries without canonical lifecycle evidence.
- Rejected as performance evidence: GitHub stars, README benchmark numbers, vendor blogs, awesome-list placement.

## Source mismatches

- No new mismatched canonical URL was promoted.
- ACL official pages with existing stubs were treated as update-existing rather than duplicate additions.
- OpenAI Help Center release-note URLs returned 403 to plain `curl`, consistent with prior runs, but stayed bounded as official vendor product-behavior evidence.

## Verification

- `ruby scripts/verify_memory_refresh.rb` passed: `papers=989 pdfs=534 stubs=988 full_notes=7 seed_notes=15 products=38 product_archives=37 benchmarks=21`.
- `git diff --cached --check` passed.
- Conflict-marker scan passed.
- Targeted URL reachability: all six arXiv URLs, AWS, Google, Mem0, and Redis returned 200 via `curl`; OpenAI Help pages returned 403 to plain `curl`.
- Verifier/source-check pass: PASS; no discovery-only/vendor/list source promoted as independent performance evidence.
- Code-reviewer pass: initial README metadata issue fixed; targeted re-review PASS.

## Known gaps

- No full-PDF reads for new seed notes.
- No independent benchmark reproduction.
- No code/data/license audit for the new benchmark resources.
- No complete external link crawl.
