### PR TITLE
Refresh July memory radar from primary sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ separate buckets.
 | Paper index | 989 scraped papers + manual radar additions through 2026-07 | [`papers/index.md`](papers/index.md) | Searchable entry point for agent-memory papers; the 989 count is the 2026-05 scrape baseline. |
 | Paper stubs | 988 stubs | [`papers/stubs/`](papers/stubs/) | Track papers that are covered but not yet fully read. |
 | Local PDFs | 534 files | [`papers/pdfs/`](papers/pdfs/) | Re-read sources and audit paper notes. |
-| Full / seed paper notes | 7 full + 15 seed | [`papers/`](papers/) | Use human-read notes for architectural decisions. |
+| Full / seed paper notes | 7 full + 20 seed | [`papers/`](papers/) | Use human-read notes for architectural decisions. |
 | Memory product notes | 38 notes | [`products/`](products/) | Compare memory layers, memory SDKs, managed memory, and memory-enabled agents. |
 | Product page archives | 37 snapshots | [`products/archives/`](products/archives/) | Audit product claims after source pages change. |
 | Benchmark catalog | 21 catalog rows | [`benchmarks/index.md`](benchmarks/index.md) | First-class benchmark records plus stub-backed candidate rows and a usage-claim ledger. |
@@ -180,7 +180,7 @@ flowchart LR
 
 | Path | Purpose |
 |---|---|
-| [`papers/`](papers/) | 7 full paper notes, 15 seed notes, and the master [`index.md`](papers/index.md). |
+| [`papers/`](papers/) | 7 full paper notes, 20 seed notes, and the master [`index.md`](papers/index.md). |
 | [`papers/stubs/`](papers/stubs/) | 988 generated stubs for papers not yet fully read. |
 | [`papers/pdfs/`](papers/pdfs/) | 534 archived PDFs, about 1.8 GB. See the archival policy below. |
 | [`papers/_scrape/`](papers/_scrape/) | Reproducibility artifacts: scrape script and dedup JSON. |

--- a/README_cn.md
+++ b/README_cn.md
@@ -56,7 +56,7 @@
 | 论文索引 | 989 篇抓取论文 + 截至 2026-07 的手工 radar 新增 | [`papers/index.md`](papers/index.md) | 搜索 agent-memory 论文和发现线索；989 是 2026-05 抓取基线。 |
 | 论文 stub | 988 个 stub | [`papers/stubs/`](papers/stubs/) | 跟踪已覆盖但尚未 full 阅读的论文。 |
 | 本地 PDF | 534 个文件 | [`papers/pdfs/`](papers/pdfs/) | 复读来源和审计论文笔记。 |
-| full / seed 论文笔记 | 7 个 full + 15 个 seed | [`papers/`](papers/) | 为架构决策引用人工阅读笔记。 |
+| full / seed 论文笔记 | 7 个 full + 20 个 seed | [`papers/`](papers/) | 为架构决策引用人工阅读笔记。 |
 | 记忆产品笔记 | 38 个笔记 | [`products/`](products/) | 对比 memory layer、memory SDK、managed memory 和带记忆的 agent 产品。 |
 | 产品页面快照 | 37 个快照 | [`products/archives/`](products/archives/) | 在源页面变化后审计产品 claims。 |
 | Benchmark 目录 | 21 个 catalog 行 | [`benchmarks/index.md`](benchmarks/index.md) | 理解 memory benchmark、stub-backed 候选行及其 claims 来源。 |
@@ -175,7 +175,7 @@ flowchart LR
 
 | 路径 | 用途 |
 |---|---|
-| [`papers/`](papers/) | 7 个 full 论文笔记、15 个 seed 笔记和主索引 [`index.md`](papers/index.md)。 |
+| [`papers/`](papers/) | 7 个 full 论文笔记、20 个 seed 笔记和主索引 [`index.md`](papers/index.md)。 |
 | [`papers/stubs/`](papers/stubs/) | 988 个尚未 full 阅读论文的生成 stub。 |
 | [`papers/pdfs/`](papers/pdfs/) | 534 个本地 PDF，约 1.8 GB。详见下方存档策略。 |
 | [`papers/_scrape/`](papers/_scrape/) | 可复现产物：抓取脚本和 dedup JSON。 |

--- a/docs/memory-radar-2026-07.md
+++ b/docs/memory-radar-2026-07.md
@@ -1,16 +1,17 @@
 ---
 title: 2026-07 Memory Radar refresh
-date: 2026-07-06
+date: 2026-07-13
 status: current-source-refresh
 language: zh-CN
 ---
 
 # 2026-07 Memory Radar refresh
 
-本页记录 2026-07-06 的 weekly radar refresh。主 agent 从最新 `origin/main`
-创建 `codex/weekly-memory-radar-2026-07-06`,并用 paper/product/GitHub discovery
-子 agent 做候选检索。所有 GitHub/list/catalog 信号只作为 discovery;最终收录只依赖
-primary paper/product sources。
+本页记录 2026-07 的 weekly radar refresh。2026-07-06 主 agent 从最新
+`origin/main` 创建 `codex/weekly-memory-radar-2026-07-06`;2026-07-13 主 agent
+创建 `codex/weekly-memory-radar-2026-07-13`。两轮都用 paper/product/GitHub
+discovery 子 agent 做候选检索。所有 GitHub/list/catalog 信号只作为 discovery;
+最终收录只依赖 primary paper/product sources。
 
 ## 执行模型
 
@@ -23,6 +24,21 @@ primary paper/product sources。
 | source/relevance review | main agent + later reviewer | must-add / update-existing / watchlist / adjacent / reject |
 
 ## Must-add / update-existing
