### PR TITLE
Refresh August 31 memory radar evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 [![Papers](https://img.shields.io/badge/papers-989-brightgreen.svg)](papers/index.md)
 [![PDFs](https://img.shields.io/badge/local_PDFs-534-orange.svg)](papers/pdfs/)
 [![Memory products](https://img.shields.io/badge/memory%20products-38-purple.svg)](products/)
-[![Benchmarks](https://img.shields.io/badge/benchmarks-21-blueviolet.svg)](benchmarks/)
+[![Benchmarks](https://img.shields.io/badge/benchmarks-26-blueviolet.svg)](benchmarks/)
 [![Surveys](https://img.shields.io/badge/meta_surveys-6-yellow.svg)](docs/meta-surveys.md)
-[![Updated](https://img.shields.io/badge/updated-2026--07-lightgrey.svg)](docs/signals.md)
+[![Updated](https://img.shields.io/badge/updated-2026--08-lightgrey.svg)](docs/signals.md)
 
 </div>
 
@@ -55,13 +55,13 @@ separate buckets.
 
 | Area | Current coverage | Entry point | Use it when you need to |
 |---|---:|---|---|
-| Paper index | 989 scraped papers + manual radar additions through 2026-07 | [`papers/index.md`](papers/index.md) | Searchable entry point for agent-memory papers; the 989 count is the 2026-05 scrape baseline. |
+| Paper index | 989 scraped papers + manual radar additions through 2026-08 | [`papers/index.md`](papers/index.md) | Searchable entry point for agent-memory papers; the 989 count is the 2026-05 scrape baseline. |
 | Paper stubs | 988 stubs | [`papers/stubs/`](papers/stubs/) | Track papers that are covered but not yet fully read. |
 | Local PDFs | 534 files | [`papers/pdfs/`](papers/pdfs/) | Re-read sources and audit paper notes. |
-| Full / seed paper notes | 7 full + 15 seed | [`papers/`](papers/) | Use human-read notes for architectural decisions. |
+| Full / seed paper notes | 7 full + 24 seed | [`papers/`](papers/) | Use human-read notes for architectural decisions. |
 | Memory product notes | 38 notes | [`products/`](products/) | Compare memory layers, memory SDKs, managed memory, and memory-enabled agents. |
 | Product page archives | 37 snapshots | [`products/archives/`](products/archives/) | Audit product claims after source pages change. |
-| Benchmark catalog | 21 catalog rows | [`benchmarks/index.md`](benchmarks/index.md) | First-class benchmark records plus stub-backed candidate rows and a usage-claim ledger. |
+| Benchmark catalog | 26 catalog rows | [`benchmarks/index.md`](benchmarks/index.md) | First-class benchmark records plus stub-backed candidate rows and a usage-claim ledger. |
 | Claims ledger | Structured YAML ledger | [`benchmarks/claims/claims.yaml`](benchmarks/claims/claims.yaml) | Separate vendor claims, paper evaluations, critiques, and reproductions. |
 | Cost-savings lane | Seed landscape | [`docs/cost-savings-landscape.md`](docs/cost-savings-landscape.md) | Find agent-memory papers, methods, code paths, and products that reduce token, latency, or runtime cost. |
 | Survey and taxonomy | 1 living survey + 6 meta-survey records | [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) · [`docs/meta-surveys.md`](docs/meta-surveys.md) | Build a field-level view before choosing an implementation. |
@@ -74,7 +74,7 @@ Start with the path that matches your question:
 | Goal | Read these first |
 |---|---|
 | Get the field overview | [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md), then [`docs/taxonomy.md`](docs/taxonomy.md) |
-| Read the latest source refresh | [`docs/memory-radar-2026-07.md`](docs/memory-radar-2026-07.md), then [`docs/signals.md`](docs/signals.md) |
+| Read the latest source refresh | [`docs/memory-radar-2026-08-31.md`](docs/memory-radar-2026-08-31.md), then [`docs/signals.md`](docs/signals.md) |
 | Find relevant papers | [`papers/index.md`](papers/index.md), then full notes under [`papers/`](papers/) |
 | Compare memory products | [`docs/products-landscape.md`](docs/products-landscape.md), [`docs/product-memory-architectures.md`](docs/product-memory-architectures.md), [`docs/product-architecture-diagrams.md`](docs/product-architecture-diagrams.md) |
 | Check why a product was included or rejected | [`docs/product-discovery-log.md`](docs/product-discovery-log.md) |
@@ -159,6 +159,7 @@ flowchart LR
 | [`docs/taxonomy.md`](docs/taxonomy.md) | Shared vocabulary for classifying agent-memory systems and memory-kernel responsibilities. |
 | [`docs/meta-surveys.md`](docs/meta-surveys.md) | External meta-survey index from late 2025 through 2026 H1. |
 | [`docs/research-radar.md`](docs/research-radar.md) | Workflow for turning papers, products, and benchmark evidence into ImpactReports and ADR inputs. |
+| [`docs/memory-radar-2026-08-31.md`](docs/memory-radar-2026-08-31.md) | 2026-08-31 weekly refresh across papers, products, GitHub projects, and reviewer decisions. |
 | [`docs/memory-radar-2026-07.md`](docs/memory-radar-2026-07.md) | 2026-07 weekly refresh across papers, products, GitHub projects, and reviewer decisions. |
 | [`docs/cost-savings-landscape.md`](docs/cost-savings-landscape.md) | Focused lane for agent-memory token reduction, budgeted retrieval, runtime-cost methods, code paths, and product practice signals. |
 | [`docs/information-sources.md`](docs/information-sources.md) | Source catalog for papers, products, communities, and zh-CN information channels. |
@@ -180,11 +181,11 @@ flowchart LR
 
 | Path | Purpose |
 |---|---|
-| [`papers/`](papers/) | 7 full paper notes, 15 seed notes, and the master [`index.md`](papers/index.md). |
+| [`papers/`](papers/) | 7 full paper notes, 24 seed notes, and the master [`index.md`](papers/index.md). |
 | [`papers/stubs/`](papers/stubs/) | 988 generated stubs for papers not yet fully read. |
 | [`papers/pdfs/`](papers/pdfs/) | 534 archived PDFs, about 1.8 GB. See the archival policy below. |
 | [`papers/_scrape/`](papers/_scrape/) | Reproducibility artifacts: scrape script and dedup JSON. |
-| [`benchmarks/`](benchmarks/) | 21 benchmark catalog rows, including protocol notes, stub-backed candidate rows, and the note template. |
+| [`benchmarks/`](benchmarks/) | 26 benchmark catalog rows, including protocol notes, stub-backed candidate rows, and the note template. |
 | [`benchmarks/claims/`](benchmarks/claims/) | Usage-event ledger for benchmark mentions, vendor claims, critiques, and reproductions. |
 | [`benchmarks/archives/`](benchmarks/archives/) | Optional source-page snapshots for benchmark pages, repositories, or dataset cards. |
 | [`docs/benchmarks-landscape.md`](docs/benchmarks-landscape.md) | Benchmark landscape by capability, usage type, and evidence independence. |

--- a/README_cn.md
+++ b/README_cn.md
@@ -10,9 +10,9 @@
 [![Papers](https://img.shields.io/badge/papers-989-brightgreen.svg)](papers/index.md)
 [![PDFs](https://img.shields.io/badge/local_PDFs-534-orange.svg)](papers/pdfs/)
 [![记忆产品](https://img.shields.io/badge/memory%20products-38-purple.svg)](products/)
-[![Benchmarks](https://img.shields.io/badge/benchmarks-21-blueviolet.svg)](benchmarks/)
+[![Benchmarks](https://img.shields.io/badge/benchmarks-26-blueviolet.svg)](benchmarks/)
 [![Surveys](https://img.shields.io/badge/meta_surveys-6-yellow.svg)](docs/meta-surveys.md)
-[![Updated](https://img.shields.io/badge/updated-2026--07-lightgrey.svg)](docs/signals.md)
+[![Updated](https://img.shields.io/badge/updated-2026--08-lightgrey.svg)](docs/signals.md)
 
 </div>
 
@@ -53,13 +53,13 @@
 
 | 板块 | 当前覆盖 | 入口 | 适合用来 |
 |---|---:|---|---|
-| 论文索引 | 989 篇抓取论文 + 截至 2026-07 的手工 radar 新增 | [`papers/index.md`](papers/index.md) | 搜索 agent-memory 论文和发现线索；989 是 2026-05 抓取基线。 |
+| 论文索引 | 989 篇抓取论文 + 截至 2026-08 的手工 radar 新增 | [`papers/index.md`](papers/index.md) | 搜索 agent-memory 论文和发现线索；989 是 2026-05 抓取基线。 |
 | 论文 stub | 988 个 stub | [`papers/stubs/`](papers/stubs/) | 跟踪已覆盖但尚未 full 阅读的论文。 |
 | 本地 PDF | 534 个文件 | [`papers/pdfs/`](papers/pdfs/) | 复读来源和审计论文笔记。 |
-| full / seed 论文笔记 | 7 个 full + 15 个 seed | [`papers/`](papers/) | 为架构决策引用人工阅读笔记。 |
+| full / seed 论文笔记 | 7 个 full + 24 个 seed | [`papers/`](papers/) | 为架构决策引用人工阅读笔记。 |
 | 记忆产品笔记 | 38 个笔记 | [`products/`](products/) | 对比 memory layer、memory SDK、managed memory 和带记忆的 agent 产品。 |
 | 产品页面快照 | 37 个快照 | [`products/archives/`](products/archives/) | 在源页面变化后审计产品 claims。 |
-| Benchmark 目录 | 21 个 catalog 行 | [`benchmarks/index.md`](benchmarks/index.md) | 理解 memory benchmark、stub-backed 候选行及其 claims 来源。 |
+| Benchmark 目录 | 26 个 catalog 行 | [`benchmarks/index.md`](benchmarks/index.md) | 理解 memory benchmark、stub-backed 候选行及其 claims 来源。 |
 | Claims ledger | 结构化 YAML ledger | [`benchmarks/claims/claims.yaml`](benchmarks/claims/claims.yaml) | 区分厂商自报、论文评测、方法批评和独立复现。 |
 | 成本节省专题 | seed landscape | [`docs/cost-savings-landscape.md`](docs/cost-savings-landscape.md) | 查找能减少 token、延迟或运行成本的 agent-memory 论文、方法、代码和产品。 |
 | 综述与 taxonomy | 1 份活综述 + 6 条 meta-survey 记录 | [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md) · [`docs/meta-surveys.md`](docs/meta-surveys.md) | 在选型或设计前建立领域视角。 |
@@ -72,7 +72,7 @@
 | 目标 | 先读这些 |
 |---|---|
 | 快速理解领域 | [`docs/agent-memory-survey.md`](docs/agent-memory-survey.md)，再读 [`docs/taxonomy.md`](docs/taxonomy.md) |
-| 阅读最新来源刷新 | [`docs/memory-radar-2026-07.md`](docs/memory-radar-2026-07.md)，再看 [`docs/signals.md`](docs/signals.md) |
+| 阅读最新来源刷新 | [`docs/memory-radar-2026-08-31.md`](docs/memory-radar-2026-08-31.md)，再看 [`docs/signals.md`](docs/signals.md) |
 | 找相关论文 | [`papers/index.md`](papers/index.md)，再看 [`papers/`](papers/) 下的 full note |
 | 比较记忆产品 | [`docs/products-landscape.md`](docs/products-landscape.md)、[`docs/product-memory-architectures.md`](docs/product-memory-architectures.md)、[`docs/product-architecture-diagrams.md`](docs/product-architecture-diagrams.md) |
 | 查看产品为什么入库或被拒绝 | [`docs/product-discovery-log.md`](docs/product-discovery-log.md) |
@@ -154,6 +154,7 @@ flowchart LR
 | [`docs/taxonomy.md`](docs/taxonomy.md) | 分类 agent-memory 系统和 memory-kernel 职责的共享词表。 |
 | [`docs/meta-surveys.md`](docs/meta-surveys.md) | 2025 年末到 2026 H1 的外部 meta-survey 索引。 |
 | [`docs/research-radar.md`](docs/research-radar.md) | 把论文、产品、benchmark 证据转成 ImpactReport 和 ADR 输入的工作流。 |
+| [`docs/memory-radar-2026-08-31.md`](docs/memory-radar-2026-08-31.md) | 2026-08-31 周更来源刷新，覆盖论文、产品、GitHub 项目和 reviewer 分流结论。 |
 | [`docs/memory-radar-2026-07.md`](docs/memory-radar-2026-07.md) | 2026-07 周更来源刷新，覆盖论文、产品、GitHub 项目和 reviewer 分流结论。 |
 | [`docs/cost-savings-landscape.md`](docs/cost-savings-landscape.md) | agent-memory token reduction、预算检索、运行成本方法、代码路径和产品实践信号专题。 |
 | [`docs/information-sources.md`](docs/information-sources.md) | 论文、产品、社区和中文信息源 catalog。 |
@@ -175,11 +176,11 @@ flowchart LR
 
 | 路径 | 用途 |
 |---|---|
-| [`papers/`](papers/) | 7 个 full 论文笔记、15 个 seed 笔记和主索引 [`index.md`](papers/index.md)。 |
+| [`papers/`](papers/) | 7 个 full 论文笔记、24 个 seed 笔记和主索引 [`index.md`](papers/index.md)。 |
 | [`papers/stubs/`](papers/stubs/) | 988 个尚未 full 阅读论文的生成 stub。 |
 | [`papers/pdfs/`](papers/pdfs/) | 534 个本地 PDF，约 1.8 GB。详见下方存档策略。 |
 | [`papers/_scrape/`](papers/_scrape/) | 可复现产物：抓取脚本和 dedup JSON。 |
-| [`benchmarks/`](benchmarks/) | 21 个 benchmark catalog 行，包含协议笔记、stub-backed 候选行和笔记模板。 |
+| [`benchmarks/`](benchmarks/) | 26 个 benchmark catalog 行，包含协议笔记、stub-backed 候选行和笔记模板。 |
 | [`benchmarks/claims/`](benchmarks/claims/) | benchmark 提及、厂商自报、方法批评和复现的 usage-event ledger。 |
 | [`benchmarks/archives/`](benchmarks/archives/) | benchmark 页面、repo 或 dataset card 的可选审计快照。 |
 | [`docs/benchmarks-landscape.md`](docs/benchmarks-landscape.md) | 按能力、使用方式和证据独立性整理的 benchmark 全景。 |

--- a/benchmarks/agent-memory-leaderboard.md
+++ b/benchmarks/agent-memory-leaderboard.md
@@ -1,0 +1,65 @@
+---
+title: Agent Memory Leaderboard — public evaluation platform
+benchmark_id: agent-memory-leaderboard
+name: Agent Memory Leaderboard
+aliases:
+  - AML
+  - Agent Memory Leaderboard
+status: candidate
+origin_type: official_benchmark_platform
+origin_source: https://github.com/AML-memory/agent-memory-leaderboard
+first_public_date: 2026-08
+domain: benchmark_platform
+modality: text
+task_grain: benchmark_submission
+capability_axes:
+  - benchmark_reporting
+  - protocol_registry
+data_nature: check
+metrics: []
+judge_type: check
+code_available: yes
+data_available: check
+license: check
+known_limitations:
+  - candidate note; README, protocol ownership, task definitions, and leaderboard governance need full read
+canonical_sources:
+  - https://github.com/AML-memory/agent-memory-leaderboard
+confidence: low
+memory_modules:
+  - evaluator-benchmark
+last_revised: 2026-08-31
+---
+
+# Agent Memory Leaderboard
+
+## What It Measures
+
+Agent Memory Leaderboard is a discovery signal for a public agent-memory
+evaluation platform. This local note does not yet treat the leaderboard as a
+normalized benchmark because protocol, submission, and governance details need
+inspection.
+
+## Protocol
+
+The repository was surfaced in the 2026-08 weekly refresh as an active GitHub
+benchmark-platform candidate. It needs a full README/code/data pass before this
+repo uses any leaderboard ranking, task suite, or score claim.
+
+## Baselines and Reported Results
+
+No score, ranking, or product comparison is logged here.
+
+## Comparability Notes
+
+Use as a watchlist anchor until benchmark definitions and evidence classes are
+mapped. GitHub activity is discovery evidence, not independent evaluation.
+
+## Related Papers
+
+- Platform repo:https://github.com/AML-memory/agent-memory-leaderboard
+
+## Impact Use
+
+- `evaluator-benchmark`:candidate platform to inspect in a later refresh.
+- Ready for ImpactReport:no.

--- a/benchmarks/claims/claims.yaml
+++ b/benchmarks/claims/claims.yaml
@@ -195,6 +195,106 @@ events:
       - benchmarks/memdelta.md
       - https://arxiv.org/abs/2606.29914
     extract_confidence: medium
+  - event_id: injecmem-origin-2026
+    benchmark_id: injecmem
+    source_kind: paper
+    source_id: benchmarks/injecmem.md
+    source_date: 2026-08
+    actor: InjecMEM authors
+    actor_type: paper_authors
+    usage_type: originates_benchmark
+    claim_direction: methodological_only
+    compared_systems: []
+    reported_metrics: []
+    experimental_setup: "Memory-injection attack benchmark for persistent agent memory; local note is seed quality."
+    reproduction_status: not_reproduced
+    evidence_level: primary_pdf
+    independence_class: survey_only
+    comparability_notes: "Origin protocol only; attack variants, defenses, setup, and reported results need full normalization."
+    evidence_refs:
+      - benchmarks/injecmem.md
+      - https://arxiv.org/abs/2608.23471
+    extract_confidence: medium
+  - event_id: compaction-cliff-origin-2026
+    benchmark_id: compaction-cliff
+    source_kind: paper
+    source_id: benchmarks/compaction-cliff.md
+    source_date: 2026-08
+    actor: Compaction Cliff authors
+    actor_type: paper_authors
+    usage_type: originates_benchmark
+    claim_direction: methodological_only
+    compared_systems: []
+    reported_metrics: []
+    experimental_setup: "AgentArtifactCorpus-style context compaction benchmark for rule retention, retrieval, and downstream compliance; local note is seed quality."
+    reproduction_status: not_reproduced
+    evidence_level: primary_pdf
+    independence_class: survey_only
+    comparability_notes: "Origin protocol only; Knowledge Triage setup and metrics need full normalization."
+    evidence_refs:
+      - benchmarks/compaction-cliff.md
+      - https://arxiv.org/abs/2608.22752
+    extract_confidence: medium
+  - event_id: stale-constraints-origin-2026
+    benchmark_id: stale-constraints
+    source_kind: paper
+    source_id: benchmarks/stale-constraints.md
+    source_date: 2026-08
+    actor: Stale Constraints authors
+    actor_type: paper_authors
+    usage_type: originates_benchmark
+    claim_direction: methodological_only
+    compared_systems: []
+    reported_metrics: []
+    experimental_setup: "Inherited-memory freshness benchmark for stale and superseded constraints; local note is seed quality."
+    reproduction_status: not_reproduced
+    evidence_level: primary_pdf
+    independence_class: survey_only
+    comparability_notes: "Origin protocol only; Zenodo artifact, task construction, and verification-budget details need full normalization."
+    evidence_refs:
+      - benchmarks/stale-constraints.md
+      - https://arxiv.org/abs/2608.25553
+    extract_confidence: medium
+  - event_id: memuse-origin-2026
+    benchmark_id: memuse
+    source_kind: paper
+    source_id: benchmarks/memuse.md
+    source_date: 2026-08
+    actor: MemUse authors
+    actor_type: paper_authors
+    usage_type: originates_benchmark
+    claim_direction: methodological_only
+    compared_systems: []
+    reported_metrics: []
+    experimental_setup: "Conversational-memory benchmark separating direct QA from natural integration; local note is seed quality."
+    reproduction_status: not_reproduced
+    evidence_level: primary_pdf
+    independence_class: survey_only
+    comparability_notes: "Origin protocol only; deployment details, released benchmark data, and metrics need full normalization."
+    evidence_refs:
+      - benchmarks/memuse.md
+      - https://arxiv.org/abs/2608.24189
+    extract_confidence: medium
+  - event_id: agent-memory-leaderboard-2026-cycle
+    benchmark_id: agent-memory-leaderboard
+    source_kind: code_repository
+    source_id: benchmarks/agent-memory-leaderboard.md
+    source_date: 2026-08
+    actor: Agent Memory Leaderboard maintainers
+    actor_type: project_maintainers
+    usage_type: originates_benchmark
+    claim_direction: methodological_only
+    compared_systems: []
+    reported_metrics: []
+    experimental_setup: "Public benchmark-platform candidate surfaced by GitHub discovery; local note is candidate quality."
+    reproduction_status: not_reproduced
+    evidence_level: primary_repository
+    independence_class: survey_only
+    comparability_notes: "Discovery/platform event only; do not use rankings until protocol governance and task definitions are mapped."
+    evidence_refs:
+      - benchmarks/agent-memory-leaderboard.md
+      - https://github.com/AML-memory/agent-memory-leaderboard
+    extract_confidence: low
   - event_id: fact-memory-vs-long-context-baseline-2026
     benchmark_id: fact-memory-vs-long-context
     source_kind: paper

--- a/benchmarks/compaction-cliff.md
+++ b/benchmarks/compaction-cliff.md
@@ -1,0 +1,76 @@
+---
+title: Compaction Cliff — context compaction and rule-retention benchmark
+benchmark_id: compaction-cliff
+name: The Compaction Cliff
+aliases:
+  - Compaction Cliff
+  - AgentArtifactCorpus
+status: seed
+origin_type: paper_origin
+origin_source: https://arxiv.org/abs/2608.22752
+first_public_date: 2026-08
+domain: context_compaction
+modality: text
+task_grain: long_horizon_agent_context
+capability_axes:
+  - rule_retention
+  - artifact_retrieval
+  - downstream_compliance
+  - compaction_safety
+data_nature: check
+metrics:
+  - retention_under_compaction
+  - downstream_compliance
+judge_type: check
+code_available: check
+data_available: check
+license: check
+known_limitations:
+  - seed note; AgentArtifactCorpus details, splits, metrics, and Knowledge Triage setup need full read
+canonical_sources:
+  - https://arxiv.org/abs/2608.22752
+confidence: medium
+memory_modules:
+  - evaluator-benchmark
+  - parser-chunker
+  - retriever-reranker
+last_revised: 2026-08-31
+---
+
+# The Compaction Cliff
+
+## What It Measures
+
+The Compaction Cliff studies when context compaction causes agents to lose
+rules, artifacts, or constraints that matter for later task compliance. It is a
+benchmark signal for memory systems that summarize, compress, or offload
+working context during long-horizon work.
+
+## Protocol
+
+The paper introduces AgentArtifactCorpus and evaluates rule retention,
+retrieval, and downstream compliance after compaction. It also proposes
+Knowledge Triage as a mitigation direction. Full task definitions and metric
+normalization remain to be extracted.
+
+## Baselines and Reported Results
+
+No normalized scores are logged here. Treat all reported improvements as
+paper-origin claims until claims ledger rows are expanded beyond the origin
+event.
+
+## Comparability Notes
+
+Compare with long-context and memory benchmarks on retained obligations, not
+conversation QA. This is a good check for memory kernels that turn active
+context into durable artifacts.
+
+## Related Papers
+
+- Paper:https://arxiv.org/abs/2608.22752
+
+## Impact Use
+
+- `evaluator-benchmark`:candidate benchmark for compaction-safe memory.
+- `parser-chunker`:useful for testing whether compressed context preserves obligations.
+- Ready for ImpactReport:no, upgrade after full protocol read.

--- a/benchmarks/index.md
+++ b/benchmarks/index.md
@@ -49,6 +49,11 @@ official repository, dataset card, or independent reproduction.
 | MemSyco-Bench | seed | paper-origin | memory-induced sycophancy | scope / conflict resolution / update / valid personalization | [`memsyco-bench.md`](memsyco-bench.md) | yes |
 | MemLeak | seed | paper-origin | multimodal deletion leakage | deletion compliance / provenance / residual image leakage | [`memleak.md`](memleak.md) | yes |
 | MemDelta | seed | paper-origin | memory-evaluation baseline control | component delta / model-family sensitivity / write-path cost | [`memdelta.md`](memdelta.md) | yes |
+| InjecMEM | seed | paper-origin | persistent memory-injection security | memory injection / poisoned retrieval / cross-session safety | [`injecmem.md`](injecmem.md) | backlog |
+| Compaction Cliff | seed | paper-origin | context compaction and rule retention | compaction safety / artifact retrieval / downstream compliance | [`compaction-cliff.md`](compaction-cliff.md) | backlog |
+| Stale Constraints | seed | paper-origin | inherited-memory freshness | supersession / freshness verification / budgeted rechecking | [`stale-constraints.md`](stale-constraints.md) | backlog |
+| MemUse | seed | paper-origin | natural conversational memory use | direct QA / natural integration / preference use | [`memuse.md`](memuse.md) | backlog |
+| Agent Memory Leaderboard | candidate | benchmark-platform | public benchmark submission hub | protocol registry / leaderboard governance | [`agent-memory-leaderboard.md`](agent-memory-leaderboard.md) | backlog |
 
 ## Evidence Ledgers
 

--- a/benchmarks/injecmem.md
+++ b/benchmarks/injecmem.md
@@ -1,0 +1,75 @@
+---
+title: InjecMEM — memory-injection attack benchmark
+benchmark_id: injecmem
+name: InjecMEM
+aliases:
+  - InjecMEM
+status: seed
+origin_type: paper_origin
+origin_source: https://arxiv.org/abs/2608.23471
+first_public_date: 2026-08
+domain: memory_security
+modality: text
+task_grain: agent_memory_attack
+capability_axes:
+  - memory_injection_resistance
+  - poisoned_retrieval_detection
+  - cross_session_safety
+data_nature: check
+metrics:
+  - attack_success_rate
+  - benign_task_utility
+judge_type: check
+code_available: check
+data_available: check
+license: check
+known_limitations:
+  - seed note; protocol, task counts, code/data release, and reported results need full read
+canonical_sources:
+  - https://arxiv.org/abs/2608.23471
+confidence: medium
+memory_modules:
+  - evaluator-benchmark
+  - policy-privacy
+  - audit-ui
+last_revised: 2026-08-31
+---
+
+# InjecMEM
+
+## What It Measures
+
+InjecMEM frames long-term agent memory as a persistent attack surface. The
+benchmark targets memory-injection attacks where a single interaction can plant
+state that later steers retrieval or downstream tool use without direct access
+to the memory store.
+
+## Protocol
+
+The arXiv abstract positions the task around indirect persistent compromise:
+attack text is introduced during ordinary interaction, stored by the memory
+layer, and later retrieved in contexts where it can affect behavior. Full
+datasets, task counts, attack variants, and defenses still need a full source
+read.
+
+## Baselines and Reported Results
+
+No normalized scores are logged here. Any author-reported attack rates remain
+paper-origin claims until the protocol and setup are mapped into
+`claims/claims.yaml`.
+
+## Comparability Notes
+
+Compare with memory-poisoning and prompt-injection benchmarks on threat model,
+not raw success rate. InjecMEM is most useful for testing whether memory write
+and retrieval gates preserve cross-session safety.
+
+## Related Papers
+
+- Paper:https://arxiv.org/abs/2608.23471
+
+## Impact Use
+
+- `evaluator-benchmark`:candidate benchmark for persistent memory injection.
+- `policy-privacy`:useful for write admission, provenance, and unsafe recall gates.
+- Ready for ImpactReport:no, upgrade after full protocol read.

--- a/benchmarks/memuse.md
+++ b/benchmarks/memuse.md
@@ -1,0 +1,72 @@
+---
+title: MemUse — natural integration benchmark for conversational memory
+benchmark_id: memuse
+name: MemUse
+aliases:
+  - MemUse
+status: seed
+origin_type: paper_origin
+origin_source: https://arxiv.org/abs/2608.24189
+first_public_date: 2026-08
+domain: conversational_memory
+modality: text
+task_grain: downstream_response_with_memory
+capability_axes:
+  - natural_memory_integration
+  - direct_memory_qa
+  - user_preference_use
+data_nature: real_world_deployment_plus_benchmark
+metrics:
+  - response_quality_with_memory
+  - direct_qa_accuracy
+judge_type: check
+code_available: yes
+data_available: check
+license: check
+known_limitations:
+  - seed note; four-month deployment design, benchmark release, and metrics need full read
+canonical_sources:
+  - https://arxiv.org/abs/2608.24189
+confidence: medium
+memory_modules:
+  - evaluator-benchmark
+  - retriever-reranker
+last_revised: 2026-08-31
+---
+
+# MemUse
+
+## What It Measures
+
+MemUse separates direct memory question answering from natural integration of
+remembered user information into assistant responses. That makes it useful for
+product-facing conversational memory, where a correct retrieved fact can still
+be used awkwardly or with the wrong salience.
+
+## Protocol
+
+The paper reports a four-month deployment and releases a benchmark for natural
+memory use. The abstract says the task is not only whether the system can answer
+questions about memory, but whether it can integrate memory into live
+conversation. Full annotations, metrics, and judge details remain to be mapped.
+
+## Baselines and Reported Results
+
+No normalized scores are logged here. Reported benchmark results stay as
+paper-origin evidence until the setup is extracted.
+
+## Comparability Notes
+
+Compare with LongMemEval and LoCoMo on task family, but not raw accuracy:
+MemUse emphasizes conversational integration rather than direct retrieval QA
+alone.
+
+## Related Papers
+
+- Paper:https://arxiv.org/abs/2608.24189
+
+## Impact Use
+
+- `evaluator-benchmark`:candidate benchmark for natural memory use.
+- `retriever-reranker`:useful for evaluating whether retrieved memories improve output quality.
+- Ready for ImpactReport:no, upgrade after full protocol read.

--- a/benchmarks/stale-constraints.md
+++ b/benchmarks/stale-constraints.md
@@ -1,0 +1,73 @@
+---
+title: Stale Constraints — inherited-memory freshness benchmark
+benchmark_id: stale-constraints
+name: When Stale Constraints Go Unchecked
+aliases:
+  - Stale Constraints
+status: seed
+origin_type: paper_origin
+origin_source: https://arxiv.org/abs/2608.25553
+first_public_date: 2026-08
+domain: memory_freshness
+modality: text
+task_grain: inherited_agent_memory
+capability_axes:
+  - freshness_verification
+  - supersession_detection
+  - budgeted_rechecking
+data_nature: check
+metrics:
+  - stale_constraint_failure_rate
+  - verification_cost
+judge_type: check
+code_available: check
+data_available: check
+license: check
+known_limitations:
+  - seed note; dataset, Zenodo resource details, and verification-budget setup need full read
+canonical_sources:
+  - https://arxiv.org/abs/2608.25553
+confidence: medium
+memory_modules:
+  - evaluator-benchmark
+  - provenance-ledger
+  - memorydiff-generator
+last_revised: 2026-08-31
+---
+
+# Stale Constraints
+
+## What It Measures
+
+This benchmark targets failures caused by inherited memories whose constraints
+have been superseded. It is directly relevant to agents that resume old project
+state, compacted handoffs, or profile memories without verifying whether those
+constraints still hold.
+
+## Protocol
+
+The source paper frames stale constraint use as a freshness and verification
+problem, including budgeted checking. The arXiv record also points to a Zenodo
+artifact. Full split, task, and metric details need a deeper read before any
+score comparison.
+
+## Baselines and Reported Results
+
+No normalized results are logged here. Origin-paper results remain
+paper-origin claims.
+
+## Comparability Notes
+
+Compare against A-TMA-style state validity and memory governance benchmarks on
+supersession behavior, not raw recall. The useful product question is whether
+memory retrieval can force revalidation when old constraints are risky.
+
+## Related Papers
+
+- Paper:https://arxiv.org/abs/2608.25553
+
+## Impact Use
+
+- `evaluator-benchmark`:candidate benchmark for stale memory and supersession.
+- `provenance-ledger`:useful for linking remembered constraints to source and age.
+- Ready for ImpactReport:no, upgrade after full protocol read.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ decide what to read before opening the paper index or the product notes.
 4. [`weekly-memory-refresh-runbook.md`](weekly-memory-refresh-runbook.md) —
    Codex weekly refresh runbook for papers, products, GitHub discovery, and
    benchmarks.
-5. [`memory-radar-2026-07.md`](memory-radar-2026-07.md) — latest current-source
+5. [`memory-radar-2026-08-31.md`](memory-radar-2026-08-31.md) — latest current-source
    refresh across papers, products, GitHub projects, and reviewer decisions.
 6. [`cost-savings-landscape.md`](cost-savings-landscape.md) — focused map of
    agent-memory papers, algorithms, code paths, and products that reduce token,
@@ -49,6 +49,7 @@ decide what to read before opening the paper index or the product notes.
 |---|---|
 | [`research-radar.md`](research-radar.md) | Generic Radar loop: paper/product/benchmark -> ResearchItem or BenchmarkItem -> ImpactReport -> sandbox -> ADR. |
 | [`weekly-memory-refresh-runbook.md`](weekly-memory-refresh-runbook.md) | Weekly Codex automation contract for source search, subagent review, verification, and PR output. |
+| [`memory-radar-2026-08-31.md`](memory-radar-2026-08-31.md) | 2026-08-31 weekly refresh with must-add, update-existing, watchlist, adjacent, and reject decisions. |
 | [`memory-radar-2026-07.md`](memory-radar-2026-07.md) | 2026-07 weekly refresh with must-add, update-existing, watchlist, adjacent, and reject decisions. |
 | [`information-sources.md`](information-sources.md) | Source catalog for papers, products, communities, and zh-CN information channels. |
 | [`related-work.md`](related-work.md) | Positioning against sibling agent-memory awesome-lists. |

--- a/docs/benchmarks-landscape.md
+++ b/docs/benchmarks-landscape.md
@@ -35,6 +35,11 @@ language: zh-CN
 | memory-induced sycophancy | [`MemSyco-Bench`](../benchmarks/memsyco-bench.md) | whether retrieved memory should influence factual reasoning, conflicts, updates, and personalization | seed,origin paper logged; results/resources not normalized |
 | multimodal deletion leakage | [`MemLeak`](../benchmarks/memleak.md) | residual recovery after deletion via correlated text and retained images | seed,origin paper logged; image/data/setup not normalized |
 | baseline-control methodology | [`MemDelta`](../benchmarks/memdelta.md) | component-controlled memory-vs-RAG/full-context evaluation and write-path cost discipline | seed,methodology event logged; not an end-agent leaderboard |
+| persistent memory injection | [`InjecMEM`](../benchmarks/injecmem.md) | memory injection / poisoned retrieval / cross-session safety | seed,origin paper logged; protocol/results not normalized |
+| context compaction | [`Compaction Cliff`](../benchmarks/compaction-cliff.md) | rule retention / artifact retrieval / downstream compliance after compaction | seed,origin paper logged; protocol/results not normalized |
+| inherited-memory freshness | [`Stale Constraints`](../benchmarks/stale-constraints.md) | supersession detection / freshness verification / budgeted rechecking | seed,origin paper logged; protocol/results not normalized |
+| natural conversational memory use | [`MemUse`](../benchmarks/memuse.md) | direct QA vs natural memory integration in responses | seed,origin paper logged; deployment/protocol not normalized |
+| benchmark platform | [`Agent Memory Leaderboard`](../benchmarks/agent-memory-leaderboard.md) | public benchmark registry and submission hub | candidate,repository discovered; governance not normalized |
 
 ## B. 初始交叉统计
 
@@ -61,6 +66,11 @@ language: zh-CN
 | MemSyco-Bench | 1 | origin paper logged; memory-induced sycophancy protocol not yet normalized |
 | MemLeak | 1 | origin paper logged; multimodal deletion-leakage protocol not yet normalized |
 | MemDelta | 1 | methodology event logged; use for claims discipline, not direct benchmark ranking |
+| InjecMEM | 1 | origin paper logged; persistent memory-injection threat model not yet normalized |
+| Compaction Cliff | 1 | origin paper logged; compaction/rule-retention protocol not yet normalized |
+| Stale Constraints | 1 | origin paper logged; inherited-memory freshness protocol not yet normalized |
+| MemUse | 1 | origin paper logged; natural memory integration benchmark not yet normalized |
+| Agent Memory Leaderboard | 1 | platform/repository discovery logged; governance and protocol not yet normalized |
 
 ### B2. Evaluation uses / baseline comparisons
 
@@ -114,6 +124,22 @@ language: zh-CN
 | LongMemEval | ConvoMem critique | sample-size and filler-source critique, not a rerun |
 | LoCoMo | ConvoMem critique | small-conversation-count critique, not a rerun |
 | ConvoMem | own baseline comparison | strong protocol for cost/accuracy crossover, but synthetic data and Mem0-only RAG baseline caveat |
+| Compaction Cliff | origin benchmark | stresses whether context compression preserves rules and artifacts, not a third-party rerun |
+| Stale Constraints | origin benchmark | stresses verification of inherited memories after constraints change, not a third-party rerun |
+| MemUse | origin benchmark | stresses natural conversational memory integration beyond direct QA, not a third-party rerun |
+
+## B8. 2026-08 Current-Source Intake
+
+The 2026-08-31 refresh adds five benchmark-layer signals. They are all seed or
+candidate records; no leaderboard scores or paper-reported numbers are promoted.
+
+| Decision | Candidate | Handling | Caveat |
+|---|---|---|---|
+| add | [`InjecMEM`](../benchmarks/injecmem.md) | Memory-injection security benchmark. | Full attack variants, defenses, and released resources still need normalization. |
+| add | [`Compaction Cliff`](../benchmarks/compaction-cliff.md) | Context compaction / rule-retention benchmark. | AgentArtifactCorpus and Knowledge Triage setup need full read. |
+| add | [`Stale Constraints`](../benchmarks/stale-constraints.md) | Inherited-memory freshness / supersession benchmark. | Zenodo artifact and verification-budget details not yet mapped. |
+| add | [`MemUse`](../benchmarks/memuse.md) | Conversational natural-integration benchmark. | Deployment design, released data, and judge setup need extraction. |
+| watchlist | [`Agent Memory Leaderboard`](../benchmarks/agent-memory-leaderboard.md) | Public benchmark-platform candidate. | GitHub activity is discovery evidence; rankings are not used. |
 
 ## C. What Counts As Evidence
 
@@ -160,7 +186,10 @@ enters the catalog.
    becomes a kernel evaluation priority.
 9. Upgrade GateMem if shared-memory governance or enterprise scoped recall becomes
    a kernel priority.
-10. Add independent reproduction rows only when the source gives enough setup
+10. Upgrade InjecMEM, Compaction Cliff, Stale Constraints, and MemUse if
+   memory-security, compaction, freshness, or conversational-integration gates
+   become evaluation priorities.
+11. Add independent reproduction rows only when the source gives enough setup
    detail to distinguish reruns from marketing summaries.
 
 ## F. Maintenance Contract

--- a/docs/cost-savings-landscape.md
+++ b/docs/cost-savings-landscape.md
@@ -64,6 +64,16 @@ language: zh-CN
 | [`LightMem agent memory`](../papers/lightmem-agent-memory.md) | seed paper note | 用 SLM 负责 retrieval、writing、offline consolidation,强调 bounded online cost 和低延迟路径。 | seed 质量;需补 PDF/code/license 细读。 |
 | [`Agent Memory systems characterization`](../papers/agent-memory-systems-characterization.md) | seed paper note | 把 memory construction、retrieval、generation 作为系统成本画像对象。 | seed 质量;尚未复核 profiling harness 细节。 |
 
+### 2026-08 current-source additions
+
+| Item | Current repo status | Cost-saving relevance | Evidence boundary |
+|---|---|---|---|
+| [`ContextPilot`](../papers/contextpilot-proactive-context-management.md) | seed paper note | Proactive context management combines planning, long-term memory, and soft offloading for long-horizon tasks. | seed quality;reported gains and code path need full read. |
+| [`EARM`](../papers/earm-experience-amortized-reranking.md) | seed paper note | Reuses query-memory relevance scores through matrix completion to reduce repeated LLM reranking. | seed quality;cost/quality trade-off and cache invalidation need extraction. |
+| [`KOPE`](../papers/kope-experience-graph-memory.md) | seed paper note | Experience graph memory for kernel optimization claims lower search effort and better reuse of past optimization attempts. | seed quality;domain-specific and not direct conversational memory evidence. |
+| [`CaSKG`](../papers/caskg-skill-graph-retrieval.md) | seed paper note | Skill-graph retrieval can constrain multi-agent communication/search overhead. | seed quality;skill graph construction cost and task coverage need full read. |
+| [`GraphMemix`](../papers/graphmemix-evidence-forests.md) | seed paper note | Evidence forests suggest a bounded graph-memory alternative for retrieval and reasoning over multimodal evidence. | seed quality;claims remain paper-origin until normalized. |
+
 ### Candidate papers and code paths to upgrade
 
 | Item | Local anchor | External source checked 2026-06-30 | Why it belongs here | Upgrade path |

--- a/docs/memory-radar-2026-08-31.md
+++ b/docs/memory-radar-2026-08-31.md
@@ -1,0 +1,98 @@
+---
+title: 2026-08 Memory Radar refresh
+date: 2026-08-31
+status: current-source-refresh
+language: zh-CN
+---
+
+# 2026-08 Memory Radar refresh
+
+本页记录 2026-08-31 的 weekly radar refresh。主 agent 从最新 `origin/main`
+创建 `codex/weekly-memory-radar-2026-08-31`,并用 paper/product/GitHub discovery
+子 agent 做候选检索。所有 GitHub/list/catalog 信号只作为 discovery;最终收录只依赖
+primary paper/product/repository sources。
+
+## 执行模型
+
+| Lane | 角色 | 输出 |
+|---|---|---|
+| papers/conferences | `researcher` | arXiv 2026-08 候选、paper-vs-benchmark 分流、duplicate 风险 |
+| products/platforms | `researcher` | 官方 release notes、changelog、GitHub release |
+| GitHub/benchmarks | `researcher` | repo/list/leaderboard discovery signals only |
+| repo-map | `explore` | counts、landing files、现有条目和 open PR overlap 风险 |
+| source/relevance review | main agent + reviewer | must-add / update-existing / watchlist / adjacent / reject |
+
+## Must-add / update-existing
+
+### Papers and benchmarks
+
+| Action | Item | Why it matters | Local anchor |
+|---|---|---|---|
+| must-add | ContextPilot | 把 proactive context management 做成 planning + long-term memory + soft offloading 的长任务路线 | [`../papers/contextpilot-proactive-context-management.md`](../papers/contextpilot-proactive-context-management.md) |
+| must-add | EARM | 用 historical query-memory relevance score amortize LLM reranking cost,补 retriever memory 方向 | [`../papers/earm-experience-amortized-reranking.md`](../papers/earm-experience-amortized-reranking.md) |
+| must-add | Recuris | recursive working / experiential / skill memory loop,补 self-improving agent memory 方向 | [`../papers/recuris-experiential-working-memory.md`](../papers/recuris-experiential-working-memory.md) |
+| must-add | EviGraph | evidence graph 作为 persistent working memory / process reward,补 proof-like graph construction 方向 | [`../papers/evigraph-evidence-construction.md`](../papers/evigraph-evidence-construction.md) |
+| must-add | KOPE | kernel optimization 的 experience graph memory,补高成本搜索任务中的 reusable experience 证据 | [`../papers/kope-experience-graph-memory.md`](../papers/kope-experience-graph-memory.md) |
+| must-add | CaSKG | counterfactual-causal skill graph retrieval,补 procedural/skill memory 检索方向 | [`../papers/caskg-skill-graph-retrieval.md`](../papers/caskg-skill-graph-retrieval.md) |
+| must-add | UAQ | uncertainty-aware querying for memory,补 memory access calibration 和 abstention 方向 | [`../papers/uaq-agent-memory.md`](../papers/uaq-agent-memory.md) |
+| must-add | GraphMemix | evidence forests for graph-based memory reasoning,补多模态/图记忆候选 | [`../papers/graphmemix-evidence-forests.md`](../papers/graphmemix-evidence-forests.md) |
+| must-add | Constraint Weakening | summaries/plans/tickets/memories/handoffs 会削弱 constraints,补 operational memory decay 风险 | [`../papers/constraint-weakening-agent-workflows.md`](../papers/constraint-weakening-agent-workflows.md) |
+| must-add | InjecMEM | persistent memory-injection attack surface,补 memory write/retrieve 安全 benchmark | [`../benchmarks/injecmem.md`](../benchmarks/injecmem.md) |
+| must-add | Compaction Cliff | context compaction 下 rule/artifact retention 和 downstream compliance,补长任务压缩 benchmark | [`../benchmarks/compaction-cliff.md`](../benchmarks/compaction-cliff.md) |
+| must-add | Stale Constraints | inherited memory 中 stale/superseded constraint 未验证的失败模式,补 freshness benchmark | [`../benchmarks/stale-constraints.md`](../benchmarks/stale-constraints.md) |
+| must-add | MemUse | direct QA 之外的 natural memory integration,补 conversational memory 产品评测方向 | [`../benchmarks/memuse.md`](../benchmarks/memuse.md) |
+| watchlist | Agent Memory Leaderboard | public benchmark platform signal,但 leaderboard governance/protocol 尚未读完 | [`../benchmarks/agent-memory-leaderboard.md`](../benchmarks/agent-memory-leaderboard.md) |
+
+### Products
+
+| Action | Product | Why it matters | Local anchor |
+|---|---|---|---|
+| update-existing | Claude memory / Claude Dreams | 2026-08-25 release notes 将 memory 扩展到 Claude Cowork/app 并公开 Topics/sensitive-topic/default-plan controls | [`../products/claude-dreams.md`](../products/claude-dreams.md) |
+| update-existing | Mem0 | changelog highlights 增加 DeepSeek Harness plugin,继续验证 memory-as-agent-tool packaging | [`../products/mem0.md`](../products/mem0.md) |
+| update-existing | TencentDB Agent Memory | v2.0.1 release 增加 client bindings、persistent session binding、Memory Hub search/permission signals | [`../products/tencentdb-agent-memory.md`](../products/tencentdb-agent-memory.md) |
+| update-existing | Letta Code | release notes 增加 configurable memory layout、root-layout memory prompts、memory limits/shared-memory frontmatter signals | [`../products/letta.md`](../products/letta.md) |
+
+## Watchlist / adjacent / reject
+
+| Decision | Item | Reason |
+|---|---|---|
+| watchlist | Agent Memory Leaderboard | GitHub activity and README are discovery evidence;protocol governance and task definitions must be normalized before using scores. |
+| watchlist | MCP Memory Service / small OSS memory repos | repo activity is not enough for Tier A product evidence without canonical docs, release health, license, and actual lifecycle surface. |
+| watchlist | AWS Natera / platform case studies | useful managed-memory practice signal, but not new product capability or independent benchmark evidence this round. |
+| adjacent | GraphMemix / CaSKG / KOPE | relevant to memory design, but domain-specific enough to keep as seed notes until full read. |
+| reject as duplicate | AuthMem-Bench / FinPerMA / MemSecBench / Setoka / Zero-Mem / Databricks and related August candidates | already covered by open weekly PR branches;do not duplicate into the 2026-08-31 branch until those PRs are merged or closed. |
+| reject as source | Google Memory Bank pricing/update snippet | page text was not verified strongly enough during this run;leave existing product note unchanged. |
+| reject as performance evidence | GitHub stars, README benchmark numbers, vendor blogs, awesome-list placement | only discovery or vendor/product behavior;not independent quality evidence. |
+
+## Evidence gaps / next verification
+
+| Item | Gap | Why not blocking |
+|---|---|---|
+| 9 paper seed notes | full PDF reads, code/data/license, exact experiment setup, and reported result normalization remain incomplete | seed notes only establish source relevance and design axis;no score claims were promoted |
+| 4 benchmark seed notes + 1 candidate platform | dataset splits, judge setup, leaderboard governance, and claims rows beyond origin events remain incomplete | claims ledger records only origin/platform events |
+| Product updates | official release/changelog pages support behavior only | no independent benchmark or product superiority claim was added |
+| Open PR overlap | PRs #18-#20 already own many August candidates | this branch avoids importing those names to prevent duplicate catalog entries |
+
+## Trend synthesis
+
+- **Memory safety is shifting from privacy-only to persistence-aware threat
+  modeling**:InjecMEM、Stale Constraints、Constraint Weakening 都把 old state /
+  injected state / inherited constraints 当成 runtime hazard。
+- **Context management is becoming a memory benchmark problem**:Compaction Cliff
+  and ContextPilot both test whether agents can compress or offload context
+  without losing obligations.
+- **Retrieval systems are learning from their own retrieval history**:EARM makes
+  the retriever remember prior relevance judgments instead of reranking every
+  query from scratch.
+- **Memory products are exposing more explicit governance controls**:Claude
+  Topics/sensitive-topic controls、TencentDB Memory Hub、Letta Code memory layout
+  and Mem0 harness tools are all public product-surface signals.
+
+## Review notes
+
+- 收录项均要求 primary source:论文用 arXiv,产品用官方 release notes / changelog /
+  GitHub release,platform candidate 用 canonical GitHub repo。
+- Author-reported benchmark results are paper-origin claims;vendor numbers are
+  vendor claims;GitHub activity is discovery only。
+- 本轮 benchmark catalog 从 21 行增至 26 行;paper seed notes 从 15 增至 24;product
+  note count 不变。

--- a/docs/product-discovery-log.md
+++ b/docs/product-discovery-log.md
@@ -156,3 +156,13 @@ language: zh-CN
 | update-existing | Mem0 | changelog highlights 2026-06-27 | 更新 `products/mem0.md`;expiration controls 作为 lifecycle signal |
 | update-existing | Redis Agent Memory Server | Redis blog 2026-07-01 | 更新 `products/redis-agent-memory-server.md`;作为产品定位/实现建议,非 benchmark |
 | watchlist | Cloudflare Think harness | Cloudflare docs | 暂不拆产品;与 Cloudflare Agent Memory 有重叠,先观察是否形成独立 memory product |
+
+## 11. 2026-08-31 weekly refresh delta
+
+| Decision | Item | Source | Action |
+|---|---|---|---|
+| update-existing | Claude memory / Claude Dreams | Anthropic release notes 2026-08-25 | 更新 `products/claude-dreams.md`;Claude Cowork/app memory 是产品行为证据,不等于 Dreams 技术披露 |
+| update-existing | Mem0 | Mem0 changelog highlights | 更新 `products/mem0.md`;DeepSeek Harness plugin 说明 Mem0 继续作为 agent-tool memory 层扩散 |
+| update-existing | TencentDB Agent Memory | GitHub release v2.0.1 | 更新 `products/tencentdb-agent-memory.md`;session binding / Memory Hub 是 release 行为证据 |
+| update-existing | Letta Code | Letta Code GitHub releases | 更新 `products/letta.md`;memory layout / prompt controls 作为 coding-agent memory UX 信号 |
+| watchlist | AWS / Google / OpenAI / Cloudflare / Microsoft / Redis | official docs and release-note spot checks | 本轮未提升新条目;已有打开 PR 覆盖部分重叠项,不重复导入 |

--- a/docs/products-landscape.md
+++ b/docs/products-landscape.md
@@ -1,6 +1,6 @@
 ---
 title: Products landscape — agent memory by domain × audience
-date: 2026-06-24
+date: 2026-08-31
 status: working-spec
 language: zh-CN
 ---
@@ -25,6 +25,13 @@ language: zh-CN
 
 下表条目的判定标准是:**产品本身把"记忆"作为一等公民设计**;只是顺带做向量
 检索或 RAG 的不算。
+
+## 2026-08 product-signal note
+
+2026-08-31 refresh 没有新增核心产品数,但更新了四个既有产品笔记:Claude
+Cowork/app memory 控制面、Mem0 DeepSeek Harness plugin、TencentDB Agent Memory
+v2.0.1 session / Memory Hub release、Letta Code memory layout releases。它们都按
+官方产品行为记录,不提升为独立 benchmark evidence。
 
 ## 分类标准
 

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -1,6 +1,6 @@
 ---
 title: Signals — agent memory news, releases, comparisons (reverse chrono)
-date: 2026-06-24
+date: 2026-08-31
 status: living-log
 language: zh-CN
 ---
@@ -20,6 +20,10 @@ Radar 动作 enum:`stub` `seed-note` `deep-note` `impact-report` `archive-only`
 
 | 日期 | 来源 | 类型 | 一句话 | Radar 动作 |
 |---|---|---|---|---|
+| 2026-08-31 | [ContextPilot](https://arxiv.org/abs/2608.28476) / [EARM](https://arxiv.org/abs/2608.22767) / [Recuris](https://arxiv.org/abs/2608.24876) / [EviGraph](https://arxiv.org/abs/2608.24667) / [KOPE](https://arxiv.org/abs/2608.25570) / [CaSKG](https://arxiv.org/abs/2608.25500) / [UAQ](https://arxiv.org/abs/2608.27924) / [GraphMemix](https://arxiv.org/abs/2608.26983) / [Constraint Weakening](https://arxiv.org/abs/2608.24569) | paper | 周更 radar 追加 proactive context management、experience-amortized retrieval、experiential/skill memory、evidence graph、budgeted graph/multimodal memory 和 operational constraint decay 九条 seed note | `seed-note` ✅(见 `papers/`) |
+| 2026-08-31 | [InjecMEM](https://arxiv.org/abs/2608.23471) / [Compaction Cliff](https://arxiv.org/abs/2608.22752) / [Stale Constraints](https://arxiv.org/abs/2608.25553) / [MemUse](https://arxiv.org/abs/2608.24189) | paper | benchmark catalog 新增 memory injection、context compaction、stale constraint freshness 和 natural memory integration 四条 paper-origin benchmark seed | `seed-note` ✅(见 `benchmarks/`) |
+| 2026-08-31 | [Agent Memory Leaderboard](https://github.com/AML-memory/agent-memory-leaderboard) | release | GitHub benchmark-platform candidate surfaced,但 governance/protocol 未归一化前不使用 leaderboard scores | `stub` ✅(见 `benchmarks/`) |
+| 2026-08-31 | [Anthropic release notes](https://support.claude.com/en/articles/12138966-release-notes) / [Mem0 changelog](https://docs.mem0.ai/changelog/highlights) / [TencentDB Agent Memory v2.0.1](https://github.com/TencentCloud/TencentDB-Agent-Memory/releases/tag/v2.0.1) / [Letta Code releases](https://github.com/letta-ai/letta-code/releases) | product | 官方产品源补充 Claude Cowork memory、Mem0 DeepSeek Harness plugin、TencentDB v2.0.1 session/memory hub 和 Letta Code memory-layout controls | `deep-note` ✅(更新 `products/`) |
 | 2026-07-06 | [A-TMA](https://arxiv.org/abs/2607.01935) / [Mandol](https://arxiv.org/abs/2606.29778) / [Forensic Trajectory Signatures](https://arxiv.org/abs/2606.30566) | paper | 周更 radar 追加 state-aware ghost memory、agglomerative memory-native storage、memory-poisoning trajectory forensics 三条 seed note | `seed-note` ✅(见 `papers/`) |
 | 2026-07-06 | [MemSyco-Bench](https://arxiv.org/abs/2607.01071) / [MemLeak](https://arxiv.org/abs/2606.29788) / [MemDelta](https://arxiv.org/abs/2606.29914) | paper | benchmark catalog 新增 memory-induced sycophancy、多模态删除泄漏、controlled baseline methodology | `seed-note` ✅(见 `benchmarks/`) |
 | 2026-07-06 | [AWS AgentCore release notes](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/release-notes.html) / [Google release notes](https://docs.cloud.google.com/gemini-enterprise-agent-platform/release-notes) / [OpenAI Business release notes](https://help.openai.com/en/articles/11391654-chatgpt-business-release-notes) / [Mem0 changelog](https://docs.mem0.ai/changelog/highlights) / [Redis guide](https://redis.io/blog/build-smarter-ai-agents-manage-short-term-and-long-term-memory-with-redis/) | product | 官方产品源补充 AgentCore streaming、Memory Bank model default、ChatGPT org memory controls、Mem0 expiration 和 Redis two-tier guidance | `deep-note` ✅(更新 `products/`) |

--- a/papers/caskg-skill-graph-retrieval.md
+++ b/papers/caskg-skill-graph-retrieval.md
@@ -1,0 +1,58 @@
+---
+title: CaSKG — Counterfactual-Causal Skill Graphs for Scalable Agent Skill Retrieval
+arxiv_id: 2608.25500
+source: arXiv:2608.25500
+date: 2026-08
+domain: memory
+core_claim: |
+  Procedural memory libraries need retrieval that preserves prerequisites,
+  state changes, and verification steps. CaSKG builds a counterfactual-causal
+  skill graph and retrieves task-conditioned neighborhoods without prompting the
+  full library.
+evidence_level: medium
+code_available: yes
+license: check
+memory_modules:
+  - retriever-reranker
+  - semantic-dedup
+  - evaluator-benchmark
+status: seed
+last_revised: 2026-08-31
+urls:
+  - https://arxiv.org/abs/2608.25500
+  - https://github.com/ZhiyuanLi218/Caskg
+---
+
+# CaSKG(arXiv 2608.25500)
+
+## Problem statement
+
+可复用 skill library 是 procedural memory,但检索很容易失真:全库 prompt 成本高,
+向量检索把技能当作孤立文本,普通 graph retrieval 又依赖不可靠边。
+
+## Core claim
+
+CaSKG 用 semantic、lexical、input/output、structural evidence 和可选 LLM judge 建高召回
+候选图,再通过方向条件的文本反事实 probe 校准 skill pair 关系。最终产出的
+state-filtered weighted graph 用于任务条件扩展,不改变下游 agent policy。
+
+## Decision relevance
+
+- `retriever-reranker`:procedural memory retrieval 要保留顺序、前置条件、状态变化和验证例程。
+- `semantic-dedup`:skill 相似不是可替代;反事实关系可帮助区分依赖、替换和补充。
+- `evaluator-benchmark`:需要任务成功率、环境步数和 graph ablation,不能只评估检索相似度。
+
+## Caveats
+
+本地笔记是 seed 质量。尚未 full read PDF、复核 GitHub license、数据构造和 ALFWorld /
+ScienceWorld 设置。论文结果只能作为 paper-origin claim。
+
+## Sources
+
+- arXiv:https://arxiv.org/abs/2608.25500
+- Code:https://github.com/ZhiyuanLi218/Caskg
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/papers/constraint-weakening-agent-workflows.md
+++ b/papers/constraint-weakening-agent-workflows.md
@@ -1,0 +1,58 @@
+---
+title: Constraint Weakening — When Must Becomes Maybe in LLM Agent Workflows
+arxiv_id: 2608.24569
+source: arXiv:2608.24569
+date: 2026-08
+domain: security
+core_claim: |
+  Summaries, plans, tickets, memories, and handoff notes can preserve topical
+  content while weakening binding constraints. Operational state preservation
+  requires prerequisite, authority, fallback, and execution consequence fields,
+  not just semantic mention.
+evidence_level: medium
+code_available: check
+license: check
+memory_modules:
+  - memorydiff-generator
+  - policy-privacy
+  - evaluator-benchmark
+status: seed
+last_revised: 2026-08-31
+urls:
+  - https://arxiv.org/abs/2608.24569
+---
+
+# Constraint Weakening(arXiv 2608.24569)
+
+## Problem statement
+
+多角色、多阶段 agent workflow 会把上游状态改写成 summary、plan、ticket、memory 或
+handoff note。对 action-constraining state 来说,只保留主题内容不够;约束可能从"必须满足"
+弱化为"可以参考",从而导致下游越权或过早执行。
+
+## Core claim
+
+论文以 safety blockers 为 controlled instance,把每个 blocker 拆成 prerequisite、
+authority、fallback 和 execution consequence。作者报告 direct handoff 能保留 blocker,
+但 compression、plan assimilation、convergence、ownership deferral 和 precedent
+substitution 会反复弱化约束;恢复四个字段可显著降低 forbidden action。
+
+## Decision relevance
+
+- `memorydiff-generator`:memory/handoff diff 必须区分事实保留和约束强度保留。
+- `policy-privacy`:权限、前置条件和 fallback 要以结构化字段进入 memory,不能只留自然语言提示。
+- `evaluator-benchmark`:需要测 operational preservation,而不只是 semantic recall。
+
+## Caveats
+
+本地笔记是 seed 质量。尚未 full read PDF、复核任务生成和执行器设置。该论文是 controlled
+synthetic evidence,适合指导评测维度,不能直接估计真实产品事故率。
+
+## Sources
+
+- arXiv:https://arxiv.org/abs/2608.24569
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/papers/contextpilot-proactive-context-management.md
+++ b/papers/contextpilot-proactive-context-management.md
@@ -1,0 +1,62 @@
+---
+title: ContextPilot — Teaching Agents for Proactive Context Management via Fine-grained RL
+arxiv_id: 2608.28476
+source: arXiv:2608.28476
+date: 2026-08
+domain: memory
+core_claim: |
+  Long-horizon agents need learned context-management actions beyond search,
+  deletion, and summarization. ContextPilot trains proactive context editing with
+  planning, long-term memory, and soft context offloading tools, using
+  fine-grained credit assignment for context actions.
+evidence_level: medium
+code_available: yes
+license: check
+memory_modules:
+  - ingest-adapter
+  - dream-consolidator
+  - retriever-reranker
+  - evaluator-benchmark
+status: seed
+last_revised: 2026-08-31
+urls:
+  - https://arxiv.org/abs/2608.28476
+  - https://github.com/Tencent/ContextPilot
+---
+
+# ContextPilot(arXiv 2608.28476)
+
+## Problem statement
+
+长任务 agent 需要不断检索、整合和维护多轮信息。只保留完整历史会让 working context
+持续膨胀,而只用 search / delete / summarization 的 context editor 又缺少全局规划、
+长期记忆和自适应压缩动作。
+
+## Core claim
+
+ContextPilot 把 context management 显式建模为 agent 行为:工具集加入 planning、
+long-term memory 和 soft context offloading,再用细粒度 RL 估计上下文编辑动作的
+action-level advantage。论文报告在 long-context QA 和 deep search 任务上以更紧凑的
+working context 获得更好表现。
+
+## Decision relevance
+
+- `ingest-adapter`:context edit / offload 应记录为可审计事件,而不是隐式 prompt 操作。
+- `dream-consolidator`:长期记忆和压缩动作可以由 learned policy 调度,但必须保存失败轨迹。
+- `retriever-reranker`:context budget 不只是检索预算,还包含 plan、memory 和 compression action。
+- `evaluator-benchmark`:需要把 compactness 与 task quality 同时记录。
+
+## Caveats
+
+本地笔记是 seed 质量。EMNLP 接收和代码链接来自 arXiv 页面,但尚未 full read PDF、
+复核 GitHub license、训练细节或 benchmark split。性能结论只能作为 paper-origin claim。
+
+## Sources
+
+- arXiv:https://arxiv.org/abs/2608.28476
+- Code:https://github.com/Tencent/ContextPilot
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/papers/earm-experience-amortized-reranking.md
+++ b/papers/earm-experience-amortized-reranking.md
@@ -1,0 +1,56 @@
+---
+title: EARM — Experience-Amortized Reranking for Long-Term Agent Memory
+arxiv_id: 2608.22767
+source: arXiv:2608.22767
+date: 2026-08
+domain: retrieval
+core_claim: |
+  Long-lived agents should remember retrieval experience, not only past content.
+  EARM stores sparse query-memory relevance scores and uses matrix completion to
+  reduce repeated LLM reranking cost as experience accumulates.
+evidence_level: medium
+code_available: check
+license: check
+memory_modules:
+  - retriever-reranker
+  - evaluator-benchmark
+status: seed
+last_revised: 2026-08-31
+urls:
+  - https://arxiv.org/abs/2608.22767
+---
+
+# EARM(arXiv 2608.22767)
+
+## Problem statement
+
+长期 agent 会积累越来越多 memory,但 retriever 通常不会积累"哪些 memory 对哪些 query
+真的有用"的经验。语义检索便宜但不总能反映证据相关性,LLM reranker 更准但每次都要
+重复给大量候选打分。
+
+## Core claim
+
+EARM 把历史 LLM relevance score 当作可复用的 retrieval experience:在线保存稀疏
+query-memory 相关性矩阵,用 causal matrix completion 学共享结构,再把少量新打分和
+估计分结合用于 reranking。论文报告在 long-term conversational memory 上能降低直接
+LLM reranking 预算并改善答案准确率。
+
+## Decision relevance
+
+- `retriever-reranker`:检索器本身也需要长期状态,尤其是 query-memory utility history。
+- `evaluator-benchmark`:retrieval cost 要随 agent lifetime 计量,不能只看单次 query。
+- `semantic-dedup`:低相似但历史上有用的 memory 应被视为可学习信号。
+
+## Caveats
+
+本地笔记是 seed 质量。尚未 full read PDF、验证代码/数据是否发布、复核 matrix-completion
+设定或 benchmark split。准确率和预算节省只能作为 paper-origin claim。
+
+## Sources
+
+- arXiv:https://arxiv.org/abs/2608.22767
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/papers/evigraph-evidence-construction.md
+++ b/papers/evigraph-evidence-construction.md
@@ -1,0 +1,57 @@
+---
+title: EviGraph — Verifiable Evidence Construction for Information-Seeking Agents
+arxiv_id: 2608.24667
+source: arXiv:2608.24667
+date: 2026-08
+domain: retrieval
+core_claim: |
+  Search agents need a structured evidence memory, not only a linear trace.
+  EviGraph separates search execution from evidence recording and validates
+  support graph updates before using the graph as persistent working memory and
+  process-reward substrate.
+evidence_level: medium
+code_available: check
+license: check
+memory_modules:
+  - ingest-adapter
+  - retriever-reranker
+  - evaluator-benchmark
+status: seed
+last_revised: 2026-08-31
+urls:
+  - https://arxiv.org/abs/2608.24667
+---
+
+# EviGraph(arXiv 2608.24667)
+
+## Problem statement
+
+信息检索 agent 可以找到相关网页,但未必证明最终回答中的 claim 被检索内容支持。普通
+线性 trace 对中间 grounding 的监督很弱,也不利于后续复用证据。
+
+## Core claim
+
+EviGraph 将 search executor 与 evidence verifier 分离。Verifier 产出带 polarity 的
+verbatim evidence item,策略再生成 add/support graph request,并由确定性结构校验器检查。
+该 graph 同时作为 persistent working memory 和 RL process reward 来源。论文报告在
+BrowseComp-Plus、BrowseComp、GAIA 和 XBench 上有一致收益。
+
+## Decision relevance
+
+- `ingest-adapter`:外部证据应以 polarity、support relation 和 source span 入库。
+- `retriever-reranker`:answer-time 检索需要区分"相关"和"支持 claim"。
+- `evaluator-benchmark`:可把 evidence graph validity 作为过程指标,而不只看最终答案。
+
+## Caveats
+
+本地笔记是 seed 质量。尚未 full read PDF、验证代码/数据、许可或是否有独立复现。
+它更偏 information-seeking agent,但 evidence memory 形态对 memory provenance 很直接。
+
+## Sources
+
+- arXiv:https://arxiv.org/abs/2608.24667
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/papers/graphmemix-evidence-forests.md
+++ b/papers/graphmemix-evidence-forests.md
@@ -1,0 +1,60 @@
+---
+title: GraphMemix — Query-Aware Evidence Forests for Long-Term Multimodal Agent Memory
+arxiv_id: 2608.26983
+source: arXiv:2608.26983
+date: 2026-08
+domain: graph
+core_claim: |
+  Multimodal long-term memory should assemble query-aware evidence subgraphs
+  instead of relying on question-agnostic summaries or naive embedding matches.
+  GraphMemix optimizes an evidence forest under a budget to balance accuracy,
+  redundancy, and lifecycle cost.
+evidence_level: medium
+code_available: yes
+license: check
+memory_modules:
+  - retriever-reranker
+  - semantic-dedup
+  - evaluator-benchmark
+status: seed
+last_revised: 2026-08-31
+urls:
+  - https://arxiv.org/abs/2608.26983
+  - https://github.com/ligeng0197/graphmemix
+---
+
+# GraphMemix(arXiv 2608.26983)
+
+## Problem statement
+
+多模态长期记忆很容易在两端失效:离线 summary 成本高且忽略查询,embedding 相似检索又会
+带来不完整、冗余或冲突的上下文。需要一种能保留图关系、控制证据预算、并按 query 激活的
+memory assembly 方法。
+
+## Core claim
+
+GraphMemix 把 memory organization 建模为 query-aware evidence-forest construction。
+它先构造 candidate graph,再估计 direct memory support、anchor-conditioned relation
+verification 和 activation cost,最后在最大 evidence budget 下选择可靠的 forest-format
+memory context。
+
+## Decision relevance
+
+- `retriever-reranker`:应把低相似但互补的证据纳入候选,而不是只靠 embedding top-k。
+- `semantic-dedup`:冗余和冲突 suppression 需要显式关系验证,不能只做文本去重。
+- `evaluator-benchmark`:多模态 memory 要同时测 accuracy、lifecycle cost 和 context budget。
+
+## Caveats
+
+本地笔记是 seed 质量。尚未 full read PDF、复核项目页、code license、四个 benchmark 的
+设置和多模态数据来源。Pareto frontier 只能作为 author-reported paper-origin claim。
+
+## Sources
+
+- arXiv:https://arxiv.org/abs/2608.26983
+- Code:https://github.com/ligeng0197/graphmemix
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/papers/index.md
+++ b/papers/index.md
@@ -19,6 +19,26 @@ removed.
 - By year: 2026=388, 2025=309, 2024=129, 2023=72, 2022=6, 2021=4, 2020=3, 2018=2, 2017=1, undated=75
 - By source-count: 6 sources=6, 5 sources=18, 4 sources=32, 3 sources=66, 2 sources=127, 1 sources=740
 
+## 2026-08 manual radar additions
+
+These entries were added by the 2026-08-31 weekly radar refresh. They are not
+part of the 2026-05-19 nine-list scrape statistics above.
+
+- [ContextPilot: Proactive Context Management for Long-Horizon Agentic Tasks](contextpilot-proactive-context-management.md) — 2026-08 — seed — [arxiv](https://arxiv.org/abs/2608.28476)
+- [The Retriever Should Remember: Experience-Amortized Reranking for Conversational Memory](earm-experience-amortized-reranking.md) — 2026-08 — seed — [arxiv](https://arxiv.org/abs/2608.22767)
+- [Recuris: Recursive Experiential-Working Memory Evolution for LLM Agents](recuris-experiential-working-memory.md) — 2026-08 — seed — [arxiv](https://arxiv.org/abs/2608.24876)
+- [EviGraph: Improving LLM Agents with Quality-Guaranteed Graph Construction for Problem-Solving](evigraph-evidence-construction.md) — 2026-08 — seed — [arxiv](https://arxiv.org/abs/2608.24667)
+- [KOPE: Kernel Optimization via Experience Graph Memory](kope-experience-graph-memory.md) — 2026-08 — seed — [arxiv](https://arxiv.org/abs/2608.25570)
+- [CaSKG: Counterfactual-Causal Skill Graphs for Scalable Agent Skill Retrieval](caskg-skill-graph-retrieval.md) — 2026-08 — seed — [arxiv](https://arxiv.org/abs/2608.25500)
+- [UAQ: Uncertainty-Aware Querying for Agentic Memory](uaq-agent-memory.md) — 2026-08 — seed — [arxiv](https://arxiv.org/abs/2608.27924)
+- [GraphMemix: Evidence Forests for Graph-Based Memory Reasoning](graphmemix-evidence-forests.md) — 2026-08 — seed — [arxiv](https://arxiv.org/abs/2608.26983)
+- [Constraint Weakening in Agent Workflows](constraint-weakening-agent-workflows.md) — 2026-08 — seed — [arxiv](https://arxiv.org/abs/2608.24569)
+- [InjecMEM: Benchmarking Memory Injection Attacks on LLM Agents](../benchmarks/injecmem.md) — 2026-08 — benchmark seed — [arxiv](https://arxiv.org/abs/2608.23471)
+- [The Compaction Cliff: Evaluating Context Compaction in LLM Agents](../benchmarks/compaction-cliff.md) — 2026-08 — benchmark seed — [arxiv](https://arxiv.org/abs/2608.22752)
+- [When Stale Constraints Go Unchecked](../benchmarks/stale-constraints.md) — 2026-08 — benchmark seed — [arxiv](https://arxiv.org/abs/2608.25553)
+- [MemUse: Benchmarking Natural Integration of Conversational Memory](../benchmarks/memuse.md) — 2026-08 — benchmark seed — [arxiv](https://arxiv.org/abs/2608.24189)
+- [Agent Memory Leaderboard](../benchmarks/agent-memory-leaderboard.md) — 2026-08 — benchmark-platform candidate — [github](https://github.com/AML-memory/agent-memory-leaderboard)
+
 ## 2026-07 manual radar additions
 
 These entries were added by the 2026-07-06 weekly radar refresh. They are not

--- a/papers/kope-experience-graph-memory.md
+++ b/papers/kope-experience-graph-memory.md
@@ -1,0 +1,59 @@
+---
+title: KOPE — Experience Graph Memory for Self-Evolving Kernel-Optimization Agents
+arxiv_id: 2608.25570
+source: arXiv:2608.25570
+date: 2026-08
+domain: memory
+core_claim: |
+  Repeated coding/optimization agents need to preserve decisions, execution
+  feedback, and branch outcomes across runs. KOPE stores optimization
+  trajectories in Experience Graph Memory and retrieves relevant experience
+  under a fixed token budget.
+evidence_level: medium
+code_available: check
+license: check
+memory_modules:
+  - ingest-adapter
+  - dream-consolidator
+  - retriever-reranker
+  - evaluator-benchmark
+status: seed
+last_revised: 2026-08-31
+urls:
+  - https://arxiv.org/abs/2608.25570
+---
+
+# KOPE(arXiv 2608.25570)
+
+## Problem statement
+
+硬件 kernel 优化 agent 会反复编译、测试、profile 和修改代码。只靠更强模型、更长上下文
+或更长执行轨迹,不能让 agent 从已完成的优化 episode 中稳定学习;全量保留历史又会挤占
+当前任务上下文。
+
+## Core claim
+
+KOPE 将正确性、性能反馈、决策顺序和替代分支写入 Experience Graph Memory,再通过
+Active Context Management and Injection 在固定 token budget 下检索相关经验。论文报告
+相对 CANNBot 和消融 baseline 有 pass rate、token consumption 和 speedup 改善。
+
+## Decision relevance
+
+- `ingest-adapter`:执行证据、失败分支和性能反馈要作为一等 memory event。
+- `dream-consolidator`:跨任务经验图比简单 summary 更适合保留因果顺序和替代路径。
+- `retriever-reranker`:预算约束下的经验注入适合作为 coding-agent memory 对照。
+- `evaluator-benchmark`:成本结论需要同时绑定硬件、operator suite、pass rate 和 valid timing。
+
+## Caveats
+
+本地笔记是 seed 质量。尚未 full read PDF、验证代码可用性、license 或实验可复现性。
+速度和 token 节省只能作为 author-reported paper-origin claim,不能外推到通用 coding agent。
+
+## Sources
+
+- arXiv:https://arxiv.org/abs/2608.25570
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/papers/recuris-experiential-working-memory.md
+++ b/papers/recuris-experiential-working-memory.md
@@ -1,0 +1,58 @@
+---
+title: Recuris — Recursive Experiential-Working Memory Evolution for Long-Horizon Agent Harnesses
+arxiv_id: 2608.24876
+source: arXiv:2608.24876
+date: 2026-08
+domain: memory
+core_claim: |
+  Long-horizon harnesses can connect Working Memory, Experiential Memory, and
+  Skill Memory so execution evidence localizes failures and validation-gated
+  updates reshape later behavior.
+evidence_level: medium
+code_available: yes
+license: check
+memory_modules:
+  - ingest-adapter
+  - dream-consolidator
+  - memorydiff-generator
+  - evaluator-benchmark
+status: seed
+last_revised: 2026-08-31
+urls:
+  - https://arxiv.org/abs/2608.24876
+---
+
+# Recuris(arXiv 2608.24876)
+
+## Problem statement
+
+Recursive self-improvement 在长任务里容易被膨胀历史、失焦 working state 和错误 skill
+调用拖垮。需要把当前任务状态、历史经验和 skill 更新分层管理,并让执行证据定位到具体
+memory component。
+
+## Core claim
+
+Recuris 使用 Working Memory 跟踪任务进展并从 Experiential Memory 引导 skill selection。
+固定 Meta-Agent 将执行证据转成 localized、validation-gated Skill Memory updates,形成
+bounded recursive memory-evolution loop。论文报告跨多个长任务 benchmark 和模型提升成功率。
+
+## Decision relevance
+
+- `ingest-adapter`:执行过程要保留为可定位失败原因的结构化证据。
+- `memorydiff-generator`:skill memory 更新应是验证门控的 patch,不是自动覆写。
+- `dream-consolidator`:working / experiential / skill memory 的分层可作为 consolidation 边界。
+- `evaluator-benchmark`:需要按 horizon length 分层报告收益和失败类型变化。
+
+## Caveats
+
+本地笔记是 seed 质量。尚未 full read PDF、复核代码仓库、license、benchmark 套件和
+SOTA 对比设置。性能数字只能作为 author-reported paper-origin claim。
+
+## Sources
+
+- arXiv:https://arxiv.org/abs/2608.24876
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/papers/uaq-agent-memory.md
+++ b/papers/uaq-agent-memory.md
@@ -1,0 +1,56 @@
+---
+title: What Makes Agent Memory Useful for Reliable Unanswerable Question Handling?
+arxiv_id: 2608.27924
+source: arXiv:2608.27924
+date: 2026-08
+domain: eval
+core_claim: |
+  Agent memory does not universally improve unanswerable-question handling.
+  Under dataset shift, procedural and rule-based guidance can be more reliable
+  than trajectory-shaped memory, and representation choice controls whether
+  memory helps abstention.
+evidence_level: medium
+code_available: check
+license: check
+memory_modules:
+  - retriever-reranker
+  - policy-privacy
+  - evaluator-benchmark
+status: seed
+last_revised: 2026-08-31
+urls:
+  - https://arxiv.org/abs/2608.27924
+---
+
+# UAQ Agent Memory(arXiv 2608.27924)
+
+## Problem statement
+
+可信 agent 在无法回答的问题上必须会拒答或保留不确定性。虽然 memory 常被加入 agentic
+RAG,但 memory 对 unanswerable question handling 的影响并不稳定。
+
+## Core claim
+
+论文在统一 agentic RAG 框架下评估四类 memory 方法、三个 UAQ 数据集和两个基础模型。
+作者报告 memory 带来的 UAQ 改善是选择性的,跨数据集迁移比跨模型复用更脆弱;procedural
+和 rule-based memory 对拒答更可靠,组合 memory 需要搭配行为信号。
+
+## Decision relevance
+
+- `retriever-reranker`:retrieved memory 不能默认提高可靠性,需要 answerability-aware gating。
+- `policy-privacy`:程序性规则和拒答策略可以作为 action-binding memory,不能被普通事实记忆覆盖。
+- `evaluator-benchmark`:memory evaluation 应包含 abstention、dataset shift 和 false-answer risk。
+
+## Caveats
+
+本地笔记是 seed 质量。尚未 full read PDF、检查数据集构造、代码、license 或是否可复现。
+结论只支持"需要测 UAQ / abstention",不支持某类 memory 的通用优越性。
+
+## Sources
+
+- arXiv:https://arxiv.org/abs/2608.27924
+
+---
+
+> *Ymem 项目对本笔记决策相关性的具体绑定见
+> [`../docs/ymem-binding/relevance-index.md`](../docs/ymem-binding/relevance-index.md)。*

--- a/products/claude-dreams.md
+++ b/products/claude-dreams.md
@@ -10,7 +10,7 @@ evidence_level: medium (production product, no public benchmark numbers)
 code_available: no (proprietary)
 license: proprietary
 status: seed
-last_revised: 2026-06-24
+last_revised: 2026-08-31
 ---
 
 # Claude Dreams
@@ -34,6 +34,22 @@ Anthropic/Claude 侧需要分开看两条线:
 本文件继续保留 Dreams/offline consolidation 的 architecture signal;Claude Code memory
 后续可单独拆成产品 note,如果公开 docs 稳定且与 `CLAUDE.md`/`MEMORY.md` 形成清晰
 agent-memory lifecycle。
+
+## 2026-08 product update
+
+Anthropic's 2026-08-25 release notes add memory behavior for Claude Cowork and
+the broader Claude app surface. The public product evidence says memory now
+works across chat and Cowork cloud, Topics can be edited or deleted from
+Settings > Memory, sensitive-topic memory is a separate opt-in, and default
+enablement differs by plan: on for Free/Pro/Max and off by default for Team and
+Enterprise.
+
+This update is useful product-behavior evidence for memory governance and user
+control. It does not disclose the Dreams implementation, and it should not be
+treated as benchmark or architecture evidence beyond the documented product
+surface.
+
+> 来源:https://support.claude.com/en/articles/12138966-release-notes
 
 ## Architectural takeaways
 

--- a/products/letta.md
+++ b/products/letta.md
@@ -10,7 +10,7 @@ evidence_level: medium
 code_available: yes
 license: Apache 2.0
 status: seed
-last_revised: 2026-05-19
+last_revised: 2026-08-31
 ---
 
 # Letta(原 MemGPT)
@@ -48,6 +48,19 @@ Letta 把它产品化为 stateful agent runtime。
 
 - Letta 在公开 memory benchmark 上的表现?
 - archival memory 的实际大小和检索成本曲线?
+
+## 2026-08 Letta Code memory layout releases
+
+Letta Code release notes in late August add memory-layout controls to the coding
+agent surface. v0.31.4 introduced configurable memory layout behavior, v0.31.5
+added root-layout memory prompts, and the adjacent v0.31.6 notes continue the
+theme with memory limits and shared-memory frontmatter.
+
+This is product-behavior evidence for explicit memory prompt/layout management
+inside a coding agent. It should stay separate from Letta/MemGPT architecture
+claims and from any benchmark-performance claim.
+
+> 来源:https://github.com/letta-ai/letta-code/releases
 
 ## Notes
 

--- a/products/mem0.md
+++ b/products/mem0.md
@@ -11,7 +11,7 @@ evidence_level: medium (open-source library, blog claims need independent benchm
 code_available: yes
 license: Apache 2.0
 status: seed
-last_revised: 2026-07-06
+last_revised: 2026-08-31
 ---
 
 # Mem0
@@ -113,6 +113,20 @@ Mem0 自报的 benchmark(LoCoMo 类基准对比上一代 baseline):
 > 来源:https://mem0.ai/blog/state-of-ai-agent-memory-2026
 > archive:[`archives/mem0-blog-state-of-2026.md`](archives/mem0-blog-state-of-2026.md)、
 > [`archives/mem0-april-2026-release.md`](archives/mem0-april-2026-release.md)
+
+## 2026-08 DeepSeek Harness plugin
+
+Mem0 changelog highlights in late August added a DeepSeek Harness plugin under
+`@mem0/deepseek-plugin`. The product surface exposes `search_memory` and
+`add_memory` tools and keeps the existing `userId` / `agentId` / `runId`
+scoping model.
+
+This is product-behavior evidence that Mem0 continues to package memory as
+agent-tool plumbing across model/harness ecosystems. It is not independent
+quality evidence and should not be mixed with the LoCoMo/LongMemEval/BEAM
+claims ledger.
+
+> 来源:https://docs.mem0.ai/changelog/highlights
 
 ## 2026-06/07 SDK expiration controls
 

--- a/products/tencentdb-agent-memory.md
+++ b/products/tencentdb-agent-memory.md
@@ -14,7 +14,7 @@ memory_modules:
   - dream-consolidator
   - audit-ui
 status: seed
-last_revised: 2026-06-29
+last_revised: 2026-08-31
 archive: archives/tencentdb-agent-memory-overview.md
 ---
 
@@ -54,6 +54,20 @@ Tencent Cloud VectorDB。
   / `node_id` 追溯
 - **接入**:OpenClaw plugin、Hermes Gateway adapter、agent tools
   `tdai_memory_search` / `tdai_conversation_search`
+
+## 3.1 2026-08 release v2.0.1
+
+TencentDB Agent Memory v2.0.1 adds product-surface evidence that the project is
+turning session and cross-session memory operations into explicit integration
+points. The release notes mention client bindings, persistent session binding,
+and a Memory Hub that supports cross-session semantic/keyword search with
+permission scoping.
+
+Treat this as official release behavior from the project maintainers. It does
+not change the benchmark-evidence class of TencentDB self-reported PersonaMem
+claims.
+
+> 来源:https://github.com/TencentCloud/TencentDB-Agent-Memory/releases/tag/v2.0.1
 
 ## 4. 决策相关性 / Decision relevance
 


### PR DESCRIPTION
## Summary
- add the 2026-08-31 memory radar page on a dated non-colliding path
- add 9 August paper seed notes and 5 benchmark/platform notes
- update benchmark counts, claims ledger, README surfaces, signals, and product notes for Claude, Mem0, TencentDB Agent Memory, and Letta

## Evidence boundaries
- new benchmark rows are origin/platform events only, not score claims
- product changes are official product-behavior signals only
- open PR overlap is called out and duplicate August candidates are not imported

## Verification
- ruby scripts/verify_memory_refresh.rb
- git diff --cached --check
- conflict-marker scan
- targeted source URL reachability: 18/18 HTTP 200
- code-reviewer staged-diff pass after fixes

## Not tested
- full PDF reads
- full external link crawl
- benchmark reproduction
- product archive refresh