+
+### 2026-07-13 delta
+
+| Action | Item | Why it matters | Local anchor |
+|---|---|---|---|
+| must-add | Learning User-Aware Recall | profile-guided personalized retrieval + query rewriting 把 user-aware ranking 作为 long-term conversational memory 的显式控制面 | [`../papers/learning-user-aware-recall.md`](../papers/learning-user-aware-recall.md) |
+| must-add | From Passive Retrieval to Active Memory Navigation | NapMem 把 long-term user memory 变成 structured action space,强调 granularity navigation 和 provenance-linked pyramid | [`../papers/active-memory-navigation.md`](../papers/active-memory-navigation.md) |
+| must-add | Forged Reasoning Attacks | 把 memory poisoning 从事实记忆扩展到 remembered reasoning histories,要求保护 rationale/provenance integrity | [`../papers/forged-reasoning-memory-attacks.md`](../papers/forged-reasoning-memory-attacks.md) |
+| must-add | Remember When It Matters | separate memory agent selectively injects reminders,把 memory 从 passive bank 变成 long-horizon decision intervention | [`../papers/proactive-memory-agent.md`](../papers/proactive-memory-agent.md) |
+| must-add | Memory in the Loop | in-process retrieval 让 memory 进入每个 observe-reason-act step,补 latency/placement 对 memory design 的系统压力 | [`../papers/memory-in-the-loop.md`](../papers/memory-in-the-loop.md) |
+| update-existing | Google Agent Platform Memory Bank | 2026-07-08 release notes 将 `IngestEvents` 标为 GA,并支持 Gemini Embedding 2 similarity search configuration;说明 managed memory ingestion/retrieval 产品面继续前移 | [`../products/google-memory-bank.md`](../products/google-memory-bank.md) |
+| update-existing | Oracle AI Agent Memory | 26.6 blogs 补 hybrid search、custom extraction、context cards、metadata filters、TTL、update APIs;性能评测表述本轮不收录,后续需先按 claims ledger 规范归档 | [`../products/oracle-ai-agent-memory.md`](../products/oracle-ai-agent-memory.md) |
+| update-existing | Zep | ABAC blog 补 action-level key policies 和 source-metadata scoped graph access,强化 agent memory governance surface | [`../products/zep.md`](../products/zep.md) |
+| update-existing | TencentDB Agent Memory | 2026-07-07 billing docs 补 memory storage / model-call credits 计费和 whitelist 免费期,说明商业化边界 | [`../products/tencentdb-agent-memory.md`](../products/tencentdb-agent-memory.md) |
+| update-existing | Alibaba Bailian Memory Library | English API reference 明确 Add/Search/List/Delete/Update/Profile APIs,但页面日期不稳定,只作为 current official API surface | [`../products/alibaba-bailian-memory.md`](../products/alibaba-bailian-memory.md) |
 
 ### Papers and benchmarks
 
@@ -50,6 +66,11 @@ primary paper/product sources。
 
 | Decision | Item | Reason |
 |---|---|---|
+| watchlist | Anthropic API memory-store beta header | 官方 release notes 暴露 memory-store endpoint behavior change,但日期为 2026-07-22,晚于本轮 2026-07-13 run date;下周再复核 |
+| watchlist | AgenticSTS | bounded-memory long-horizon testbed 很相关,但提交日期为 2026-07-02 且应进入 benchmark layer;本轮先不新增 benchmark count |
+| watchlist | MRAgent / WorldMemArena | GitHub activity surfaced primary papers,但 arXiv dates 分别为 2026-06 和 2026-05/06;下轮做 benchmark/paper integration,不作为本周 must-add |
+| watchlist | SAGE-Mem / OWASP Agent Memory Guard / agent-memory-integrity | GitHub/repo activity 是 discovery signal;需 primary paper/protocol 或 independent reproduction 后再升级 |
+| update-existing only | How Memory Management Impacts / Preference-Aware Memory Update / PersonaAgent / From Storage to Experience ACL pages | ACL 2026 official pages 可验证 venue metadata,但本仓已有 scrape stubs or existing notes;本轮不重复建 note |
 | watchlist | AutoMem | memory as cognitive skill 方向相关,但本轮未完成 project/code/data verification |
 | watchlist | Governed Shared Memory / Forget to Improve | post-window awesome-list commits surfaced pre-window papers;先等 full source read 后再决定是否升级 |
 | watchlist | Cloudflare Think harness | Cloudflare agent harness 暴露 persistent memory/context patterns,但与 Cloudflare Agent Memory 产品边界重叠 |
@@ -87,5 +108,6 @@ primary paper/product sources。
   notes / changelog / blog。
 - GitHub stars、README 性能数字、MCP catalog 和 awesome-list placement 只作 discovery。
 - Author-reported benchmark results are paper-origin claims;vendor numbers are vendor claims。
-- 本轮 benchmark catalog 从 18 行增至 21 行;paper seed notes 从 12 增至 15;product
-  note count 不变。
+- 2026-07-06 benchmark catalog 从 18 行增至 21 行;paper seed notes 从 12 增至
+  15;product note count 不变。
+- 2026-07-13 paper seed notes 从 15 增至 20;product / benchmark counts 不变。

--- a/docs/product-discovery-log.md
+++ b/docs/product-discovery-log.md
@@ -1,6 +1,6 @@
 ---
 title: Product discovery log — agent memory products
-date: 2026-06-24
+date: 2026-07-13
 status: working-log
 language: zh-CN
 ---
@@ -156,3 +156,14 @@ language: zh-CN
 | update-existing | Mem0 | changelog highlights 2026-06-27 | 更新 `products/mem0.md`;expiration controls 作为 lifecycle signal |
 | update-existing | Redis Agent Memory Server | Redis blog 2026-07-01 | 更新 `products/redis-agent-memory-server.md`;作为产品定位/实现建议,非 benchmark |
 | watchlist | Cloudflare Think harness | Cloudflare docs | 暂不拆产品;与 Cloudflare Agent Memory 有重叠,先观察是否形成独立 memory product |
+
+## 11. 2026-07-13 weekly refresh delta
+
+| Decision | Item | Source | Action |
+|---|---|---|---|
+| update-existing | Google Agent Platform Memory Bank | Gemini Enterprise Agent Platform release notes 2026-07-08 | 更新 `products/google-memory-bank.md`;IngestEvents GA 和 Gemini Embedding 2 support 是 managed memory ingestion / retrieval 产品行为证据,不是独立质量结论 |
+| update-existing | Oracle AI Agent Memory | Oracle developer/database blogs 2026-07-07 / 2026-07-10 | 更新 `products/oracle-ai-agent-memory.md`;26.6 hybrid search、context cards、TTL、metadata filters、update APIs 是 vendor product behavior;性能评测表述本轮不入 claims ledger |
+| update-existing | Zep | Zep ABAC blog 2026-07-09 | 更新 `products/zep.md`;API-key action policies and metadata-scoped graph access 是 governance surface,不是 quality claim |
+| update-existing | TencentDB Agent Memory | Tencent Cloud billing docs 2026-07-07 | 更新 `products/tencentdb-agent-memory.md`;商业计费和白名单免费期是 productization/procurement signal |
+| update-existing | Alibaba Bailian Memory Library | Alibaba Cloud long-term memory API reference | 更新 `products/alibaba-bailian-memory.md`;Add/Search/List/Delete/Update/Profile APIs 是 official API surface,但页面日期不可稳定确认 |
+| watchlist | Anthropic API memory-store beta header | Claude API release notes surfaced a dated-after-run memory-store change | 当前 run date 为 2026-07-13;不收录 2026-07-22 future-dated release-note item,下周复核 |

--- a/docs/products-landscape.md
+++ b/docs/products-landscape.md
@@ -1,6 +1,6 @@
 ---
 title: Products landscape — agent memory by domain × audience
-date: 2026-06-24
+date: 2026-07-13
 status: working-spec
 language: zh-CN
 ---
@@ -122,6 +122,18 @@ language: zh-CN
 | Cloudflare Agent Memory | [`../products/cloudflare-agent-memory.md`](../products/cloudflare-agent-memory.md) | Big-tech-builtin / Private beta | Cloudflare Agents 用户 |
 | Oracle AI Agent Memory | [`../products/oracle-ai-agent-memory.md`](../products/oracle-ai-agent-memory.md) | Enterprise platform | Oracle AI Database 客户 |
 | Alibaba Cloud Bailian Memory Library | [`../products/alibaba-bailian-memory.md`](../products/alibaba-bailian-memory.md) | Cloud platform | 百炼 / Model Studio 开发者 |
+
+2026-07-13 refresh note:Google Memory Bank 的 2026-07-08 release notes 把
+`IngestEvents` 标为 GA,并加入 Gemini Embedding 2 similarity-search configuration。
+这加强了其 event ingestion / memory generation 解耦的 managed memory 产品面;
+证据类别仍是官方产品行为,不代表独立 benchmark 复现。
+
+同轮产品复核还更新 Oracle AI Agent Memory 26.6、Zep ABAC、TencentDB Agent
+Memory 计费页和 Alibaba long-term memory API reference。Oracle / Zep / Tencent /
+Alibaba 的更新分别对应 enterprise DB memory lifecycle controls、API-key
+metadata-scoped governance、商业化计费边界和 Add/Search/Profile API surface。性能
+或 benchmark table claims 本轮不进入 accepted refresh;后续使用前需先按 claims
+ledger 规范归档。
 
 ### A4. Coding & Dev agents(memory 用于代码上下文)
 

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -1,6 +1,6 @@
 ---
 title: Signals — agent memory news, releases, comparisons (reverse chrono)
-date: 2026-06-24
+date: 2026-07-13
 status: living-log
 language: zh-CN
 ---
@@ -20,6 +20,8 @@ Radar 动作 enum:`stub` `seed-note` `deep-note` `impact-report` `archive-only`
 
 | 日期 | 来源 | 类型 | 一句话 | Radar 动作 |
 |---|---|---|---|---|
+| 2026-07-13 | [Learning User-Aware Recall](https://arxiv.org/abs/2607.00017) / [Active Memory Navigation](https://arxiv.org/abs/2607.05794) / [Forged Reasoning Attacks](https://arxiv.org/abs/2607.05029) / [Remember When It Matters](https://arxiv.org/abs/2607.08716) / [Memory in the Loop](https://arxiv.org/abs/2607.05690) | paper | 周更 radar 追加 user-aware recall、memory-as-action-space、reasoning-history poisoning、selective memory intervention、in-process working memory 五条 seed note | `seed-note` ✅(见 `papers/`) |
+| 2026-07-13 | [Google Agent Platform release notes](https://docs.cloud.google.com/gemini-enterprise-agent-platform/release-notes) / [Oracle 26.6 blog](https://blogs.oracle.com/developers/whats-new-in-oracle-ai-agent-memory-custom-extraction-hybrid-search-and-more-control) / [Zep ABAC](https://blog.getzep.com/attribute-based-access-control/) / [Tencent billing](https://cloud.tencent.com/document/product/1813/133512) / [Alibaba API reference](https://help.aliyun.com/en/model-studio/long-term-memory-api-reference) | product | 官方产品源补充 Memory Bank IngestEvents GA、Oracle 26.6 controls、Zep metadata-scoped ABAC、Tencent 商业计费和 Alibaba memory API surface | `deep-note` ✅(更新 `products/`) |
 | 2026-07-06 | [A-TMA](https://arxiv.org/abs/2607.01935) / [Mandol](https://arxiv.org/abs/2606.29778) / [Forensic Trajectory Signatures](https://arxiv.org/abs/2606.30566) | paper | 周更 radar 追加 state-aware ghost memory、agglomerative memory-native storage、memory-poisoning trajectory forensics 三条 seed note | `seed-note` ✅(见 `papers/`) |
 | 2026-07-06 | [MemSyco-Bench](https://arxiv.org/abs/2607.01071) / [MemLeak](https://arxiv.org/abs/2606.29788) / [MemDelta](https://arxiv.org/abs/2606.29914) | paper | benchmark catalog 新增 memory-induced sycophancy、多模态删除泄漏、controlled baseline methodology | `seed-note` ✅(见 `benchmarks/`) |
 | 2026-07-06 | [AWS AgentCore release notes](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/release-notes.html) / [Google release notes](https://docs.cloud.google.com/gemini-enterprise-agent-platform/release-notes) / [OpenAI Business release notes](https://help.openai.com/en/articles/11391654-chatgpt-business-release-notes) / [Mem0 changelog](https://docs.mem0.ai/changelog/highlights) / [Redis guide](https://redis.io/blog/build-smarter-ai-agents-manage-short-term-and-long-term-memory-with-redis/) | product | 官方产品源补充 AgentCore streaming、Memory Bank model default、ChatGPT org memory controls、Mem0 expiration 和 Redis two-tier guidance | `deep-note` ✅(更新 `products/`) |

--- a/papers/active-memory-navigation.md
+++ b/papers/active-memory-navigation.md
@@ -1,0 +1,65 @@
+---
+title: From Passive Retrieval to Active Memory Navigation — Learning to Use Memory as a Structured Action Space
+arxiv_id: 2607.05794
+source: arXiv:2607.05794
+date: 2026-07
+domain: memory
+core_claim: |
+  Long-term user memory can be exposed as a structured action space with
+  navigable granularity, provenance, and learned memory-tool selection rather
+  than as passive retrieved context.
+evidence_level: medium
+code_available: check
+license: check
+memory_modules:
+  - retriever-reranker
+  - semantic-dedup
+  - evaluator-benchmark
+status: seed
+last_revised: 2026-07-13
+urls:
+  - https://arxiv.org/abs/2607.05794
+---
+
+# From Passive Retrieval to Active Memory Navigation(arXiv 2607.05794)
+
+## Problem statement
+
+Many memory systems preselect evidence and pass it to the answer model. The
+paper argues that this leaves the agent as a passive memory consumer and hides
+which memory granularity should be inspected for a given user query.
+
+## Core claim
+
+NapMem organizes user history into a linked multi-granularity memory pyramid:
+raw conversations, typed memory records, topic tracks, and user profiles are
+connected through provenance relations and exposed through memory tools. The
+agent learns to select among memory tools and granularities before answering.
+
+Reported PersonaMem-v2, LongMemEval, and LoCoMo results are paper-origin
+claims. This seed note records the memory-as-action-space design pressure, not
+an independent benchmark conclusion.
+
+## Decision relevance
+
+- `retriever-reranker`:retrieval should sometimes be a learned navigation policy
+  over memory levels, not only a static top-k result.
+- `semantic-dedup`:multi-granularity memory needs provenance links between raw
+  conversations, records, topics, and profiles.
+- `evaluator-benchmark`:tool-use behavior and granularity choices are measurable
+  components of memory evaluation.
+
+## Caveats
+
+This local note is seed quality. A full read should verify code/data
+availability, memory pyramid construction, RL setup, and whether benchmark
+comparisons isolate memory navigation from model/backbone differences.
+
+## Sources
+
+- arXiv:https://arxiv.org/abs/2607.05794
+
+---
+
+> *Ymem project-specific decision relevance is mapped in
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md).*

--- a/papers/forged-reasoning-memory-attacks.md
+++ b/papers/forged-reasoning-memory-attacks.md
@@ -1,0 +1,65 @@
+---
+title: Your Agent's Memories Are Not Its Own — Forged Reasoning Attacks on LLM Agent Memory and Defenses
+arxiv_id: 2607.05029
+source: arXiv:2607.05029
+date: 2026-07
+domain: memory-security
+core_claim: |
+  Persistent agent memory must protect remembered reasoning histories, not only
+  factual memory records, because forged rationale traces can be injected and
+  reinforced across later agent runs.
+evidence_level: medium
+code_available: check
+license: check
+memory_modules:
+  - policy-privacy
+  - audit-ui
+  - evaluator-benchmark
+status: seed
+last_revised: 2026-07-13
+urls:
+  - https://arxiv.org/abs/2607.05029
+---
+
+# Forged Reasoning Attacks on Agent Memory(arXiv 2607.05029)
+
+## Problem statement
+
+Memory poisoning work often focuses on stored factual knowledge or user facts.
+This paper shifts the threat model to remembered reasoning histories: prior
+decisions, rationales, and tool-use explanations that future agents may trust as
+their own state.
+
+## Core claim
+
+The paper introduces FARMA, the Forged Amplifying Rationale Memory Attack, which
+poisons remembered reasoning rather than factual memory. It also proposes
+SENTINEL, a layered defense with a Reasoning Guard that analyzes candidate
+reasoning entries for forgery signals.
+
+Reported attack success and defense rates are paper-origin claims. This seed
+records the security surface, not an independent validation of the metrics.
+
+## Decision relevance
+
+- `policy-privacy`:memory authorization has to include provenance and integrity
+  of reasoning traces, not only access to facts.
+- `audit-ui`:operators need to inspect why a rationale was stored and whether it
+  came from a trusted execution path.
+- `evaluator-benchmark`:poisoning tests should cover rationale-memory entries
+  and self-referential reinforcement.
+
+## Caveats
+
+This local note is seed quality. A full read should verify agent harnesses,
+attack insertion assumptions, benign-trace construction, and whether SENTINEL's
+signals generalize beyond the evaluated agents.
+
+## Sources
+
+- arXiv:https://arxiv.org/abs/2607.05029
+
+---
+
+> *Ymem project-specific decision relevance is mapped in
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md).*

--- a/papers/index.md
+++ b/papers/index.md
@@ -21,9 +21,14 @@ removed.
 
 ## 2026-07 manual radar additions
 
-These entries were added by the 2026-07-06 weekly radar refresh. They are not
+These entries were added by the 2026-07 weekly radar refreshes. They are not
 part of the 2026-05-19 nine-list scrape statistics above.
 
+- [Learning User-Aware Recall: Personalized Retrieval in Long-Term Conversational Memory](learning-user-aware-recall.md) — 2026-07 — seed — [arxiv](https://arxiv.org/abs/2607.00017)
+- [From Passive Retrieval to Active Memory Navigation: Learning to Use Memory as a Structured Action Space](active-memory-navigation.md) — 2026-07 — seed — [arxiv](https://arxiv.org/abs/2607.05794)
+- [Your Agent's Memories Are Not Its Own: Forged Reasoning Attacks on LLM Agent Memory and Defenses](forged-reasoning-memory-attacks.md) — 2026-07 — seed — [arxiv](https://arxiv.org/abs/2607.05029)
+- [Remember When It Matters: Proactive Memory Agent for Long-Horizon Agents](proactive-memory-agent.md) — 2026-07 — seed — [arxiv](https://arxiv.org/abs/2607.08716)
+- [Memory in the Loop: In-Process Retrieval as Extended Working Memory for Language Agents](memory-in-the-loop.md) — 2026-07 — seed — [arxiv](https://arxiv.org/abs/2607.05690)
 - [A-TMA: Decoupling State-Aware Memory Failures in Long-Term Agent Memory](atma-state-aware-memory-failures.md) — 2026-07 — seed — [arxiv](https://arxiv.org/abs/2607.01935)
 - [MemSyco-Bench: Benchmarking Sycophancy in Agent Memory](../benchmarks/memsyco-bench.md) — 2026-07 — benchmark seed — [arxiv](https://arxiv.org/abs/2607.01071)
 - [MemLeak: Diagnosing Information Leaks in Multimodal Agent Memory](../benchmarks/memleak.md) — 2026-06 — benchmark seed — [arxiv](https://arxiv.org/abs/2606.29788)

--- a/papers/learning-user-aware-recall.md
+++ b/papers/learning-user-aware-recall.md
@@ -1,0 +1,66 @@
+---
+title: Learning User-Aware Recall — Personalized Retrieval in Long-Term Conversational Memory
+arxiv_id: 2607.00017
+source: arXiv:2607.00017
+date: 2026-07
+domain: memory
+core_claim: |
+  Long-term conversational memory retrieval should use explicit user-profile
+  priors and retrieval-oriented query rewriting instead of relying only on
+  query-centered similarity or fixed ranking rules.
+evidence_level: medium
+code_available: check
+license: check
+memory_modules:
+  - retriever-reranker
+  - ingest-adapter
+  - evaluator-benchmark
+status: seed
+last_revised: 2026-07-13
+urls:
+  - https://arxiv.org/abs/2607.00017
+---
+
+# Learning User-Aware Recall(arXiv 2607.00017)
+
+## Problem statement
+
+Long-term conversational agents need to retrieve the right remembered evidence
+for the right user. The paper argues that many memory-augmented agents still
+rank memories mostly by query similarity or fixed rules, leaving stable user
+attributes, preferences, and relationships underused during recall.
+
+## Core claim
+
+The paper proposes Profile-guided Personalized Retrieval Optimization(PPRO).
+PPRO builds episodic and semantic memory banks from dialogue history, derives a
+user profile from accumulated memories, and uses that profile as an explicit
+prior in memory ranking. It also trains a query rewriter with Group Relative
+Policy Optimization while keeping the memory banks and answer model fixed.
+
+Reported LoCoMo and LongMemEval-S gains are paper-origin claims. This seed note
+records the retrieval-control design pressure, not an independent reproduction.
+
+## Decision relevance
+
+- `retriever-reranker`:profile-conditioned ranking is a first-class retrieval
+  axis separate from semantic similarity.
+- `ingest-adapter`:episodic and semantic banks need enough profile structure to
+  support personalized recall without collapsing everything into flat facts.
+- `evaluator-benchmark`:retrieval quality and downstream answer quality should
+  both be measured when optimizing memory recall.
+
+## Caveats
+
+This local note is seed quality. A full read should verify code and data
+availability, user-profile construction, privacy assumptions, and whether the
+reported LongMemEval-S setup is directly comparable to existing memory baselines.
+
+## Sources
+
+- arXiv:https://arxiv.org/abs/2607.00017
+
+---
+
+> *Ymem project-specific decision relevance is mapped in
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md).*

--- a/papers/memory-in-the-loop.md
+++ b/papers/memory-in-the-loop.md
@@ -1,0 +1,65 @@
+---
+title: Memory in the Loop — In-Process Retrieval as Extended Working Memory for Language Agents
+arxiv_id: 2607.05690
+source: arXiv:2607.05690
+date: 2026-07
+domain: memory-systems
+core_claim: |
+  If retrieval is fast enough to run inside every observe-reason-act step, an
+  in-process memory store can function as extended working memory rather than a
+  once-per-turn external tool.
+evidence_level: medium
+code_available: check
+license: check
+memory_modules:
+  - retriever-reranker
+  - ingest-adapter
+  - evaluator-benchmark
+status: seed
+last_revised: 2026-07-13
+urls:
+  - https://arxiv.org/abs/2607.05690
+---
+
+# Memory in the Loop(arXiv 2607.05690)
+
+## Problem statement
+
+Most language-agent memory stores are queried once per turn or managed as a
+separate tool because networked retrieval adds latency. The paper asks what
+changes when memory reads and writes can happen inside every agent step.
+
+## Core claim
+
+The paper frames in-process retrieval as extended working memory. It argues that
+latency is a placement property: when the store is local enough to answer in
+microseconds rather than cloud round trips, per-step memory access becomes a
+different design regime. The reported experiments connect memory latency to
+redundant agent actions under a fixed per-turn budget.
+
+Reported latency and redundancy measurements are paper-origin claims. This seed
+records the systems hypothesis, not an independent reproduction.
+
+## Decision relevance
+
+- `retriever-reranker`:retrieval placement and latency budget affect whether
+  memory can participate in every reasoning step.
+- `ingest-adapter`:in-loop write paths need consistency and overhead rules, not
+  just a batch consolidation job.
+- `evaluator-benchmark`:memory cost metrics should include step-level latency
+  and behavioral side effects such as redundant actions.
+
+## Caveats
+
+This local note is seed quality. A full read should verify implementation,
+hardware, memory-store design, model choices, and whether the extended-working
+memory framing holds beyond the reported task setup.
+
+## Sources
+
+- arXiv:https://arxiv.org/abs/2607.05690
+
+---
+
+> *Ymem project-specific decision relevance is mapped in
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md).*

--- a/papers/proactive-memory-agent.md
+++ b/papers/proactive-memory-agent.md
@@ -1,0 +1,65 @@
+---
+title: Remember When It Matters — Proactive Memory Agent for Long-Horizon Agents
+arxiv_id: 2607.08716
+source: arXiv:2607.08716
+date: 2026-07
+domain: memory
+core_claim: |
+  A separate memory agent can update a structured memory bank and selectively
+  inject memory-grounded reminders into long-horizon agents when state would
+  otherwise decay from the working context.
+evidence_level: medium
+code_available: check
+license: check
+memory_modules:
+  - dream-consolidator
+  - retriever-reranker
+  - evaluator-benchmark
+status: seed
+last_revised: 2026-07-13
+urls:
+  - https://arxiv.org/abs/2607.08716
+---
+
+# Remember When It Matters(arXiv 2607.08716)
+
+## Problem statement
+
+In long-horizon tasks, requirements, diagnoses, prior attempts, environment
+facts, and open subgoals can be buried in an expanding trajectory. The paper
+calls this behavioral state decay and treats memory as an active intervention
+mechanism rather than passive retrieval.
+
+## Core claim
+
+The proposed memory agent runs beside an unmodified action agent. It updates a
+structured memory bank from recent trajectory evidence and decides whether to
+inject a memory-grounded reminder or stay silent. The paper reports results on
+Terminal-Bench 2.0 and tau2-Bench and explores open-weight memory policies.
+
+Reported pass@1 gains are paper-origin claims. This seed note records the
+selective-intervention design, not an independent benchmark result.
+
+## Decision relevance
+
+- `dream-consolidator`:memory updates can happen as a sidecar process over the
+  recent trajectory rather than inside the action agent.
+- `retriever-reranker`:retrieval may need a silence option; always injecting
+  memory can be worse than selective intervention.
+- `evaluator-benchmark`:long-horizon agent tasks should measure whether memory
+  affects decisions at the point it matters.
+
+## Caveats
+
+This local note is seed quality. A full read should verify the memory bank
+schema, intervention policy labels, benchmark harness details, and whether gains
+come from memory timing rather than extra advisor compute.
+
+## Sources
+
+- arXiv:https://arxiv.org/abs/2607.08716
+
+---
+
+> *Ymem project-specific decision relevance is mapped in
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md).*

--- a/products/alibaba-bailian-memory.md
+++ b/products/alibaba-bailian-memory.md
@@ -12,7 +12,7 @@ memory_modules:
   - retriever-reranker
   - policy-privacy
 status: seed
-last_revised: 2026-06-29
+last_revised: 2026-07-13
 archive: archives/alibaba-bailian-memory-overview.md
 ---
 
@@ -45,6 +45,18 @@ AgentLoop 更像 enterprise agent observability / optimization platform,而不�
 产品条目,避免与 Bailian Memory Library / long-term memory API / OpenClaw memory
 plugin 混淆。
 
+## 3.2 2026-07 refresh
+
+The English long-term memory API reference is now explicit about the API
+surface: `AddMemory`, `SearchMemory`, `ListMemory`, `DeleteMemory`,
+`UpdateMemory`, profile-schema CRUD, and `GetUserProfile`. It also documents
+account-level throttling and says generated memory fragments and user profiles
+do not expire by default.
+
+The visible page body did not expose a stable update date during the
+2026-07-13 refresh, so this note treats the API reference as official current
+product behavior and keeps the date caveat out of any freshness claim.
+
 ## 4. 决策相关性 / Decision relevance
 
 - **对照点**:百炼代表国内云平台把 long-term memory API 产品化的路线。
@@ -69,6 +81,7 @@ plugin 混淆。
 - archive: [`archives/alibaba-bailian-memory-overview.md`](archives/alibaba-bailian-memory-overview.md)
 - 记忆库:https://help.aliyun.com/zh/model-studio/memory-library
 - 长期记忆 API:https://help.aliyun.com/zh/model-studio/long-term-memory-2-0
+- Long-term memory API reference:https://help.aliyun.com/en/model-studio/long-term-memory-api-reference
 - AgentLoop:https://help.aliyun.com/en/document_detail/3033860.html
 - OpenClaw memory plugin:https://help.aliyun.com/en/model-studio/modelstudio-memory-for-openclaw
 

--- a/products/google-memory-bank.md
+++ b/products/google-memory-bank.md
@@ -12,7 +12,7 @@ memory_modules:
   - retriever-reranker
   - policy-privacy
 status: seed
-last_revised: 2026-07-06
+last_revised: 2026-07-13
 archive: archives/google-memory-bank-overview.md
 ---
 
@@ -54,6 +54,13 @@ Google 2026-06-29 Gemini Enterprise Agent Platform release notes 将 Memory Bank
 generation 的默认模型从 Gemini 2.5 Flash 改为 Gemini 3.5 Flash。该更新说明托管
 memory extraction / generation 仍会随平台模型配置变化;它是产品行为证据,不代表
 memory ranking 机制或质量有独立复现。
+
+2026-07-08 release notes 又把 Memory Bank `IngestEvents` API 标为 GA,并增加
+Gemini Embedding 2 similarity-search configuration 支持。`IngestEvents` 将事件
+ingestion 与 memory generation 解耦,支持连续 stream content、generation window
+overlap、revision labels / TTL / disable revisions,以及 memory metadata merge。
+这强化了 Memory Bank 作为 evented managed memory pipeline 的公开产品面,但仍然
+是 Google 官方产品行为证据。
 
 ## 4. 决策相关性 / Decision relevance
 

--- a/products/oracle-ai-agent-memory.md
+++ b/products/oracle-ai-agent-memory.md
@@ -11,7 +11,7 @@ memory_modules:
   - retriever-reranker
   - policy-privacy
 status: seed
-last_revised: 2026-06-29
+last_revised: 2026-07-13
 archive: archives/oracle-ai-agent-memory-overview.md
 ---
 
@@ -43,6 +43,19 @@ memory(`add` / `search` workflows),用于保存用户偏好、规则和跨会话
 官方文档集存在。Oracle developer blog 的 Claude / Oracle / LangChain 组合文章在
 本环境返回 403,因此不把该 blog 的架构定位升级为本仓强证据;后续可人工复核后再补。
 
+## 3.2 2026-07 refresh
+
+Oracle 2026-07-07 developer blog 将 26.6 更新描述为更面向开发者控制面的版本:
+background extraction、hybrid vector + text search、custom extraction
+instructions、context cards、metadata filtering、update APIs、TTL、OracleDBEmbedder
+和 chunked semantic indexing。2026-07-10 database blog 进一步把 26.6 定位为
+"memory with receipts"。
+
+这些更新强化了 Oracle 路线的核心特征:memory 不是独立黑箱服务,而是数据库内的
+可过滤、可更新、可保留期限管理的 enterprise substrate。本轮只收录产品行为和
+治理面变化;博客中的性能评测表述不进入 benchmark claims ledger,后续若要使用需先
+按 claims ledger 规范单独归档。
+
 ## 4. 决策相关性 / Decision relevance
 
 - **对照点**:Oracle 代表 "enterprise database becomes memory substrate" 路线。
@@ -67,6 +80,8 @@ memory(`add` / `search` workflows),用于保存用户偏好、规则和跨会话
 - archive: [`archives/oracle-ai-agent-memory-overview.md`](archives/oracle-ai-agent-memory-overview.md)
 - Docs:https://docs.oracle.com/en/database/oracle/agent-memory/26.4/agmea/about.html
 - Docs index:https://docs.oracle.com/en/database/oracle/agent-memory/26.4/agmea/index.html
+- 26.6 developer blog:https://blogs.oracle.com/developers/whats-new-in-oracle-ai-agent-memory-custom-extraction-hybrid-search-and-more-control
+- 26.6 database blog:https://blogs.oracle.com/database/oracle-ai-agent-memory-26-6
 
 ---
 

--- a/products/tencentdb-agent-memory.md
+++ b/products/tencentdb-agent-memory.md
@@ -14,7 +14,7 @@ memory_modules:
   - dream-consolidator
   - audit-ui
 status: seed
-last_revised: 2026-06-29
+last_revised: 2026-07-13
 archive: archives/tencentdb-agent-memory-overview.md
 ---
 
@@ -55,6 +55,14 @@ Tencent Cloud VectorDB。
 - **接入**:OpenClaw plugin、Hermes Gateway adapter、agent tools
   `tdai_memory_search` / `tdai_conversation_search`
 
+## 3.1 2026-07 commercial signal
+
+Tencent Cloud 2026-07-07 billing documentation makes Agent Memory a commercial
+cloud service surface rather than only an OSS/research signal. The billing page
+describes pay-as-you-go charging by memory storage and model-call credits, while
+the public beta / whitelist period remains free until 2026-08-15. This is a
+productization and procurement signal, not evidence of memory quality.
+
 ## 4. 决策相关性 / Decision relevance
 
 - **对照点**:它把"可调试记忆"作为核心卖点,不像纯 vector DB 只返回相似度列表。
@@ -91,6 +99,7 @@ Tencent Cloud VectorDB。
 
 - archive: [`archives/tencentdb-agent-memory-overview.md`](archives/tencentdb-agent-memory-overview.md)
 - 腾讯云产品页:https://cloud.tencent.com/product/agm
+- 计费概述:https://cloud.tencent.com/document/product/1813/133512
 - GitHub:https://github.com/TencentCloud/TencentDB-Agent-Memory
 - Historical GitHub alias:https://github.com/Tencent/TencentDB-Agent-Memory
 

--- a/products/zep.md
+++ b/products/zep.md
@@ -12,7 +12,7 @@ memory_modules:
   - dream-consolidator
   - memorydiff-generator
 status: full
-last_revised: 2026-05-19
+last_revised: 2026-07-13
 archive: archives/zep-overview.md
 ---
 
@@ -51,6 +51,9 @@ healthcare 等行业的预置 entity schema 模板。
   "为什么这条曾经成立"的审计链
 - **性能**:产品页声称 P95 < 200ms,LoCoMo 单次检索 80.32%
 - **合规**:SOC 2 Type II / HIPAA(hosted 版)
+- **ABAC**:2026-07 Zep blog describes attribute-based access control for API
+  keys, including action-level policies and source-based graph-artifact access
+  based on effective metadata projected from source episodes.
 
 > Benchmark record: [`../benchmarks/locomo.md`](../benchmarks/locomo.md);
 > event ledger row: `zep-locomo-2026` in
@@ -91,6 +94,8 @@ domain × audience 表:
   vector store 那样无状态
 - **benchmark 自报**:LoCoMo 80.32% 是产品页声明,与 Mem0 / LangMem 的可比性
   需要独立复现
+- **ABAC 证据类别**:Zep ABAC 是官方产品治理能力,可支持 access-control surface
+  判断,但不支持 memory quality 或 benchmark superiority claims。
 - **温度计**:Zep 把"知识图谱 + LLM extraction"的复杂度藏在 API 后面,出
   问题时排错路径长
 
@@ -99,6 +104,7 @@ domain × audience 表:
 - archive: [`archives/zep-overview.md`](archives/zep-overview.md)
 - 配套笔记:[`graphiti.md`](graphiti.md)(OSS 内核)
 - 官方:https://www.getzep.com、https://help.getzep.com/(docs 已迁移)
+- ABAC blog:https://blog.getzep.com/attribute-based-access-control/
 
 ---
 


### PR DESCRIPTION
## Accepted additions

### Papers
- Added `Learning User-Aware Recall` as a seed note for profile-guided personalized recall and query rewriting.
- Added `From Passive Retrieval to Active Memory Navigation` as a seed note for NapMem structured memory navigation.
- Added `Forged Reasoning Attacks` as a seed note for remembered-reasoning memory poisoning and defenses.
- Added `Remember When It Matters` as a seed note for proactive memory-agent intervention in long-horizon agents.
- Added `Memory in the Loop` as a seed note for in-process retrieval as extended working memory.

### Product updates
- Updated Google Memory Bank for 2026-07-08 `IngestEvents` GA and Gemini Embedding 2 similarity-search support.
- Updated Oracle AI Agent Memory for 26.6 hybrid search, custom extraction, context cards, metadata filtering, update APIs, and TTL; performance/benchmark claims are explicitly excluded pending claims-ledger intake.
- Updated Zep for metadata-scoped ABAC and action-level API-key policies.
- Updated TencentDB Agent Memory for billing/productization evidence and whitelist-free period.
- Updated Alibaba Bailian Memory for Add/Search/List/Delete/Update/Profile API surface, with page-date caveat.

## Updated connected surfaces

- Updated `papers/index.md`, `docs/memory-radar-2026-07.md`, `docs/signals.md`, `docs/product-discovery-log.md`, `docs/products-landscape.md`, `README.md`, and `README_cn.md`.
- Paper seed-note count moves from 15 to 20. Product and benchmark counts stay at 38 and 21.

## Watchlist / adjacent / rejected

- Watchlist: Anthropic API memory-store beta header because the visible release-note item is dated 2026-07-22, after this 2026-07-13 run date.
- Watchlist: AgenticSTS, MRAgent, WorldMemArena, SAGE-Mem, OWASP Agent Memory Guard, and agent-memory-integrity until primary source timing, setup detail, or independent evidence is stronger.
- Adjacent/reject: GitHub-only memory tools, MCP implementations, generic long-context/prompts/cache sources, and duplicate Redis/Mem0/Cloudflare/AWS signals without a new memory-specific July delta.
- Source mismatch guard: ACL/OpenReview/list/GitHub sources remain discovery or update-existing signals only unless backed by accessible primary paper/product evidence.

## Verification

- `ruby scripts/verify_memory_refresh.rb` passed.
  - Counts: `papers=989 pdfs=534 stubs=988 full_notes=7 seed_notes=20 products=38 product_archives=37 benchmarks=21`.
- `git diff --cached --check` passed.
- Conflict-marker scan passed.
- Targeted canonical URL checks passed for the five arXiv entries plus Google, Zep, Tencent, and Alibaba official sources.
- Final code-reviewer pass returned PASS after tightening Oracle benchmark-claim wording.

## Known gaps

- Oracle blog URLs were accessible through browser/web fetch, but direct `curl` returned 403 for both 26.6 blog pages.
- No full PDF read, full external-link crawl, or independent benchmark reproduction was performed.
- Alibaba API reference is treated as current official API surface, but a stable page update date was not confirmed.
